### PR TITLE
Made use of get_first_public_key to always return a public key even i…

### DIFF
--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -285,13 +285,13 @@ defmodule ArchEthic.Mining.PendingTransactionValidation do
     |> get_first_public_key(previous_address)
   end
 
-  defp get_first_public_key([node | rest], address) do
-    case P2P.send_message(node, %GetFirstPublicKey{address: address}) do
+  defp get_first_public_key([node | rest], public_key) do
+    case P2P.send_message(node, %GetFirstPublicKey{public_key: public_key}) do
       {:ok, %FirstPublicKey{public_key: public_key}} ->
         {:ok, public_key}
 
       {:error, _} ->
-        get_first_public_key(rest, address)
+        get_first_public_key(rest, public_key)
     end
   end
 

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -307,8 +307,8 @@ defmodule ArchEthic.P2P.Message do
     <<19::8, length(node_public_keys)::16, :erlang.list_to_binary(node_public_keys)::binary>>
   end
 
-  def encode(%GetFirstPublicKey{address: address}) do
-    <<20::8, address::binary>>
+  def encode(%GetFirstPublicKey{public_key: public_key}) do
+    <<20::8, public_key::binary>>
   end
 
   def encode(%GetLastTransactionAddress{address: address, timestamp: timestamp}) do
@@ -706,10 +706,10 @@ defmodule ArchEthic.P2P.Message do
   end
 
   def decode(<<20::8, rest::bitstring>>) do
-    {address, rest} = Utils.deserialize_address(rest)
+    {public_key, rest} = Utils.deserialize_address(rest)
 
     {%GetFirstPublicKey{
-       address: address
+       public_key: public_key
      }, rest}
   end
 
@@ -1227,7 +1227,7 @@ defmodule ArchEthic.P2P.Message do
   end
 
   # Returns the first public_key for a given public_key and if the public_key is used for the first time, return the same public_key.
-  def process(%GetFirstPublicKey{address: public_key}) do
+  def process(%GetFirstPublicKey{public_key: public_key}) do
     case TransactionChain.get_first_public_key(public_key) do
       pub_key ->
         %FirstPublicKey{public_key: pub_key}

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -1227,12 +1227,9 @@ defmodule ArchEthic.P2P.Message do
   end
 
   def process(%GetFirstPublicKey{address: address}) do
-    case TransactionChain.get_first_transaction(address, [:previous_public_key]) do
-      {:ok, %Transaction{previous_public_key: key}} ->
+    case TransactionChain.get_first_public_key(address) do
+      key ->
         %FirstPublicKey{public_key: key}
-
-      {:error, :transaction_not_exists} ->
-        %NotFound{}
     end
   end
 

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -1226,10 +1226,11 @@ defmodule ArchEthic.P2P.Message do
     }
   end
 
-  def process(%GetFirstPublicKey{address: address}) do
-    case TransactionChain.get_first_public_key(address) do
-      key ->
-        %FirstPublicKey{public_key: key}
+  # Returns the first public_key for a given public_key and if the public_key is used for the first time, return the same public_key.
+  def process(%GetFirstPublicKey{address: public_key}) do
+    case TransactionChain.get_first_public_key(public_key) do
+      pub_key ->
+        %FirstPublicKey{public_key: pub_key}
     end
   end
 

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -706,7 +706,7 @@ defmodule ArchEthic.P2P.Message do
   end
 
   def decode(<<20::8, rest::bitstring>>) do
-    {public_key, rest} = Utils.deserialize_address(rest)
+    {public_key, rest} = Utils.deserialize_public_key(rest)
 
     {%GetFirstPublicKey{
        public_key: public_key
@@ -1228,10 +1228,9 @@ defmodule ArchEthic.P2P.Message do
 
   # Returns the first public_key for a given public_key and if the public_key is used for the first time, return the same public_key.
   def process(%GetFirstPublicKey{public_key: public_key}) do
-    case TransactionChain.get_first_public_key(public_key) do
-      pub_key ->
-        %FirstPublicKey{public_key: pub_key}
-    end
+    %FirstPublicKey{
+      public_key: TransactionChain.get_first_public_key(public_key)
+    }
   end
 
   def process(%GetLastTransactionAddress{address: address, timestamp: timestamp}) do

--- a/lib/archethic/p2p/message/get_first_public_key.ex
+++ b/lib/archethic/p2p/message/get_first_public_key.ex
@@ -3,10 +3,10 @@ defmodule ArchEthic.P2P.Message.GetFirstPublicKey do
   Represents a message to request the first public key from a transaction chain
   """
 
-  @enforce_keys [:address]
-  defstruct [:address]
+  @enforce_keys [:public_key]
+  defstruct [:public_key]
 
   @type t() :: %__MODULE__{
-          address: binary()
+          public_key: binary()
         }
 end

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -776,7 +776,7 @@ defmodule ArchEthic.P2P.MessageTest do
 
     test "GetFirstPublicKey message" do
       msg = %GetFirstPublicKey{
-        address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+        public_key: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
       }
 
       assert msg ==


### PR DESCRIPTION
Made use of TransactionChain.get_first_public_key/1 to always return a public key even in case of nonexistent transactions and lower I/O operations which are not required if only want to get First_Public_Key for any given address.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
