### PR TITLE
Leverage sharded origin key

### DIFF
--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -6,6 +6,7 @@ defmodule ArchEthic.Bootstrap.NetworkInit do
   """
 
   alias ArchEthic.Bootstrap
+  alias ArchEthic.Bootstrap.NetworkInit
 
   alias ArchEthic.BeaconChain.ReplicationAttestation
 
@@ -31,12 +32,18 @@ defmodule ArchEthic.Bootstrap.NetworkInit do
   alias ArchEthic.TransactionChain.TransactionData.Ledger
   alias ArchEthic.TransactionChain.TransactionData.UCOLedger
   alias ArchEthic.TransactionChain.TransactionData.UCOLedger.Transfer
+  alias ArchEthic.TransactionChain.TransactionData.Ownership
 
   alias ArchEthic.TransactionChain.TransactionSummary
 
   require Logger
 
   @genesis_seed Application.compile_env(:archethic, [__MODULE__, :genesis_seed])
+
+  @genesis_origin_public_keys Application.compile_env!(
+                                :archethic,
+                                [NetworkInit, :genesis_origin_public_keys]
+                              )
 
   defp get_genesis_pools do
     Application.get_env(:archethic, __MODULE__) |> Keyword.get(:genesis_pools, [])
@@ -70,6 +77,37 @@ defmodule ArchEthic.Bootstrap.NetworkInit do
       )
 
     tx
+    |> self_validation()
+    |> self_replication()
+  end
+
+  @doc """
+  Create the first origin shared secret transaction
+  """
+  @spec init_software_origin_shared_secrets_chain() :: :ok
+  def init_software_origin_shared_secrets_chain do
+    Logger.info("Create first software origin shared secret transaction")
+
+    origin_seed = :crypto.strong_rand_bytes(32)
+    secret_key = :crypto.strong_rand_bytes(32)
+    signing_seed = Crypto.storage_nonce() <> "software"
+
+    # Default keypair generation creates software public key
+    {origin_public_key, origin_private_key} = Crypto.generate_deterministic_keypair(origin_seed)
+
+    encrypted_origin_private_key = Crypto.aes_encrypt(origin_private_key, secret_key)
+
+    Transaction.new(
+      :origin_shared_secrets,
+      %TransactionData{
+        content: <<origin_public_key::binary>>,
+        ownerships: [
+          Ownership.new(encrypted_origin_private_key, secret_key, @genesis_origin_public_keys)
+        ]
+      },
+      signing_seed,
+      0
+    )
     |> self_validation()
     |> self_replication()
   end

--- a/lib/archethic/bootstrap/sync.ex
+++ b/lib/archethic/bootstrap/sync.ex
@@ -119,6 +119,7 @@ defmodule ArchEthic.Bootstrap.Sync do
     P2P.set_node_globally_available(Crypto.first_node_public_key())
     P2P.authorize_node(Crypto.last_node_public_key(), DateTime.utc_now())
 
+    NetworkInit.init_software_origin_shared_secrets_chain()
     NetworkInit.init_node_shared_secrets_chain()
     NetworkInit.init_genesis_wallets()
   end

--- a/lib/archethic/shared_secrets/mem_tables/origin_key_lookup.ex
+++ b/lib/archethic/shared_secrets/mem_tables/origin_key_lookup.ex
@@ -7,8 +7,6 @@ defmodule ArchEthic.SharedSecrets.MemTables.OriginKeyLookup do
 
   alias ArchEthic.Crypto
 
-  alias ArchEthic.Bootstrap.NetworkInit
-
   alias ArchEthic.SharedSecrets
 
   require Logger
@@ -16,10 +14,6 @@ defmodule ArchEthic.SharedSecrets.MemTables.OriginKeyLookup do
   @origin_key_table :archethic_origin_keys
   @origin_key_by_type_table :archethic_origin_key_by_type
 
-  @genesis_origin_public_keys Application.compile_env!(
-                                :archethic,
-                                [NetworkInit, :genesis_origin_public_keys]
-                              )
   @doc """
   Initialize memory tables to index public information from the shared secrets
 
@@ -39,10 +33,6 @@ defmodule ArchEthic.SharedSecrets.MemTables.OriginKeyLookup do
     :ets.new(@origin_key_by_type_table, [:bag, :named_table, :public, read_concurrency: true])
     :ets.new(@origin_key_table, [:set, :named_table, :public, read_concurrency: true])
 
-    Enum.each(@genesis_origin_public_keys, fn key ->
-      add_public_key(:software, key)
-    end)
-
     {:ok, []}
   end
 
@@ -60,10 +50,6 @@ defmodule ArchEthic.SharedSecrets.MemTables.OriginKeyLookup do
       iex> { :ets.tab2list(:archethic_origin_keys), :ets.tab2list(:archethic_origin_key_by_type) }
       {
           [
-            {<<1, 0, 4, 171, 65, 41, 31, 132, 122, 96, 16, 85, 174, 221, 26, 242, 79, 247,
-              111, 169, 112, 214, 68, 30, 45, 202, 56, 24, 168, 49, 155, 0, 76, 150, 178,
-              123, 143, 235, 29, 163, 26, 4, 75, 160, 164, 128, 11, 67, 83, 53, 151, 53,
-              113, 158, 187, 58, 5, 249, 131, 147, 169, 204, 89, 156, 63, 175, 214>>, :software},
             {"key1", :software},
             {"key3", :hardware},
             {"key2", :hardware}
@@ -71,10 +57,6 @@ defmodule ArchEthic.SharedSecrets.MemTables.OriginKeyLookup do
           [
             {:hardware, "key2"},
             {:hardware, "key3"},
-            {:software, <<1, 0, 4, 171, 65, 41, 31, 132, 122, 96, 16, 85, 174, 221, 26, 242, 79, 247,
-              111, 169, 112, 214, 68, 30, 45, 202, 56, 24, 168, 49, 155, 0, 76, 150, 178,
-              123, 143, 235, 29, 163, 26, 4, 75, 160, 164, 128, 11, 67, 83, 53, 151, 53,
-              113, 158, 187, 58, 5, 249, 131, 147, 169, 204, 89, 156, 63, 175, 214>>},
             {:software, "key1"}
           ],
       }
@@ -118,11 +100,7 @@ defmodule ArchEthic.SharedSecrets.MemTables.OriginKeyLookup do
       iex> :ok = OriginKeyLookup.add_public_key(:hardware, "key3")
       iex> OriginKeyLookup.list_public_keys()
       [
-        <<1, 0, 4, 171, 65, 41, 31, 132, 122, 96, 16, 85, 174, 221, 26, 242, 79, 247,
-        111, 169, 112, 214, 68, 30, 45, 202, 56, 24, 168, 49, 155, 0, 76, 150, 178,
-        123, 143, 235, 29, 163, 26, 4, 75, 160, 164, 128, 11, 67, 83, 53, 151, 53,
-        113, 158, 187, 58, 5, 249, 131, 147, 169, 204, 89, 156, 63, 175, 214>>, 
-        "key1", 
+        "key1",
         "key3",
         "key2"
       ]

--- a/test/archethic/bootstrap/sync_test.exs
+++ b/test/archethic/bootstrap/sync_test.exs
@@ -26,6 +26,7 @@ defmodule ArchEthic.Bootstrap.SyncTest do
   alias ArchEthic.P2P.Message.UnspentOutputList
   alias ArchEthic.P2P.Node
 
+  alias ArchEthic.SharedSecrets
   alias ArchEthic.SharedSecrets.NodeRenewalScheduler
 
   alias ArchEthic.TransactionChain
@@ -270,6 +271,8 @@ defmodule ArchEthic.Bootstrap.SyncTest do
 
       assert %Node{authorized?: true} = P2P.get_node_info()
       assert 1 == Crypto.number_of_node_shared_secrets_keys()
+
+      assert 2 == SharedSecrets.list_origin_public_keys() |> Enum.count()
 
       Application.get_env(:archethic, ArchEthic.Bootstrap.NetworkInit)[:genesis_pools]
       |> Enum.each(fn %{address: address, amount: amount} ->

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -35,6 +35,7 @@ defmodule ArchEthic.BootstrapTest do
 
   alias ArchEthic.SelfRepair.Scheduler, as: SelfRepairScheduler
 
+  alias ArchEthic.SharedSecrets
   alias ArchEthic.SharedSecrets.NodeRenewalScheduler
 
   alias ArchEthic.TransactionChain
@@ -133,6 +134,8 @@ defmodule ArchEthic.BootstrapTest do
                P2P.list_nodes()
 
       assert 1 == Crypto.number_of_node_shared_secrets_keys()
+
+      assert 2 == SharedSecrets.list_origin_public_keys() |> Enum.count()
     end
   end
 


### PR DESCRIPTION
Fixes #275

# Description
First software origin key is no more hardcoded but randomly generated during network init and encrypted with the hardcoded public key in secret transaction.
Hardcoded key is now able to read and decrypt first software origin key

Fixes #275

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

- Implement file test to ensure that an origin key is generated during network init
- Used GraphiQL to get first ```origin_shared_secret``` and decypt it using libjs. Resulted private key is the same that the one generated during network init

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
