### PR TITLE
Added Rest API for origin device public key

### DIFF
--- a/lib/archethic/shared_secrets.ex
+++ b/lib/archethic/shared_secrets.ex
@@ -63,6 +63,20 @@ defmodule ArchEthic.SharedSecrets do
               to: NodeRenewal
 
   @doc """
+  Create a new transaction for origin shared secrets renewal generating secret encrypted origin priv keys using the aes key
+  for the authorized nodes public keys
+  """
+  @spec new_origin_shared_secrets_transaction(
+          origin_public_keys :: list(Crypto.key()),
+          aes_key :: binary()
+        ) :: Transaction.t()
+  defdelegate new_origin_shared_secrets_transaction(
+                origin_public_keys,
+                aes_key
+              ),
+              to: NodeRenewal
+
+  @doc """
   Load the transaction into the Shared Secrets context
   by filling memory tables and setup the new node shared secret renewal if applicable.
 

--- a/lib/archethic/shared_secrets/node_renewal.ex
+++ b/lib/archethic/shared_secrets/node_renewal.ex
@@ -138,8 +138,6 @@ defmodule ArchEthic.SharedSecrets.NodeRenewal do
 
     new_origin_shared_priv_keys = :erlang.list_to_binary(new_origin_shared_priv_keys_list)
 
-    origin_public_keys_bin = :erlang.list_to_binary(origin_public_keys)
-
     encrypted_origin_shared_priv_keys =
       Crypto.aes_encrypt(new_origin_shared_priv_keys, secret_key)
 
@@ -148,7 +146,7 @@ defmodule ArchEthic.SharedSecrets.NodeRenewal do
     Transaction.new(
       :origin_shared_secrets,
       %TransactionData{
-        content: <<origin_public_keys_bin <> new_origin_shared_pub_keys>>,
+        content: new_origin_shared_pub_keys,
         ownerships: [
           Ownership.new(secret, secret_key, origin_public_keys)
         ]

--- a/lib/archethic/shared_secrets/node_renewal.ex
+++ b/lib/archethic/shared_secrets/node_renewal.ex
@@ -134,13 +134,11 @@ defmodule ArchEthic.SharedSecrets.NodeRenewal do
       new_shared_origin_keys
       |> Enum.map(fn {_pub, priv} -> priv end)
 
-    new_origin_shared_pub_keys =
-      new_origin_shared_pub_keys_list
-      |> Enum.reduce(fn x, acc -> acc <> x end)
+    new_origin_shared_pub_keys = :erlang.list_to_binary(new_origin_shared_pub_keys_list)
 
-    new_origin_shared_priv_keys =
-      new_origin_shared_priv_keys_list
-      |> Enum.reduce(fn x, acc -> acc <> x end)
+    new_origin_shared_priv_keys = :erlang.list_to_binary(new_origin_shared_priv_keys_list)
+
+    origin_public_keys_bin = :erlang.list_to_binary(origin_public_keys)
 
     encrypted_origin_shared_priv_keys =
       Crypto.aes_encrypt(new_origin_shared_priv_keys, secret_key)
@@ -150,7 +148,7 @@ defmodule ArchEthic.SharedSecrets.NodeRenewal do
     Transaction.new(
       :origin_shared_secrets,
       %TransactionData{
-        content: new_origin_shared_pub_keys,
+        content: <<origin_public_keys_bin <> new_origin_shared_pub_keys>>,
         ownerships: [
           Ownership.new(secret, secret_key, origin_public_keys)
         ]

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -124,14 +124,6 @@ defmodule ArchEthic.SharedSecrets.NodeRenewalScheduler do
 
     ArchEthic.send_new_transaction(tx)
 
-    tx =
-      NodeRenewal.new_origin_shared_secrets_transaction(
-        [Crypto.first_node_public_key()],
-        :crypto.strong_rand_bytes(32)
-      )
-
-    ArchEthic.send_new_transaction(tx)
-
     Logger.info(
       "Node shared secrets renewal transaction sent (#{Crypto.number_of_node_shared_secrets_keys()})"
     )

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -124,6 +124,9 @@ defmodule ArchEthic.SharedSecrets.NodeRenewalScheduler do
 
     ArchEthic.send_new_transaction(tx)
 
+    tx = NodeRenewal.new_origin_shared_secrets_transaction()
+    ArchEthic.send_new_transaction(tx)
+
     Logger.info(
       "Node shared secrets renewal transaction sent (#{Crypto.number_of_node_shared_secrets_keys()})"
     )

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -124,7 +124,12 @@ defmodule ArchEthic.SharedSecrets.NodeRenewalScheduler do
 
     ArchEthic.send_new_transaction(tx)
 
-    tx = NodeRenewal.new_origin_shared_secrets_transaction()
+    tx =
+      NodeRenewal.new_origin_shared_secrets_transaction(
+        [Crypto.first_node_public_key()],
+        :crypto.strong_rand_bytes(32)
+      )
+
     ArchEthic.send_new_transaction(tx)
 
     Logger.info(

--- a/lib/archethic/transaction_chain/transaction/data/ownership.ex
+++ b/lib/archethic/transaction_chain/transaction/data/ownership.ex
@@ -23,7 +23,7 @@ defmodule ArchEthic.TransactionChain.TransactionData.Ownership do
       iex> %Ownership{authorized_keys: authorized_keys} = Ownership.new(secret, secret_key, [pub])
       iex> Map.keys(authorized_keys)
       [
-        <<0, 0, 241, 101, 225, 229, 247, 194, 144, 229, 47, 46, 222, 243, 251, 171, 96, 203, 174, 116, 191, 211, 
+        <<0, 0, 241, 101, 225, 229, 247, 194, 144, 229, 47, 46, 222, 243, 251, 171, 96, 203, 174, 116, 191, 211,
         39, 79, 142, 94, 225, 222, 51, 69, 201, 84, 161,102>>
       ]
   """

--- a/lib/archethic_web/controllers/api/origin_public_key_payload.ex
+++ b/lib/archethic_web/controllers/api/origin_public_key_payload.ex
@@ -1,0 +1,49 @@
+defmodule ArchEthicWeb.API.OriginPublicKeyPayload do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ArchEthic.Utils
+
+  alias ArchEthicWeb.API.Types.Hex
+  alias ArchEthicWeb.API.Types.PublicKey
+
+  embedded_schema do
+    field(:PublicKey, PublicKey)
+    field(:Certificate, Hex)
+  end
+
+  def changeset(params = %{}) do
+    %__MODULE__{}
+    |> cast(params, [
+      :PublicKey,
+      :Certificate
+    ])
+    |> validate_required([
+      :PublicKey
+    ])
+  end
+
+  def to_map(changes, acc \\ %{})
+
+  def to_map(%{changes: changes}, acc) do
+    Enum.reduce(changes, acc, fn {key, value}, acc ->
+      key = Macro.underscore(Atom.to_string(key))
+
+      case value do
+        %{changes: _} ->
+          Map.put(acc, key, to_map(value))
+
+        value when is_list(value) ->
+          Map.put(acc, key, Enum.map(value, &to_map/1))
+
+        _ ->
+          Map.put(acc, key, value)
+      end
+    end)
+    |> Utils.atomize_keys()
+  end
+
+  def to_map(value, _), do: value
+end

--- a/lib/archethic_web/controllers/api/origin_public_key_payload.ex
+++ b/lib/archethic_web/controllers/api/origin_public_key_payload.ex
@@ -4,46 +4,22 @@ defmodule ArchEthicWeb.API.OriginPublicKeyPayload do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias ArchEthic.Utils
-
   alias ArchEthicWeb.API.Types.Hex
   alias ArchEthicWeb.API.Types.PublicKey
 
   embedded_schema do
-    field(:PublicKey, PublicKey)
-    field(:Certificate, Hex)
+    field(:publicKey, PublicKey)
+    field(:certificate, Hex)
   end
 
   def changeset(params = %{}) do
     %__MODULE__{}
     |> cast(params, [
-      :PublicKey,
-      :Certificate
+      :publicKey,
+      :certificate
     ])
     |> validate_required([
-      :PublicKey
+      :publicKey
     ])
   end
-
-  def to_map(changes, acc \\ %{})
-
-  def to_map(%{changes: changes}, acc) do
-    Enum.reduce(changes, acc, fn {key, value}, acc ->
-      key = Macro.underscore(Atom.to_string(key))
-
-      case value do
-        %{changes: _} ->
-          Map.put(acc, key, to_map(value))
-
-        value when is_list(value) ->
-          Map.put(acc, key, Enum.map(value, &to_map/1))
-
-        _ ->
-          Map.put(acc, key, value)
-      end
-    end)
-    |> Utils.atomize_keys()
-  end
-
-  def to_map(value, _), do: value
 end

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -124,17 +124,17 @@ defmodule ArchEthicWeb.API.TransactionController do
 
   def origin_public_key_verify(conn, data) do
     case OriginPublicKeyPayload.changeset(data) do
-      %{valid?: true} ->
-        public_key =
-          data["publicKey"]
-          |> Base.decode16()
-          |> elem(1)
+      changeset = %{valid?: true} ->
+        %Ecto.Changeset{changes: changes} = changeset
+
+        public_key = Map.get(changes, :publicKey)
+        certificate = Map.get(changes, :certificate)
 
         root_ca_key =
           public_key
           |> Crypto.get_root_ca_public_key()
 
-        if Crypto.verify_key_certificate?(public_key, data["certificate"], root_ca_key) do
+        if Crypto.verify_key_certificate?(public_key, certificate, root_ca_key) do
           conn
           |> put_status(:ok)
           |> json(%{

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -163,9 +163,7 @@ defmodule ArchEthicWeb.API.TransactionController do
   end
 
   def create_new_origin_shared_secret_tx(origin_public_key) do
-    aes_key =
-      <<200, 161, 216, 155, 119, 51, 4, 103, 76, 61, 205, 106, 243, 97, 236, 219, 223, 87, 122,
-        44, 162, 15, 61, 233, 101, 41, 236, 9, 188, 108, 15, 65>>
+    aes_key = :crypto.strong_rand_bytes(32)
 
     SharedSecrets.new_origin_shared_secrets_transaction(
       [origin_public_key],

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -10,8 +10,10 @@ defmodule ArchEthicWeb.API.TransactionController do
 
   alias ArchEthic.Mining
   alias ArchEthic.OracleChain
+  alias ArchEthic.Crypto
 
   alias ArchEthicWeb.API.TransactionPayload
+  alias ArchEthicWeb.API.OriginPublicKeyPayload
   alias ArchEthicWeb.ErrorView
   alias ArchEthicWeb.TransactionSubscriber
 
@@ -111,6 +113,39 @@ defmodule ArchEthicWeb.API.TransactionController do
             "eur" => uco_eur
           }
         })
+
+      changeset ->
+        conn
+        |> put_status(:bad_request)
+        |> put_view(ErrorView)
+        |> render("400.json", changeset: changeset)
+    end
+  end
+
+  def origin_public_key_verify(conn, data) do
+    case OriginPublicKeyPayload.changeset(data) do
+      %{valid?: true} ->
+        cert =
+          data["PublicKey"]
+          |> Base.decode16()
+          |> elem(1)
+          |> Crypto.get_key_certificate()
+
+        if cert == data["Certificate"] do
+          conn
+          |> put_status(:ok)
+          |> json(%{
+            "OriginPublicKey" => "valid",
+            "Certificate" => "valid"
+          })
+        else
+          conn
+          |> put_status(:ok)
+          |> json(%{
+            "OriginPublicKey" => "valid",
+            "Certificate" => "in valid"
+          })
+        end
 
       changeset ->
         conn

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -125,25 +125,28 @@ defmodule ArchEthicWeb.API.TransactionController do
   def origin_public_key_verify(conn, data) do
     case OriginPublicKeyPayload.changeset(data) do
       %{valid?: true} ->
-        cert =
-          data["PublicKey"]
+        public_key =
+          data["publicKey"]
           |> Base.decode16()
           |> elem(1)
-          |> Crypto.get_key_certificate()
 
-        if cert == data["Certificate"] do
+        root_ca_key =
+          public_key
+          |> Crypto.get_root_ca_public_key()
+
+        if Crypto.verify_key_certificate?(public_key, data["certificate"], root_ca_key) do
           conn
           |> put_status(:ok)
           |> json(%{
-            "OriginPublicKey" => "valid",
-            "Certificate" => "valid"
+            "originPublicKey" => "valid",
+            "certificate" => "valid"
           })
         else
           conn
           |> put_status(:ok)
           |> json(%{
-            "OriginPublicKey" => "valid",
-            "Certificate" => "in valid"
+            "originPublicKey" => "valid",
+            "certificate" => "in valid"
           })
         end
 

--- a/lib/archethic_web/router.ex
+++ b/lib/archethic_web/router.ex
@@ -72,6 +72,7 @@ defmodule ArchEthicWeb.Router do
 
     post("/transaction", ArchEthicWeb.API.TransactionController, :new)
     post("/transaction_fee", ArchEthicWeb.API.TransactionController, :transaction_fee)
+    post("/origin_public_key", ArchEthicWeb.API.TransactionController, :origin_public_key_verify)
 
     forward(
       "/graphiql",

--- a/test/archethic/shared_secrets/node_renewal_test.exs
+++ b/test/archethic/shared_secrets/node_renewal_test.exs
@@ -38,6 +38,27 @@ defmodule ArchEthic.SharedSecrets.NodeRenewalTest do
     assert {:ok, _, _} = NodeRenewal.decode_transaction_content(content)
   end
 
+  test "new_origin_shared_secrets_transaction/2 should create a new origin shared secrets transaction" do
+    aes_key = :crypto.strong_rand_bytes(32)
+    origin_public_key = Crypto.first_node_public_key()
+
+    %Transaction{
+      type: :origin_shared_secrets,
+      data: %TransactionData{
+        ownerships: [ownership = %Ownership{}],
+        content: _content
+      }
+    } =
+      SharedSecrets.new_origin_shared_secrets_transaction(
+        [origin_public_key],
+        aes_key
+      )
+
+    assert Ownership.authorized_public_key?(ownership, Crypto.first_node_public_key())
+
+    # assert {:ok, _, _} = NodeRenewal.decode_transaction_content(content)
+  end
+
   describe "initiator?/0" do
     test "should return false when the first elected node is not the current node" do
       P2P.add_and_connect_node(%Node{


### PR DESCRIPTION
#  Description

We are adding Rest API to post origin public key with certificate along with the validation of  certificate as per the public key and  validate and Implement the transaction generation with new authorized device for renewal

- [x] post req -> to get origin public key and cert
- [x] generate new shared origin keys, and encrypt with new AES key which will be encrypted by the origin public keys (refer Ownership module)
- [x] add the TransactionData containing content, ownerships and secrets to the transaction 
- [x] add unit test 

# Type of Change 
- [x] Feature

# How Has This Been Tested?

Post Req to API Endpoint http://localhost:4000/api/origin_public_key 
Request
`
{
	"publicKey" : "00005D6B602E754079AEA9A69675BDBE2468CFAC3EE25F38FF3EE5E8974A3F779E97",
	"certificate": ""
}
`
Response
`
{
	"certificate": "valid",
	"originPublicKey": "valid"
}
`
