### PR TITLE
Verify the origin  of node public key

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -125,6 +125,12 @@ config :archethic, ArchEthic.Governance.Pools,
     uniris: []
   ]
 
+config :archethic, ArchEthic.Mining.PendingTransactionValidation,
+  allowed_node_key_origins:
+    System.get_env("ARCHETHIC_NODE_ALLOWED_KEY_ORIGINS", "tpm")
+    |> String.split(";", trim: true)
+    |> Enum.map(&String.to_existing_atom/1)
+
 config :archethic,
        ArchEthic.Networking.IPLookup,
        (case(System.get_env("ARCHETHIC_NETWORKING_IMPL", "NAT")) do

--- a/lib/archethic/crypto.ex
+++ b/lib/archethic/crypto.ex
@@ -9,7 +9,7 @@ defmodule ArchEthic.Crypto do
    ```
    Ed25519  Software  Public key
         |  /           |
-        |  |   |-------|  
+        |  |   |-------|
         |  |   |
       <<0, 0, 106, 58, 193, 73, 144, 121, 104, 101, 53, 140, 125, 240, 52, 222, 35, 181,
       13, 81, 241, 114, 227, 205, 51, 167, 139, 100, 176, 111, 68, 234, 206, 72>>
@@ -1070,7 +1070,7 @@ defmodule ArchEthic.Crypto do
   end
 
   @doc """
-  Return the Root CA public key for the given versioned public key 
+  Return the Root CA public key for the given versioned public key
   """
   @spec get_root_ca_public_key(key()) :: binary()
   def get_root_ca_public_key(<<_::8, origin_id::8, _::binary>>) do
@@ -1133,4 +1133,29 @@ defmodule ArchEthic.Crypto do
   """
   @spec default_curve() :: supported_curve()
   def default_curve, do: Application.get_env(:archethic, __MODULE__)[:default_curve]
+
+  @doc """
+  Determine if the origin of the key is allowed
+
+  This prevent software keys to be used in prod, as we want secure element to prevent malicious nodes
+
+  ## Examples
+
+      iex> Crypto.authorized_key_origin?(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>, [:tpm])
+      false
+
+      iex> Crypto.authorized_key_origin?(<<0::8, 1::8, :crypto.strong_rand_bytes(32)::binary>>, [:tpm])
+      true
+
+      iex> Crypto.authorized_key_origin?(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>, [])
+      true
+  """
+  @spec authorized_key_origin?(key(), list(supported_origin())) :: boolean()
+  def authorized_key_origin?(<<_::8, origin_id::8, _::binary>>, allowed_key_origins = [_ | _]) do
+    ID.to_origin(origin_id) in allowed_key_origins
+  end
+
+  def authorized_key_origin?(<<_::8, _::8, _::binary>>, []) do
+    true
+  end
 end

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -42,8 +42,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
     Enum.each(BeaconChain.list_subsets(), &Registry.register(SubsetRegistry, &1, []))
 
     P2P.add_and_connect_node(%Node{
-      ip: {127, 0, 0, 1},
-      port: 3000,
+      ip: {80, 10, 20, 102},
+      port: 3001,
       first_public_key: Crypto.first_node_public_key(),
       last_public_key: Crypto.last_node_public_key(),
       authorized?: true,
@@ -58,8 +58,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
     {pub, _} = Crypto.generate_deterministic_keypair("seed")
 
     P2P.add_and_connect_node(%Node{
-      ip: {127, 0, 0, 1},
-      port: 3000,
+      ip: {80, 10, 20, 102},
+      port: 3002,
       first_public_key: pub,
       last_public_key: pub,
       authorized?: true,
@@ -76,7 +76,7 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
     tx =
       Transaction.new(:node, %TransactionData{
         content:
-          <<127, 0, 0, 1, 3000::16, 1, 0, 16, 233, 156, 172, 143, 228, 236, 12, 227, 76, 1, 80,
+          <<80, 10, 20, 102, 3000::16, 1, 0, 16, 233, 156, 172, 143, 228, 236, 12, 227, 76, 1, 80,
             12, 236, 69, 10, 209, 6, 234, 172, 97, 188, 240, 207, 70, 115, 64, 117, 44, 82, 132,
             186, byte_size(certificate)::16, certificate::binary>>
       })
@@ -158,7 +158,7 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
         )
 
       welcome_node = %Node{
-        ip: {127, 0, 0, 1},
+        ip: {80, 10, 20, 102},
         port: 3005,
         first_public_key: "key1",
         last_public_key: "key1",
@@ -188,8 +188,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
     test "should aggregate context and wait enough confirmed validation nodes context building",
          %{tx: tx, sorting_seed: sorting_seed} do
       P2P.add_and_connect_node(%Node{
-        ip: {127, 0, 0, 1},
-        port: 3000,
+        ip: {80, 10, 20, 102},
+        port: 3006,
         last_public_key: "other_validator_key",
         first_public_key: "other_validator_key",
         authorized?: true,
@@ -202,8 +202,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
       })
 
       P2P.add_and_connect_node(%Node{
-        ip: {127, 0, 0, 1},
-        port: 3000,
+        ip: {80, 10, 20, 102},
+        port: 3007,
         last_public_key: "other_validator_key2",
         first_public_key: "other_validator_key2",
         authorized?: true,
@@ -240,7 +240,7 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
       end)
 
       welcome_node = %Node{
-        ip: {127, 0, 0, 1},
+        ip: {80, 10, 20, 102},
         port: 3005,
         first_public_key: "key1",
         last_public_key: "key1",
@@ -257,8 +257,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
 
       previous_storage_nodes = [
         %Node{
-          ip: {127, 0, 0, 1},
-          port: 3000,
+          ip: {80, 10, 20, 102},
+          port: 3006,
           first_public_key: "key10",
           last_public_key: "key10",
           authorized?: true,
@@ -267,8 +267,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
           network_patch: "AAA"
         },
         %Node{
-          ip: {127, 0, 0, 1},
-          port: 3002,
+          ip: {80, 10, 20, 102},
+          port: 3007,
           first_public_key: "key23",
           last_public_key: "key23",
           authorized?: true,
@@ -333,7 +333,7 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
       end)
 
       welcome_node = %Node{
-        ip: {127, 0, 0, 1},
+        ip: {80, 10, 20, 102},
         port: 3005,
         first_public_key: "key1",
         last_public_key: "key1",
@@ -352,8 +352,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
 
       previous_storage_nodes = [
         %Node{
-          ip: {127, 0, 0, 1},
-          port: 3000,
+          ip: {80, 10, 20, 102},
+          port: 3006,
           first_public_key: "key10",
           last_public_key: "key10",
           reward_address: :crypto.strong_rand_bytes(32),
@@ -363,8 +363,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
           network_patch: "AAA"
         },
         %Node{
-          ip: {127, 0, 0, 1},
-          port: 3002,
+          ip: {80, 10, 20, 102},
+          port: 3007,
           first_public_key: "key23",
           last_public_key: "key23",
           reward_address: :crypto.strong_rand_bytes(32),
@@ -410,8 +410,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
       {pub, _} = Crypto.generate_deterministic_keypair("seed3")
 
       P2P.add_and_connect_node(%Node{
-        ip: {127, 0, 0, 1},
-        port: 3000,
+        ip: {80, 10, 20, 102},
+        port: 3008,
         last_public_key: pub,
         first_public_key: pub,
         authorized?: true,
@@ -458,7 +458,7 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
       end)
 
       welcome_node = %Node{
-        ip: {127, 0, 0, 1},
+        ip: {80, 10, 20, 102},
         port: 3005,
         first_public_key: "key1",
         last_public_key: "key1",
@@ -485,8 +485,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
 
       previous_storage_nodes = [
         %Node{
-          ip: {127, 0, 0, 1},
-          port: 3000,
+          ip: {80, 10, 20, 102},
+          port: 3006,
           first_public_key: "key10",
           last_public_key: "key10",
           reward_address: :crypto.strong_rand_bytes(32),
@@ -496,8 +496,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
           network_patch: "AAA"
         },
         %Node{
-          ip: {127, 0, 0, 1},
-          port: 3002,
+          ip: {80, 10, 20, 102},
+          port: 3007,
           first_public_key: "key23",
           last_public_key: "key23",
           reward_address: :crypto.strong_rand_bytes(32),
@@ -639,8 +639,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
       end)
 
       P2P.add_and_connect_node(%Node{
-        ip: {127, 0, 0, 1},
-        port: 3000,
+        ip: {80, 10, 20, 102},
+        port: 3006,
         last_public_key: "key10",
         first_public_key: "key10",
         network_patch: "AAA",
@@ -653,8 +653,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
       })
 
       P2P.add_and_connect_node(%Node{
-        ip: {127, 0, 0, 1},
-        port: 3000,
+        ip: {80, 10, 20, 102},
+        port: 3007,
         last_public_key: "key23",
         first_public_key: "key23",
         network_patch: "AAA",
@@ -667,7 +667,7 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
       })
 
       welcome_node = %Node{
-        ip: {127, 0, 0, 1},
+        ip: {80, 10, 20, 102},
         port: 3005,
         first_public_key: "key1",
         last_public_key: "key1",
@@ -694,8 +694,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
 
       previous_storage_nodes = [
         %Node{
-          ip: {127, 0, 0, 1},
-          port: 3000,
+          ip: {80, 10, 20, 102},
+          port: 3007,
           first_public_key: "key10",
           last_public_key: "key10",
           reward_address: :crypto.strong_rand_bytes(32),
@@ -703,8 +703,8 @@ defmodule ArchEthic.Mining.DistributedWorkflowTest do
           authorization_date: DateTime.utc_now()
         },
         %Node{
-          ip: {127, 0, 0, 1},
-          port: 3002,
+          ip: {80, 10, 20, 102},
+          port: 3008,
           first_public_key: "key23",
           last_public_key: "key23",
           reward_address: :crypto.strong_rand_bytes(32),


### PR DESCRIPTION
Enable verification of the node origin key family to avoid node on prod using software implementation.
However, an environment variable can be set to overload it.

Fixes #109 