### PR TITLE
Fix previous_summary from summary timer

### DIFF
--- a/lib/archethic/beacon_chain/summary_timer.ex
+++ b/lib/archethic/beacon_chain/summary_timer.ex
@@ -42,19 +42,20 @@ defmodule Archethic.BeaconChain.SummaryTimer do
   Returns the list of previous summaries times from the given date
   """
   @spec previous_summary(DateTime.t()) :: DateTime.t()
-  def previous_summary(date_from = %DateTime{microsecond: {0, 0}}) do
-    get_interval()
-    |> CronParser.parse!(true)
-    |> CronScheduler.get_previous_run_dates(DateTime.to_naive(date_from))
-    |> Enum.at(1)
-    |> DateTime.from_naive!("Etc/UTC")
-  end
-
   def previous_summary(date_from = %DateTime{}) do
-    get_interval()
-    |> CronParser.parse!(true)
-    |> CronScheduler.get_previous_run_date!(DateTime.to_naive(date_from))
-    |> DateTime.from_naive!("Etc/UTC")
+    cron_expression = CronParser.parse!(get_interval(), true)
+    naive_date_from = DateTime.to_naive(date_from)
+
+    if Crontab.DateChecker.matches_date?(cron_expression, naive_date_from) do
+      cron_expression
+      |> CronScheduler.get_previous_run_dates(naive_date_from)
+      |> Enum.at(1)
+      |> DateTime.from_naive!("Etc/UTC")
+    else
+      cron_expression
+      |> CronScheduler.get_previous_run_date!(naive_date_from)
+      |> DateTime.from_naive!("Etc/UTC")
+    end
   end
 
   @doc """


### PR DESCRIPTION
# Description

Retrieval of the previous summary date from another date didn't work as expected.
This PR fixes this.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
