### PR TITLE
Format UCO's amount in the chain UI

### DIFF
--- a/lib/archethic_web/templates/explorer/chain.html.eex
+++ b/lib/archethic_web/templates/explorer/chain.html.eex
@@ -81,14 +81,12 @@
                 <div class="level-item has-text-centered">
                     <div>
                         <p class="heading">UCO Balance</p>
-                        <p class="title"><%= @uco_balance %> UCO
+                        <p class="title"><%= to_float(@uco_balance) %> UCO
                         <%= if @uco_balance > 0 do %>
-                            (<%= format_usd_amount(@uco_balance, @uco_price[:usd]) %>)
+                          <%= format_usd_amount(@uco_balance, @uco_price[:usd]) %>)
                         <% end %>
-                        </p>
-
                     </div>
-                </div>
+              </div>
             </nav>
         </div>
     </div>

--- a/lib/archethic_web/templates/explorer/chain.html.eex
+++ b/lib/archethic_web/templates/explorer/chain.html.eex
@@ -83,7 +83,7 @@
                         <p class="heading">UCO Balance</p>
                         <p class="title"><%= to_float(@uco_balance) %> UCO
                         <%= if @uco_balance > 0 do %>
-                          <%= format_usd_amount(@uco_balance, @uco_price[:usd]) %>)
+                          (<%= format_usd_amount(@uco_balance, @uco_price[:usd]) %>)
                         <% end %>
                     </div>
               </div>


### PR DESCRIPTION
# Description

Fix the formatting of the UCO in the explorer, specifically in the chain UI .

Fixes #295 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Go the faucet at: http://localhost:4000/faucet and send funds to an address
- Go the chain explorer: http://localhost:4000/explorer/chain?address={youraddress}
- You should see 100.0 UC0 instead of 10000000000

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
