### PR TITLE
Make summary transaction address more consistent

### DIFF
--- a/lib/archethic/beacon_chain.ex
+++ b/lib/archethic/beacon_chain.ex
@@ -91,13 +91,7 @@ defmodule Archethic.BeaconChain do
   """
   @spec summary_transaction_address(binary(), DateTime.t()) :: binary()
   def summary_transaction_address(subset, date = %DateTime{}) when is_binary(subset) do
-    {pub, _} =
-      Crypto.derive_keypair(
-        Crypto.storage_nonce(),
-        Crypto.hash([subset, <<DateTime.to_unix(date)::32>>])
-      )
-
-    Crypto.derive_address(pub)
+    Crypto.derive_beacon_chain_address(subset, date, true)
   end
 
   @doc """

--- a/lib/archethic/election.ex
+++ b/lib/archethic/election.ex
@@ -4,8 +4,6 @@ defmodule Archethic.Election do
   and constraints to ensure a fair distributed processing and data storage among its network.
   """
 
-  alias Archethic.BeaconChain
-
   alias Archethic.Crypto
 
   alias __MODULE__.Constraints
@@ -620,7 +618,7 @@ defmodule Archethic.Election do
       )
       when is_binary(subset) and is_list(nodes) do
     subset
-    |> BeaconChain.summary_transaction_address(date)
+    |> Crypto.derive_beacon_chain_address(date, true)
     |> storage_nodes(nodes, storage_constraints)
   end
 


### PR DESCRIPTION
Beacon summary address were generated no in the same way in the codebase
So now it's more unified and would prevent bug for that matter.

