### PR TITLE
Remove TopTransactionLive as unused for now

### DIFF
--- a/lib/archethic_web/templates/explorer/index.html.leex
+++ b/lib/archethic_web/templates/explorer/index.html.leex
@@ -47,22 +47,6 @@
                        </div>
                       </div>
                 </div>
-<!--
-                <div class="columns">
-                  <div class="column is-half-desktop">
-                    <div class="card">
-                      <div class="card-header">
-                        <p class="card-header-title">Latest transactions</p>
-                      </div>
-                      <div class="card-content">
-                        <div class="content">
-                          <%= live_render(@socket, ArchethicWeb.TopTransactionLive, id: "top_transactions") %>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  </div>
-                -->
               </div>
             </div>
           </h2>


### PR DESCRIPTION
Remove TopTransactionLive component in the HTML as not used for now and causing some issues sometimes.
So it's just a cleanup
