### PR TITLE
297 Pagination based on paging_state as last page last transaction address GraphQl API

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -240,11 +240,34 @@ defmodule Archethic do
   """
   @spec get_transaction_chain(binary()) :: {:ok, list(Transaction.t())} | {:error, :network_issue}
   def get_transaction_chain(address) when is_binary(address) do
+    local_available_nodes = locally_available_nodes(address)
+    get_transaction_chain(local_available_nodes, address)
+  end
+
+  def get_transaction_chain_by_paging_address(address, paging_address) when is_binary(address) do
+    options = [paging_state: paging_address]
+    local_available_nodes = locally_available_nodes(address)
+    transaction_chain_by_paging_address(local_available_nodes, address, options)
+  end
+
+  defp transaction_chain_by_paging_address([node | rest], address, options) do
+    case P2P.send_message(node, %GetTransactionChain{
+           address: address,
+           paging_state: Keyword.get(options, :paging_state)
+         }) do
+      {:ok, %TransactionList{transactions: transactions}} ->
+        {:ok, transactions}
+
+      {:error, _} ->
+        transaction_chain_by_paging_address(rest, address, options)
+    end
+  end
+
+  defp locally_available_nodes(address) do
     address
     |> Election.chain_storage_nodes(P2P.available_nodes())
     |> P2P.nearest_nodes()
     |> Enum.filter(&Node.locally_available?/1)
-    |> get_transaction_chain(address)
   end
 
   defp get_transaction_chain(nodes, address, opts \\ [], acc \\ [])

--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -244,32 +244,6 @@ defmodule Archethic do
     get_transaction_chain(local_available_nodes, address)
   end
 
-  def get_transaction_chain_by_paging_address(address, paging_address) when is_binary(address) do
-    options = [paging_state: paging_address]
-    local_available_nodes = locally_available_nodes(address)
-    transaction_chain_by_paging_address(local_available_nodes, address, options)
-  end
-
-  defp transaction_chain_by_paging_address([node | rest], address, options) do
-    case P2P.send_message(node, %GetTransactionChain{
-           address: address,
-           paging_state: Keyword.get(options, :paging_state)
-         }) do
-      {:ok, %TransactionList{transactions: transactions}} ->
-        {:ok, transactions}
-
-      {:error, _} ->
-        transaction_chain_by_paging_address(rest, address, options)
-    end
-  end
-
-  defp locally_available_nodes(address) do
-    address
-    |> Election.chain_storage_nodes(P2P.available_nodes())
-    |> P2P.nearest_nodes()
-    |> Enum.filter(&Node.locally_available?/1)
-  end
-
   defp get_transaction_chain(nodes, address, opts \\ [], acc \\ [])
 
   defp get_transaction_chain([node | rest], address, opts, acc) do
@@ -294,6 +268,38 @@ defmodule Archethic do
   end
 
   defp get_transaction_chain([], _, _, _), do: {:error, :network_issue}
+
+  defp locally_available_nodes(address) do
+    address
+    |> Election.chain_storage_nodes(P2P.available_nodes())
+    |> P2P.nearest_nodes()
+    |> Enum.filter(&Node.locally_available?/1)
+  end
+
+  @doc """
+  Retrieve a transaction chain based on an address from the closest nodes
+  by setting `paging_address as an offset address.
+  """
+  @spec get_transaction_chain_by_paging_address(binary(), binary()) ::
+          {:ok, list(Transaction.t())} | {:error, :network_issue}
+  def get_transaction_chain_by_paging_address(address, paging_address) when is_binary(address) do
+    options = [paging_state: paging_address]
+    local_available_nodes = locally_available_nodes(address)
+    transaction_chain_by_paging_address(local_available_nodes, address, options)
+  end
+
+  defp transaction_chain_by_paging_address([node | rest], address, options) do
+    case P2P.send_message(node, %GetTransactionChain{
+           address: address,
+           paging_state: Keyword.get(options, :paging_state)
+         }) do
+      {:ok, %TransactionList{transactions: transactions}} ->
+        {:ok, transactions}
+
+      {:error, _} ->
+        transaction_chain_by_paging_address(rest, address, options)
+    end
+  end
 
   @doc """
   Retrieve the number of transaction in a transaction chain from the closest nodes

--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -301,6 +301,10 @@ defmodule Archethic do
     end
   end
 
+  defp transaction_chain_by_paging_address([], _address, _options) do
+    {:error, :network_issue}
+  end
+
   @doc """
   Retrieve the number of transaction in a transaction chain from the closest nodes
   """

--- a/lib/archethic_web/graphql_schema.ex
+++ b/lib/archethic_web/graphql_schema.ex
@@ -106,7 +106,7 @@ defmodule ArchethicWeb.GraphQLSchema do
     Query the network to list the transaction on the type
     """
     field :network_transactions, list_of(:transaction) do
-      arg(:type, :transaction_type)
+      arg(:type, non_null(:transaction_type))
       arg(:page, :page)
 
       resolve(fn args, _ ->

--- a/lib/archethic_web/graphql_schema.ex
+++ b/lib/archethic_web/graphql_schema.ex
@@ -58,18 +58,10 @@ defmodule ArchethicWeb.GraphQLSchema do
     """
     field :transaction_chain, list_of(:transaction) do
       arg(:address, non_null(:address))
-      arg(:paging_address, :string)
+      arg(:paging_address, :address)
 
       resolve(fn args = %{address: address}, _ ->
         paging_address = Map.get(args, :paging_address)
-
-        paging_address =
-          if paging_address do
-            Base.decode16!(paging_address)
-          else
-            paging_address
-          end
-
         Resolver.transaction_chain_by_paging_address(address, paging_address)
       end)
     end

--- a/lib/archethic_web/graphql_schema.ex
+++ b/lib/archethic_web/graphql_schema.ex
@@ -58,11 +58,19 @@ defmodule ArchethicWeb.GraphQLSchema do
     """
     field :transaction_chain, list_of(:transaction) do
       arg(:address, non_null(:address))
-      arg(:page, :integer)
+      arg(:paging_address, :string)
 
       resolve(fn args = %{address: address}, _ ->
-        page = Map.get(args, :page, 1)
-        Resolver.paginate_chain(address, page)
+        paging_address = Map.get(args, :paging_address)
+
+        paging_address =
+          if paging_address do
+            Base.decode16!(paging_address)
+          else
+            paging_address
+          end
+
+        Resolver.transaction_chain_by_paging_address(address, paging_address)
       end)
     end
 

--- a/lib/archethic_web/graphql_schema.ex
+++ b/lib/archethic_web/graphql_schema.ex
@@ -9,6 +9,7 @@ defmodule ArchethicWeb.GraphQLSchema do
   alias __MODULE__.Resolver
   alias __MODULE__.SharedSecretsType
   alias __MODULE__.TransactionType
+  alias __MODULE__.PageType
   alias __MODULE__.TransactionAttestation
 
   import_types(HexType)
@@ -17,6 +18,7 @@ defmodule ArchethicWeb.GraphQLSchema do
   import_types(SharedSecretsType)
   import_types(P2PType)
   import_types(TransactionAttestation)
+  import_types(PageType)
 
   query do
     @desc """
@@ -105,7 +107,7 @@ defmodule ArchethicWeb.GraphQLSchema do
     """
     field :network_transactions, list_of(:transaction) do
       arg(:type, :transaction_type)
-      arg(:page, :integer)
+      arg(:page, :page)
 
       resolve(fn args, _ ->
         type = Map.get(args, :type)

--- a/lib/archethic_web/graphql_schema/page_type.ex
+++ b/lib/archethic_web/graphql_schema/page_type.ex
@@ -1,0 +1,22 @@
+defmodule ArchethicWeb.GraphQLSchema.PageType do
+  @moduledoc false
+
+  use Absinthe.Schema.Notation
+
+  @desc """
+  The [Page] scalar type represents the page number
+  """
+  scalar :page do
+    parse(&do_parse/1)
+  end
+
+  @spec do_parse(Absinthe.Blueprint.Input.Integer.t()) ::
+          {:ok, integer()} | :error
+  defp do_parse(%Absinthe.Blueprint.Input.Integer{value: page_value}) when page_value >= 1 do
+    {:ok, page_value}
+  end
+
+  defp do_parse(_page) do
+    :error
+  end
+end

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -116,4 +116,8 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
     TransactionChain.list_transactions_by_type(type, [])
     |> paginate_transactions(page)
   end
+
+  def network_transactions(_type, page) do
+    %{message: "page value must be >= 1 but give #{page}"}
+  end
 end

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -47,10 +47,10 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
     }
   end
 
-  def paginate_chain(address, page) do
-    case Archethic.get_transaction_chain(address) do
+  def transaction_chain_by_paging_address(address, paging_address) do
+    case Archethic.get_transaction_chain_by_paging_address(address, paging_address) do
       {:ok, chain} ->
-        {:ok, paginate_transactions(chain, page)}
+        {:ok, chain}
 
       {:error, _} = e ->
         e

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -112,12 +112,8 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
     )
   end
 
-  def network_transactions(type, page) when page >= 1 do
+  def network_transactions(type, page) do
     TransactionChain.list_transactions_by_type(type, [])
     |> paginate_transactions(page)
-  end
-
-  def network_transactions(_type, page) do
-    %{message: "page value must be >= 1 but give #{page}"}
   end
 end

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -112,7 +112,7 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
     )
   end
 
-  def network_transactions(type, page) do
+  def network_transactions(type, page) when page >= 1 do
     TransactionChain.list_transactions_by_type(type, [])
     |> paginate_transactions(page)
   end

--- a/test/archethic_web/controllers/api/transaction_controller_test.exs
+++ b/test/archethic_web/controllers/api/transaction_controller_test.exs
@@ -7,8 +7,6 @@ defmodule ArchethicWeb.API.TransactionControllerTest do
   alias Archethic.P2P.Node
   alias Archethic.Crypto
 
-  import Mox
-
   setup do
     P2P.add_and_connect_node(%Node{
       ip: {127, 0, 0, 1},

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -209,7 +209,7 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
 
         {:ok,
          %TransactionList{
-           transactions: Enum.slice(transactions, 1..@transaction_chain_page_size)
+           transactions: Enum.slice(transactions, slice_range)
          }}
       end)
 


### PR DESCRIPTION
# Description

Before this change, to get the specific page level transaction_chain, we are loading whole transactions and slicing them by the page size and retrieving the relevant page transactions. 

In this change, the `page` attribute which was `number` now converted to `pagingAddress` of type `string` is now the address of the last transaction in the page which act as a `paginate_state` for next page.

Here, we are loading specific `paging_state` based page size transactions only. 

Fixes #297 #296 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?
## Steps
1. Select the address whose chain length is greater 10 for an example consider chain_length of 15
2. Now run query `transactionChain(address: "address_selected"){address}`, which gives 10 transactions
3. Make sure it is listed only 10 transactions
4. Pick the last transaction address from above 10 transactions
5. Run the query `transactionChain(address: "address_selected", pagingAddress: "last_transaction_address"){address}`
6. Now above query should give only 5 transactions
7. Now take out the last transaction address from above 5 transactions and repeat the step 5
8. It should give empty list of transactions.

- Test with out paging state based transactions
- Test paging_state based transactions

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
