### PR TITLE
Ensure to fetch missed transaction from the beacon in the self repair

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ArchEthic.MixProject do
   def project do
     [
       app: :archethic,
-      version: "0.12.0",
+      version: "0.12.1",
       build_path: "_build",
       config_path: "config/config.exs",
       deps_path: "deps",


### PR DESCRIPTION
Tries to fetch the transaction from the closest nodes, but retry until the end of the node list.
Because it's not subject to important latency here, in case of issue of sync from one node, try to load from the next one.

Fixes #92 
Fixes #83 