### PR TITLE
Correct playbook origin key error

### DIFF
--- a/lib/archethic/utils/regression/playbook.ex
+++ b/lib/archethic/utils/regression/playbook.ex
@@ -175,6 +175,8 @@ defmodule ArchEthic.Utils.Regression.Playbook do
 
     {next_public_key, _} = Crypto.derive_keypair(transaction_seed, chain_length + 1, curve)
 
+    genesis_origin_private_key = get_origin_private_key(host, port)
+
     tx =
       %Transaction{
         address: Crypto.derive_address(next_public_key),
@@ -183,7 +185,7 @@ defmodule ArchEthic.Utils.Regression.Playbook do
         previous_public_key: previous_public_key
       }
       |> Transaction.previous_sign_transaction(previous_private_key)
-      |> Transaction.origin_sign_transaction(@genesis_origin_private_key)
+      |> Transaction.origin_sign_transaction(genesis_origin_private_key)
 
     true =
       Crypto.verify?(


### PR DESCRIPTION
# Description

Correction of a bug in benchmark where the origin private key was still hardcoded and not asked threw the API

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Runned benchmark without error

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
