### PR TITLE
Correct self repair utxo error

### DIFF
--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -280,7 +280,7 @@ defmodule Archethic.Replication do
 
   defp fetch_inputs_unspent_outputs(
          tx = %Transaction{validation_stamp: %ValidationStamp{timestamp: tx_time}},
-         _self_repair = true
+         _self_repair? = true
        ) do
     previous_address = Transaction.previous_address(tx)
 
@@ -300,7 +300,7 @@ defmodule Archethic.Replication do
     end)
   end
 
-  defp fetch_inputs_unspent_outputs(tx = %Transaction{}, _self_repair = false) do
+  defp fetch_inputs_unspent_outputs(tx = %Transaction{}, _self_repair? = false) do
     previous_address = Transaction.previous_address(tx)
 
     Logger.debug(

--- a/lib/archethic/self_repair/sync/beacon_summary_handler/transaction_handler.ex
+++ b/lib/archethic/self_repair/sync/beacon_summary_handler/transaction_handler.ex
@@ -106,7 +106,7 @@ defmodule Archethic.SelfRepair.Sync.BeaconSummaryHandler.TransactionHandler do
 
     cond do
       Election.chain_storage_node?(address, type, Crypto.first_node_public_key(), node_list) ->
-        Replication.validate_and_store_transaction_chain(tx, self_repair: true)
+        Replication.validate_and_store_transaction_chain(tx, self_repair?: true)
 
       Election.io_storage_node?(tx, Crypto.first_node_public_key(), node_list) ->
         Replication.validate_and_store_transaction(tx)


### PR DESCRIPTION
# Description

An UTXO error was provided during self repair when encounter a transfer transaction which was the first transaction of the chain.
Reproduce it : 
- Launch a node and make a transaction from faucet
- Launch a second node, and `[error] Invalid unspent outputs` will raise during self repair

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run both nodes without error

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
