### PR TITLE
Write beacon slot to summary chain

### DIFF
--- a/lib/archethic/beacon_chain.ex
+++ b/lib/archethic/beacon_chain.ex
@@ -116,8 +116,11 @@ defmodule Archethic.BeaconChain do
           data: %TransactionData{content: content}
         }
       ) do
-    with {%Slot{subset: subset} = slot, _} <- Slot.deserialize(content),
-         :ok <- validate_slot(tx, slot) do
+    with {%Slot{subset: subset, slot_time: slot_time} = slot, _} <- Slot.deserialize(content),
+         :ok <- validate_slot(tx, slot),
+         genesis_address <-
+           Crypto.derive_beacon_chain_address(subset, previous_summary_time(slot_time)),
+         :ok <- TransactionChain.write_transaction_at(tx, genesis_address) do
       Logger.debug("New beacon transaction loaded - #{inspect(slot)}",
         beacon_subset: Base.encode16(subset)
       )


### PR DESCRIPTION
# Description

Add the transaction slot to the summary chain by giving the genesis address (from the previous summary date) to append the transaction to.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
