### PR TITLE
Fix beacon summary aggregate

### DIFF
--- a/lib/archethic/beacon_chain/summary_timer.ex
+++ b/lib/archethic/beacon_chain/summary_timer.ex
@@ -20,14 +20,22 @@ defmodule ArchEthic.BeaconChain.SummaryTimer do
   end
 
   @doc """
-  Give the next beacon chain slot using the `SlotTimer` interval
+  Give the next beacon chain slot using the `SummaryTimer` interval
   """
-
   def next_summary(date_from = %DateTime{}) do
-    get_interval()
-    |> CronParser.parse!(true)
-    |> CronScheduler.get_next_run_date!(DateTime.to_naive(date_from))
-    |> DateTime.from_naive!("Etc/UTC")
+    cron_expression = CronParser.parse!(get_interval(), true)
+    naive_date_from = DateTime.to_naive(date_from)
+
+    if Crontab.DateChecker.matches_date?(cron_expression, naive_date_from) do
+      cron_expression
+      |> CronScheduler.get_next_run_dates(naive_date_from)
+      |> Enum.at(1)
+      |> DateTime.from_naive!("Etc/UTC")
+    else
+      cron_expression
+      |> CronScheduler.get_next_run_date!(naive_date_from)
+      |> DateTime.from_naive!("Etc/UTC")
+    end
   end
 
   @doc """

--- a/lib/archethic/self_repair/sync/beacon_summary_handler.ex
+++ b/lib/archethic/self_repair/sync/beacon_summary_handler.ex
@@ -45,6 +45,7 @@ defmodule ArchEthic.SelfRepair.Sync.BeaconSummaryHandler do
     )
     |> Enum.filter(&match?({:ok, {:ok, %BeaconSummary{}}}, &1))
     |> Enum.map(fn {:ok, {:ok, summary}} -> summary end)
+    |> Enum.reject(&BeaconSummary.empty?/1)
     |> Enum.reduce(
       %{
         transaction_attestations: [],

--- a/lib/mix/tasks/clean_db.ex
+++ b/lib/mix/tasks/clean_db.ex
@@ -4,14 +4,12 @@ defmodule Mix.Tasks.ArchEthic.CleanDb do
   use Mix.Task
 
   def run(_arg) do
-    files_to_remove =
-      ["_build", "dev", "lib", "archethic", "data_*"]
-      |> Path.join()
-      |> Path.wildcard()
-
-    IO.puts("#{files_to_remove} will be removed")
-
-    Enum.each(files_to_remove, &File.rm_rf!/1)
+    "_build/dev/lib/archethic/data*"
+    |> Path.wildcard()
+    |> Enum.each(fn path ->
+      IO.puts("#{path} will be removed")
+      File.rm_rf!(path)
+    end)
 
     IO.puts("Database dropped")
   end

--- a/test/archethic/beacon_chain/summary_timer_test.exs
+++ b/test/archethic/beacon_chain/summary_timer_test.exs
@@ -4,11 +4,20 @@ defmodule ArchEthic.BeaconChain.SummaryTimerTest do
 
   alias ArchEthic.BeaconChain.SummaryTimer
 
-  test "next_summary/2 should get the next summary time from a given date" do
-    {:ok, _pid} = SummaryTimer.start_link([interval: "0 * * * * * *"], [])
-    now = ~U[2021-01-02 03:00:19Z]
-    next_summary_time = SummaryTimer.next_summary(now)
-    assert 1 == abs(now.minute - next_summary_time.minute)
+  describe "next_summary/2" do
+    test "should get the next summary time from a given date" do
+      {:ok, _pid} = SummaryTimer.start_link([interval: "0 * * * * * *"], [])
+      now = ~U[2021-01-02 03:00:19.501Z]
+      next_summary_time = SummaryTimer.next_summary(now)
+      assert 1 == abs(now.minute - next_summary_time.minute)
+    end
+
+    test "should get the 2nd next summary time when the date is an summary interval date" do
+      {:ok, _pid} = SummaryTimer.start_link([interval: "0 * * * * * *"], [])
+      next_date = SummaryTimer.next_summary(DateTime.utc_now())
+      next_summary_time = SummaryTimer.next_summary(next_date)
+      assert DateTime.compare(next_summary_time, next_date) == :gt
+    end
   end
 
   property "previous_summaries/1 should retrieve the previous summary times from a date" do


### PR DESCRIPTION
# Description

This PR fixes the ordering of transaction during synchronization of the missed transactions in the self-repair when a node joins after some time of network liveness.

The issue resolved is not present on docker-compose or local node environment, but only when a node joins after a first one is there for several minutes.

The issue was about the aggregation of beacon summaries

Fixes #287 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?



- Start a node using `iex -S mix`
- After several 5/10 min, start another using: `ARCHETHIC_P2P_PORT=3005 ARCHETHIC_HTTP_PORT=4005 ARCHETHIC_CRYPTO_SEED="node2" iex -S mix`
- The transaction should be synchronized without the `:invalid_proof_of_election` error

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
