### PR TITLE
Fix the shared secret keystore loading

### DIFF
--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -26,6 +26,9 @@ defmodule ArchEthic.DB do
               Enumerable.t()
   @callback count_transactions_by_type(type :: Transaction.transaction_type()) ::
               non_neg_integer()
+
+  @callback list_addresses_by_type(Transaction.transaction_type()) ::
+              Enumerable.t() | list(binary())
   @callback get_last_chain_address(binary()) :: binary()
   @callback get_last_chain_address(binary(), DateTime.t()) :: binary()
   @callback get_first_chain_address(binary()) :: binary()

--- a/lib/archethic/db/embedded_impl.ex
+++ b/lib/archethic/db/embedded_impl.ex
@@ -131,6 +131,14 @@ defmodule ArchEthic.DB.EmbeddedImpl do
   end
 
   @doc """
+  Stream all the addresses for a transaction type
+  """
+  @spec list_addresses_by_type(Transaction.transaction_type()) :: Enumerable.t() | list(binary())
+  def list_addresses_by_type(type) when is_atom(type) do
+    ChainIndex.get_addresses_by_type(type, db_path())
+  end
+
+  @doc """
   Count the number of transactions for a given type
   """
   @spec count_transactions_by_type(Transaction.transaction_type()) :: non_neg_integer()

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -44,6 +44,12 @@ defmodule ArchEthic.TransactionChain do
   defdelegate count_transactions_by_type(type), to: DB
 
   @doc """
+  Stream all the addresses for a transaction type
+  """
+  @spec list_addresses_by_type(Transaction.transaction_type()) :: Enumerable.t() | list(binary())
+  defdelegate list_addresses_by_type(type), to: DB
+
+  @doc """
   Get the last transaction address from a transaction chain
   """
   @spec get_last_address(binary()) :: binary()

--- a/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
+++ b/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
@@ -26,20 +26,23 @@ defmodule ArchEthic.Crypto.SharedSecrets.SoftwareImplTest do
       timestamp = ~U[2021-10-10 00:00:00Z]
 
       MockDB
-      |> expect(:count_transactions_by_type, fn
+      |> stub(:count_transactions_by_type, fn
         :node_rewards -> 1
+        :node_shared_secrets -> 1
       end)
-      |> expect(:list_transactions_by_type, fn :node_shared_secrets, _ ->
-        [
-          %Transaction{
-            data: %TransactionData{
-              ownerships: [Ownership.new(secrets, aes_key, [Crypto.last_node_public_key()])]
-            },
-            validation_stamp: %ValidationStamp{
-              timestamp: timestamp
-            }
-          }
-        ]
+      |> expect(:list_addresses_by_type, fn :node_shared_secrets ->
+        [:crypto.strong_rand_bytes(32)]
+      end)
+      |> expect(:get_transaction, fn _, _ ->
+        {:ok,
+         %Transaction{
+           data: %TransactionData{
+             ownerships: [Ownership.new(secrets, aes_key, [Crypto.last_node_public_key()])]
+           },
+           validation_stamp: %ValidationStamp{
+             timestamp: timestamp
+           }
+         }}
       end)
 
       {:ok, _pid} = Keystore.start_link()

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -47,6 +47,7 @@ defmodule ArchEthicCase do
     |> stub(:chain_size, fn _ -> 0 end)
     |> stub(:list_transactions_by_type, fn _, _ -> [] end)
     |> stub(:count_transactions_by_type, fn _ -> 0 end)
+    |> stub(:list_addresses_by_type, fn _ -> [] end)
     |> stub(:list_transactions, fn _ -> [] end)
     |> stub(:transaction_exists?, fn _ -> false end)
     |> stub(:register_p2p_summary, fn _, _, _, _ -> :ok end)


### PR DESCRIPTION
# Description

Because of the new DB design, the order of transaction is not desc but
asc.

So the loader had to be changed, to load the latest transaction
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

When you run the node after few times, when you restart it should have error of proof_of_election, due to an invalid last shared secrets tx.
Also unit tests have been update

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
