### PR TITLE
Fix NFT tx movement decoding

### DIFF
--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/transaction_movement.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/transaction_movement.ex
@@ -129,11 +129,11 @@ defmodule ArchEthic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
     }
 
     case Map.get(movement, :type) do
-      type when type in [:UCO, "UCO"] ->
+      :UCO ->
         %{res | type: :UCO}
 
-      type when type in [:NFT, "NFT"] ->
-        %{res | type: {:NFT, Map.get(movement, :nft_address)}}
+      {:NFT, nft_address} ->
+        %{res | type: {:NFT, nft_address}}
     end
   end
 


### PR DESCRIPTION
# Description

This PR fixes the transaction movement issue from the `to_map` decoding of the NFT cases.

Fixes #281 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Create an address and allocate funds through the faucet
- Create a transaction chain with NFT, with allocated funds
- Create another address for a recipient
- Create a transaction to transfer the NFT
- Go to the explorer, it should not reproduce the error of decoding

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
