### PR TITLE
Fix renaming of ArchEthic to Archethic

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,15 +1,15 @@
 IEx.configure(inspect: [limit: :infinity])
 
-alias ArchEthic.Crypto
-alias ArchEthic.DB
-alias ArchEthic.P2P
-alias ArchEthic.P2P.Node
-alias ArchEthic.SharedSecrets
-alias ArchEthic.Account
-alias ArchEthic.Election
-alias ArchEthic.Governance
-alias ArchEthic.Contracts
-alias ArchEthic.TransactionChain
-alias ArchEthic.TransactionChain.Transaction
-alias ArchEthic.TransactionChain.TransactionData
-alias ArchEthic.BeaconChain
+alias Archethic.Crypto
+alias Archethic.DB
+alias Archethic.P2P
+alias Archethic.P2P.Node
+alias Archethic.SharedSecrets
+alias Archethic.Account
+alias Archethic.Election
+alias Archethic.Governance
+alias Archethic.Contracts
+alias Archethic.TransactionChain
+alias Archethic.TransactionChain.Transaction
+alias Archethic.TransactionChain.TransactionData
+alias Archethic.BeaconChain

--- a/rel/commands/regression_test
+++ b/rel/commands/regression_test
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-release_ctl eval --mfa "Mix.Tasks.ArchEthic.Regression.run/1" --argv -- "$@"
+release_ctl eval --mfa "Mix.Tasks.Archethic.Regression.run/1" --argv -- "$@"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,7 +11,7 @@ SERVICE_CREATION=0
 usage() {
   echo "Usage:"
   echo ""
-  echo " Release ArchEthic node binary"
+  echo " Release Archethic node binary"
   echo ""
   echo "  " release.sh [-d  dir] " Specify the installation dir"
   echo "  " release.sh -u "       Upgrade the release"

--- a/test/archethic/governance/0001-CI-Pass.patch
+++ b/test/archethic/governance/0001-CI-Pass.patch
@@ -23,7 +23,7 @@ diff --git a/mix.exs b/mix.exs
 index 5fea88d..ddce700 100644
 --- a/mix.exs
 +++ b/mix.exs
-@@ -4,7 +4,7 @@ defmodule ArchEthic.MixProject do
+@@ -4,7 +4,7 @@ defmodule Archethic.MixProject do
    def project do
      [
        app: :archethic,


### PR DESCRIPTION
# Description

Fix a bug of module name from ArchEthic to Archethic.
While using `mix dev.bench` to run benchmark with docker, it calls module ArchEthic... which do not exists

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Launch command `mix dev.bench` and docker container run bench without error

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
