### PR TITLE
Fix the testnet genesis overloading on runtime

### DIFF
--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -32,7 +32,7 @@ defmodule ArchEthic.Bootstrap.NetworkInit do
 
   require Logger
 
-  @genesis_seed Application.compile_env(:archethic, __MODULE__)[:genesis_seed]
+  @genesis_seed Application.compile_env(:archethic, [__MODULE__, :genesis_seed])
 
   defp get_genesis_pools do
     Application.get_env(:archethic, __MODULE__) |> Keyword.get(:genesis_pools, [])

--- a/lib/archethic/utils/benchmarks/balance.ex
+++ b/lib/archethic/utils/benchmarks/balance.ex
@@ -6,26 +6,42 @@ defmodule ArchEthic.Benchmark.Balance do
   require Logger
 
   alias ArchEthic.Benchmark
+
+  alias ArchEthic.Bootstrap.NetworkInit
+
+  alias ArchEthic.P2P.Endpoint, as: P2PEndpoint
   alias ArchEthic.P2P.Message
+  alias ArchEthic.P2P.Message.Balance
   alias ArchEthic.P2P.Message.GetBalance
+
   alias ArchEthic.Utils
+
   alias ArchEthic.WebClient
+
+  alias ArchEthicWeb.Endpoint, as: WebEndpoint
 
   @behaviour Benchmark
 
   def plan([host | _nodes], _opts) do
-    port = Application.get_env(:archethic, ArchEthic.P2P.Endpoint)[:port]
-    http = Application.get_env(:archethic, ArchEthicWeb.Endpoint)[:http][:port]
+    port = Application.get_env(:archethic, P2PEndpoint)[:port]
+    http = Application.get_env(:archethic, WebEndpoint)[:http][:port]
     {:ok, addr} = :inet.getaddr(to_charlist(host), :inet)
 
     {:ok, sock} = :socket.open(:inet, :stream, :tcp)
     :ok = :socket.connect(sock, %{family: :inet, port: port, addr: addr})
 
+    genesis_balance = get_genesis_balance()
+    genesis_address = get_genesis_address()
+
     {%{
-       "P2P socket" => fn _ -> get_balance_p2p_socket(addr, port) end,
-       "P2P gentcp" => fn _ -> get_balance_p2p_gentcp(addr, port) end,
-       "P2P attach" => fn _ -> get_balance_p2p(sock) end,
-       "WEB" => fn _ -> get_balance_web(host, http) end
+       "P2P socket" => fn _ ->
+         get_balance_p2p_socket(addr, port, genesis_balance, genesis_address)
+       end,
+       "P2P gentcp" => fn _ ->
+         get_balance_p2p_gentcp(addr, port, genesis_balance, genesis_address)
+       end,
+       "P2P attach" => fn _ -> get_balance_p2p(sock, genesis_balance, genesis_address) end,
+       "WEB" => fn _ -> get_balance_web(host, http, genesis_balance, genesis_address) end
      },
      [
        before_scenario: fn _ -> get_vm_status(host, http) end,
@@ -58,42 +74,63 @@ defmodule ArchEthic.Benchmark.Balance do
     |> Enum.into(%{})
   end
 
-  @genesis Application.compile_env!(:archethic, ArchEthic.Bootstrap.NetworkInit)[:genesis_pools]
-  @balance Enum.at(@genesis, 0)[:amount]
-  @address Enum.at(@genesis, 0)[:address]
-  @message %GetBalance{address: @address} |> Message.encode() |> Utils.wrap_binary()
-  @msgdata <<byte_size(@message) + 4::32, 1::32, @message::binary>>
+  defp get_genesis_balance do
+    get_genesis_pools()
+    |> Enum.at(0)
+    |> Map.get(:amount)
+  end
 
-  defp get_balance_p2p_socket(addr, port) do
+  defp get_genesis_address do
+    get_genesis_pools()
+    |> Enum.at(0)
+    |> Map.get(:address)
+  end
+
+  defp get_genesis_pools do
+    :archethic
+    |> Application.get_env(:archethic, NetworkInit)
+    |> Keyword.fetch!(:genesis_pools)
+  end
+
+  defp message_data(address) do
+    message_bin =
+      %GetBalance{address: address}
+      |> Message.encode()
+      |> Utils.wrap_binary()
+
+    <<byte_size(message_bin) + 4::32, 1::32, message_bin::binary>>
+  end
+
+  defp get_balance_p2p_socket(addr, port, expected_balance, address) do
     {:ok, sock} = :socket.open(:inet, :stream, :tcp)
     :ok = :socket.connect(sock, %{family: :inet, port: port, addr: addr})
-    :ok = :socket.send(sock, @msgdata)
+    :ok = :socket.send(sock, message_data(address))
     {:ok, <<_::32, _::32, data::binary>>} = :socket.recv(sock, 0, 1000)
     :ok = :socket.close(sock)
 
-    {%ArchEthic.P2P.Message.Balance{nft: %{}, uco: @balance}, ""} = Message.decode(data)
+    {%Balance{nft: %{}, uco: ^expected_balance}, ""} = Message.decode(data)
 
     :ok
   end
 
-  defp get_balance_p2p(sock) do
-    :ok = :socket.send(sock, @msgdata)
+  defp get_balance_p2p(sock, expected_balance, address) do
+    :ok = :socket.send(sock, message_data(address))
     {:ok, <<_::32, _::32, data::binary>>} = :socket.recv(sock, 0, 1000)
 
-    {%ArchEthic.P2P.Message.Balance{nft: %{}, uco: @balance}, ""} = Message.decode(data)
+    {%Balance{nft: %{}, uco: ^expected_balance}, ""} = Message.decode(data)
 
     :ok
   end
 
-  defp get_balance_p2p_gentcp(addr, port) do
+  defp get_balance_p2p_gentcp(addr, port, expected_balance, address) do
     {:ok, sock} = :gen_tcp.connect(addr, port, [:binary])
-    :ok = :gen_tcp.send(sock, @msgdata)
+    :ok = :gen_tcp.send(sock, message_data(address))
 
     receive do
       {:tcp, ^sock, <<_::32, _::32, data::binary>>} ->
         :ok = :gen_tcp.close(sock)
 
-        {%ArchEthic.P2P.Message.Balance{nft: %{}, uco: @balance}, ""} = Message.decode(data)
+        {%Balance{nft: %{}, uco: ^expected_balance}, ""} = Message.decode(data)
 
         :ok
     after
@@ -101,12 +138,16 @@ defmodule ArchEthic.Benchmark.Balance do
     end
   end
 
-  @graphql """
-  query {balance(address: "#{@address |> Base.encode16()}"){uco}}
-  """
+  defp get_balance_web(host, port, expected_balance, address) do
+    query = """
+    query { 
+      balance(address: "#{Base.encode16(address)}") {
+        uco
+      }
+    }
+    """
 
-  defp get_balance_web(host, port) do
-    {:ok, %{"data" => %{"balance" => %{"uco" => @balance}}}} =
-      WebClient.with_connection(host, port, &WebClient.query(&1, @graphql))
+    {:ok, %{"data" => %{"balance" => %{"uco" => ^expected_balance}}}} =
+      WebClient.with_connection(host, port, &WebClient.query(&1, query))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ArchEthic.MixProject do
   def project do
     [
       app: :archethic,
-      version: "0.11.1",
+      version: "0.11.2",
       build_path: "_build",
       config_path: "config/config.exs",
       deps_path: "deps",


### PR DESCRIPTION
Use runtime configuration instead of compile configuration
to be able to overload the testnet genesis address and amount.