### PR TITLE
Correct CrossValidate message error

### DIFF
--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -256,11 +256,12 @@ defmodule Archethic.P2P.Message do
       }) do
     nb_validation_nodes = length(chain_replication_tree)
     tree_size = chain_replication_tree |> List.first() |> bit_size()
+    io_tree_size = io_replication_tree |> List.first() |> bit_size()
 
     <<9::8, address::binary, ValidationStamp.serialize(stamp)::bitstring, nb_validation_nodes::8,
       tree_size::8, :erlang.list_to_bitstring(chain_replication_tree)::bitstring,
-      :erlang.list_to_bitstring(beacon_replication_tree)::bitstring,
-      length(io_replication_tree)::8, :erlang.list_to_bitstring(io_replication_tree)::bitstring,
+      :erlang.list_to_bitstring(beacon_replication_tree)::bitstring, io_tree_size::8,
+      :erlang.list_to_bitstring(io_replication_tree)::bitstring,
       bit_size(confirmed_validation_nodes)::8, confirmed_validation_nodes::bitstring>>
   end
 
@@ -625,7 +626,7 @@ defmodule Archethic.P2P.Message do
 
     {io_tree, rest} =
       if io_tree_size > 0 do
-        deserialize_bit_sequences(rest, nb_validations, tree_size, [])
+        deserialize_bit_sequences(rest, nb_validations, io_tree_size, [])
       else
         {[], rest}
       end


### PR DESCRIPTION
# Description

Correction of a bug occuring in CrossValidate message :
`MatchError) no match of right hand side value: <<192, 6::size(4)>>
    (archethic 0.14.0) lib/archethic/p2p/message.ex:653: Archethic.P2P.Message.decode/1`

Error is reproductible by this way : 
Start node1 and node2 -> everything is going well
Start node3 -> node3 goes in pending
When node3 goes in pending, node1 send a CrossValidate message to node2 and then here is the error on node2 side

Do not have Github issue for this error

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run 3 nodes as described before, and there is no more error

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
