### PR TITLE
165 transaction content max size

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -46,7 +46,7 @@ config :archethic, :mut_dir, "data"
 config :archethic, :marker, "-=%=-=%=-=%=-"
 
 # size represents in bytes binary
-config :archethic, :transaction_data_content_max_size, 3145728
+config :archethic, :transaction_data_content_max_size, 3_145_728
 
 config :archethic, ArchEthic.Crypto,
   supported_curves: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -45,8 +45,8 @@ config :archethic, :mut_dir, "data"
 
 config :archethic, :marker, "-=%=-=%=-=%=-"
 
-# size represents in mb i.e 1024 * 1024  * 3 bytes
-config :archethic, :transaction_data_content_max_size, 3
+# size represents in bytes binary
+config :archethic, :transaction_data_content_max_size, 3145728
 
 config :archethic, ArchEthic.Crypto,
   supported_curves: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -45,6 +45,9 @@ config :archethic, :mut_dir, "data"
 
 config :archethic, :marker, "-=%=-=%=-=%=-"
 
+# size represents in mb i.e 1024 * 1024  * 3 bytes
+config :archethic, :transaction_data_content_max_size, 3
+
 config :archethic, ArchEthic.Crypto,
   supported_curves: [
     :ed25519,

--- a/lib/archethic_web/controllers/api/schema/transaction_data.ex
+++ b/lib/archethic_web/controllers/api/schema/transaction_data.ex
@@ -27,17 +27,14 @@ defmodule ArchEthicWeb.API.Schema.TransactionData do
   end
 
   defp validate_content_size(%Ecto.Changeset{} = changeset) do
-    content = Map.get(changeset.changes, :content)
-    content_size = byte_size(content) / (1024 * 1024)
+    validate_change(changeset, :content, fn field, content ->
+      content_size = byte_size(content) / (1024 * 1024)
 
-    if content_size >= @content_max_size do
-      add_error(
-        changeset,
-        :content,
-        "Content size cannot be greater than #{@content_max_size} MB"
-      )
-    else
-      changeset
-    end
+      if content_size >= @content_max_size do
+        [{field, "content size must be lessthan content_max_size"}]
+      else
+        []
+      end
+    end)
   end
 end

--- a/lib/archethic_web/controllers/api/schema/transaction_data.ex
+++ b/lib/archethic_web/controllers/api/schema/transaction_data.ex
@@ -1,6 +1,6 @@
 defmodule ArchEthicWeb.API.Schema.TransactionData do
   @moduledoc false
-  @content_max_size Application.get_env(:archethic, :transaction_data_content_max_size)
+  @content_max_size Application.compile_env!(:archethic, :transaction_data_content_max_size)
 
   use Ecto.Schema
   import Ecto.Changeset

--- a/lib/archethic_web/controllers/api/schema/transaction_data.ex
+++ b/lib/archethic_web/controllers/api/schema/transaction_data.ex
@@ -28,7 +28,7 @@ defmodule ArchEthicWeb.API.Schema.TransactionData do
 
   defp validate_content_size(%Ecto.Changeset{} = changeset) do
     validate_change(changeset, :content, fn field, content ->
-      content_size = byte_size(content) / (1024 * 1024)
+      content_size = byte_size(content)
 
       if content_size >= @content_max_size do
         [{field, "content size must be lessthan content_max_size"}]

--- a/lib/archethic_web/controllers/api/schema/transaction_data.ex
+++ b/lib/archethic_web/controllers/api/schema/transaction_data.ex
@@ -1,5 +1,6 @@
 defmodule ArchEthicWeb.API.Schema.TransactionData do
   @moduledoc false
+  @content_max_size Application.get_env(:archethic, :transaction_data_content_max_size)
 
   use Ecto.Schema
   import Ecto.Changeset
@@ -22,5 +23,21 @@ defmodule ArchEthicWeb.API.Schema.TransactionData do
     |> cast(params, [:code, :content, :recipients])
     |> cast_embed(:ledger)
     |> cast_embed(:ownerships)
+    |> validate_content_size()
+  end
+
+  defp validate_content_size(%Ecto.Changeset{} = changeset) do
+    content = Map.get(changeset.changes, :content)
+    content_size = byte_size(content) / (1024 * 1024)
+
+    if content_size >= @content_max_size do
+      add_error(
+        changeset,
+        :content,
+        "Content size cannot be greater than #{@content_max_size} MB"
+      )
+    else
+      changeset
+    end
   end
 end

--- a/lib/archethic_web/controllers/api/transaction_payload.ex
+++ b/lib/archethic_web/controllers/api/transaction_payload.ex
@@ -42,6 +42,7 @@ defmodule ArchEthicWeb.API.TransactionPayload do
       :originSignature
     ])
     |> cast_embed(:data, required: true)
+    |> validate_data()
   end
 
   def to_map(changes, acc \\ %{})
@@ -65,4 +66,13 @@ defmodule ArchEthicWeb.API.TransactionPayload do
   end
 
   def to_map(value, _), do: value
+
+  defp validate_data(%Ecto.Changeset{} = changeset) do
+    validate_change(changeset, :data, fn _, data_changeset ->
+      case data_changeset.valid? do
+        true -> []
+        false -> data_changeset.errors
+      end
+    end)
+  end
 end


### PR DESCRIPTION
# Description
In this change, we are keeping the **threshold** limit for the size of the `content` in the `data` field of the `transaction`. This means we are not allowing the content size to be greater than the configured threshold limit.

Add validation functions for the changesest `TransactionPayload` and `TransactionData` structs.

A new config line was added as follows

```elixir
config :archethic, :transaction_data_content_max_size, 3_145_728
```

Fixes #165 

## Type of change

- [x] New feature (setting up the max-content size )

# How Has This Been Tested?

Creating the content size greater than content_max_size using the LOC 
```elixir
Base.encode16(:crypto.strong_rand_bytes(4 * 1024 * 1024))
```` 
and trying to create a changeset of the transaction payload.

- [x] Test  **API** should return an error if the content size is greater than the `content_max_size`
- [x] Test  **Mining**  should return an error if the content size is greater than the `content_max_size`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules