### PR TITLE
Specify nil as host to support dynamic hostname

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -229,7 +229,7 @@ config :archethic, ArchEthicWeb.FaucetController,
 # before starting your production server.
 config :archethic, ArchEthicWeb.Endpoint,
   http: [:inet6, port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],
-  url: [host: "*", port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],
+  url: [host: nil, port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true,
   root: ".",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ArchEthic.MixProject do
   def project do
     [
       app: :archethic,
-      version: "0.12.4",
+      version: "0.12.5",
       build_path: "_build",
       config_path: "config/config.exs",
       deps_path: "deps",


### PR DESCRIPTION
Setting host to nil on the endpoint will dynamically use the host of the current request

Fixes #167 