### PR TITLE
Set last transaction address from the genesis in DB

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_index.ex
+++ b/lib/archethic/db/embedded_impl/chain_index.ex
@@ -309,14 +309,11 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
   end
 
   @doc """
-  Reference a new transaction address for the previous address at the transaction time
-
-  This will perform a lookup to find out the genesis address from the previous address
-  and set the new address as reference
+  Reference a new transaction address for the genesis address at the transaction time
   """
   @spec set_last_chain_address(binary(), binary(), DateTime.t(), String.t()) :: :ok
   def set_last_chain_address(
-        previous_address,
+        genesis_address,
         new_address,
         datetime = %DateTime{},
         db_path
@@ -325,16 +322,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
 
     encoded_data = <<unix_time::64, new_address::binary>>
 
-    {filename, genesis_address} =
-      case get_tx_entry(previous_address, db_path) do
-        {:ok, %{genesis_address: genesis_address}} ->
-          filename = chain_addresses_path(db_path, genesis_address)
-          {filename, genesis_address}
-
-        {:error, :not_exists} ->
-          filename = chain_addresses_path(db_path, previous_address)
-          {filename, previous_address}
-      end
+    filename = chain_addresses_path(db_path, genesis_address)
 
     :ok = File.write!(filename, encoded_data, [:binary, :append])
     true = :ets.insert(:archethic_db_last_index, {genesis_address, new_address})

--- a/lib/archethic/db/embedded_impl/chain_writer.ex
+++ b/lib/archethic/db/embedded_impl/chain_writer.ex
@@ -70,7 +70,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
   end
 
   defp index_transaction(
-         tx = %Transaction{
+         %Transaction{
            address: tx_address,
            type: tx_type,
            previous_public_key: previous_public_key,
@@ -81,11 +81,10 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
          db_path
        ) do
     start = System.monotonic_time()
-    previous_address = Transaction.previous_address(tx)
 
     ChainIndex.add_tx(tx_address, genesis_address, encoded_size, db_path)
     ChainIndex.add_tx_type(tx_type, tx_address, db_path)
-    ChainIndex.set_last_chain_address(previous_address, tx_address, timestamp, db_path)
+    ChainIndex.set_last_chain_address(genesis_address, tx_address, timestamp, db_path)
     ChainIndex.set_public_key(genesis_address, previous_public_key, timestamp, db_path)
 
     :telemetry.execute([:archethic, :db], %{duration: System.monotonic_time() - start}, %{

--- a/test/archethic/db/embedded_impl_test.exs
+++ b/test/archethic/db/embedded_impl_test.exs
@@ -631,8 +631,10 @@ defmodule Archethic.DB.EmbeddedTest do
           index: 1
         )
 
+      genesis_address = Transaction.previous_address(tx1)
+
       EmbeddedImpl.write_transaction(tx1)
-      EmbeddedImpl.add_last_transaction_address(tx1.address, tx2.address, DateTime.utc_now())
+      EmbeddedImpl.add_last_transaction_address(genesis_address, tx2.address, DateTime.utc_now())
 
       assert tx2.address == EmbeddedImpl.get_last_chain_address(tx1.address)
     end


### PR DESCRIPTION
# Description

Fix the set last transaction address to target the genesis right away.
Instead to perform another lookup from the previous address, use directly the genesis address from the write transaction command to specify the genesis address from this new transaction address

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
