### PR TITLE
Change faucet success flash link to tx URL, fix #204

### DIFF
--- a/lib/archethic_web/controllers/faucet_controller.ex
+++ b/lib/archethic_web/controllers/faucet_controller.ex
@@ -40,13 +40,13 @@ defmodule ArchEthicWeb.FaucetController do
   def create_transfer(conn, %{"address" => address}) do
     with {:ok, recipient_address} <- Base.decode16(address, case: :mixed),
          true <- Crypto.valid_hash?(recipient_address),
-         :ok <- transfer(recipient_address) do
+         {:ok, tx_address} <- transfer(recipient_address) do
       conn
       |> put_resp_header("cache-control", "no-cache, no-store, must-revalidate")
       |> put_resp_header("pragma", "no-cache")
       |> put_resp_header("expires", "0")
       |> put_flash(:info, "Transferred successfully (click to view)")
-      |> render("index.html", address: "", link_address: address)
+      |> render("index.html", address: "", link_address: Base.encode16(tx_address))
     else
       {:error, _} ->
         conn
@@ -79,24 +79,32 @@ defmodule ArchEthicWeb.FaucetController do
   end
 
   defp create_transaction(transaction_index, curve, recipient_address) do
-    Transaction.new(
-      :transfer,
-      %TransactionData{
-        ledger: %Ledger{
-          uco: %UCOLedger{
-            transfers: [
-              %UCOLedger.Transfer{
-                to: recipient_address,
-                amount: 10_000_000_000
-              }
-            ]
+    tx =
+      Transaction.new(
+        :transfer,
+        %TransactionData{
+          ledger: %Ledger{
+            uco: %UCOLedger{
+              transfers: [
+                %UCOLedger.Transfer{
+                  to: recipient_address,
+                  amount: 10_000_000_000
+                }
+              ]
+            }
           }
-        }
-      },
-      @pool_seed,
-      transaction_index,
-      curve
-    )
-    |> ArchEthic.send_new_transaction()
+        },
+        @pool_seed,
+        transaction_index,
+        curve
+      )
+
+    case ArchEthic.send_new_transaction(tx) do
+      :ok ->
+        {:ok, tx.address}
+
+      {:error, _} = e ->
+        e
+    end
   end
 end

--- a/test/archethic_web/controllers/faucet_controller_test.exs
+++ b/test/archethic_web/controllers/faucet_controller_test.exs
@@ -1,0 +1,99 @@
+defmodule ArchEthicWeb.FaucetControllerTest do
+  use ArchEthicCase
+  use ArchEthicWeb.ConnCase
+
+  alias ArchEthic.{
+    Crypto,
+    P2P,
+    P2P.Node,
+    PubSub
+  }
+
+  alias ArchEthic.P2P.Message.{
+    GetLastTransactionAddress,
+    GetTransactionChainLength,
+    LastTransactionAddress,
+    Ok,
+    StartMining,
+    TransactionChainLength
+  }
+
+  alias ArchEthic.TransactionChain.{
+    Transaction,
+    TransactionData,
+    TransactionData.Ledger,
+    TransactionData.UCOLedger
+  }
+
+  import Mox
+
+  @pool_seed Application.compile_env(:archethic, [ArchEthicWeb.FaucetController, :seed])
+
+  setup do
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      first_public_key: Crypto.last_node_public_key(),
+      last_public_key: Crypto.last_node_public_key(),
+      network_patch: "AAA",
+      geo_patch: "AAA",
+      available?: true,
+      authorized?: true,
+      authorization_date: DateTime.utc_now()
+    })
+
+    :ok
+  end
+
+  describe "create_transfer/2" do
+    test "should show success flash with tx URL on valid transaction", %{conn: conn} do
+      recipient_address = "0098fe10e8633bce19c59a40a089731c1f72b097c5a8f7dc71a37eb26913aa4f80"
+
+      tx =
+        Transaction.new(
+          :transfer,
+          %TransactionData{
+            ledger: %Ledger{
+              uco: %UCOLedger{
+                transfers: [
+                  %UCOLedger.Transfer{
+                    to: recipient_address,
+                    amount: 10_000_000_000
+                  }
+                ]
+              }
+            }
+          },
+          @pool_seed,
+          0,
+          Crypto.default_curve()
+        )
+
+      MockClient
+      |> stub(:send_message, fn
+        _, %GetLastTransactionAddress{}, _ ->
+          {:ok, %LastTransactionAddress{address: "1234"}}
+
+        _, %GetTransactionChainLength{}, _ ->
+          {:ok, %TransactionChainLength{length: 0}}
+
+        _, %StartMining{}, _ ->
+          PubSub.notify_new_transaction(tx.address)
+
+          {:ok, %Ok{}}
+      end)
+
+      conn = post(conn, Routes.faucet_path(conn, :create_transfer), address: recipient_address)
+
+      assert html_response(conn, 200) =~
+               Base.encode16(tx.address)
+    end
+
+    test "should show 'Malformed address' flash on invalid address", %{conn: conn} do
+      conn = post(conn, Routes.faucet_path(conn, :create_transfer), address: "XYZ")
+
+      assert html_response(conn, 200) =~
+               "Malformed address"
+    end
+  end
+end


### PR DESCRIPTION
Faucet success flash now points to transaction address instead of recipient address
Added testcases for faucet controller create_transfer/2
Fixed error pattern matching in faucet controller to better detect network errors