### PR TITLE
Trigger webhook to publish snap in mainnet track

### DIFF
--- a/.github/workflows/trigger-mainnet-publish.yml
+++ b/.github/workflows/trigger-mainnet-publish.yml
@@ -1,0 +1,16 @@
+name: trigger-mainnet-publish
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/archethic-foundation/archethic-snap/actions/workflows/publish-mainnet-track.yml/dispatches \
+          -d '{"ref": "master"}'


### PR DESCRIPTION
# Description

Automatically trigger archethic-snap workflow webhook to build and publish snap to mainnet/edge on master branch push

Related to https://github.com/archethic-foundation/archethic-snap/issues/20

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This can only be tested and merged once `mainnet` track is added.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
