### PR TITLE
Postponed beacon chain replication attestations when conflicts on slot/tx's time

### DIFF
--- a/lib/archethic/beacon_chain/slot.ex
+++ b/lib/archethic/beacon_chain/slot.ex
@@ -436,9 +436,7 @@ defmodule Archethic.BeaconChain.Slot do
         # P2P view network stats (1st node)
         10,
         # P2P view network stats (2nd node)
-        0,
-        # Size involved nodes bitstring
-        4
+        0
         >>
   """
   @spec serialize(t()) :: bitstring()
@@ -489,7 +487,7 @@ defmodule Archethic.BeaconChain.Slot do
       ...>  119, 6, 8, 48, 201, 244, 138, 99, 52, 22, 1, 97, 123, 140, 195,
       ...>  0, 1, 0, 0, 38, 105, 235, 147, 234, 114, 41, 1, 152, 148, 120, 31, 200, 255, 174, 190, 91,
       ...>  100, 169, 225, 113, 249, 125, 21, 168, 14, 196, 222, 140, 87, 143, 241, 94, 244, 190, 185,
-      ...>  0, 2, 1::1, 0::1, 10>>
+      ...>  0, 2, 1::1, 0::1, 10, 0>>
       ...> |> Slot.deserialize()
       {
         %Slot{

--- a/lib/archethic/beacon_chain/summary_timer.ex
+++ b/lib/archethic/beacon_chain/summary_timer.ex
@@ -22,6 +22,7 @@ defmodule Archethic.BeaconChain.SummaryTimer do
   @doc """
   Give the next beacon chain slot using the `SummaryTimer` interval
   """
+  @spec next_summary(DateTime.t()) :: DateTime.t()
   def next_summary(date_from = %DateTime{}) do
     cron_expression = CronParser.parse!(get_interval(), true)
     naive_date_from = DateTime.to_naive(date_from)

--- a/test/archethic/beacon_chain/summary_timer_test.exs
+++ b/test/archethic/beacon_chain/summary_timer_test.exs
@@ -35,9 +35,6 @@ defmodule Archethic.BeaconChain.SummaryTimerTest do
     {:ok, _pid} = SummaryTimer.start_link([interval: "* * * * * * *"], [])
 
     assert ~U[2020-09-10 12:30:29Z] = SummaryTimer.previous_summary(~U[2020-09-10 12:30:30Z])
-
-    assert ~U[2021-02-03 13:07:37Z] =
-             SummaryTimer.previous_summary(~U[2021-02-03 13:07:37.761481Z])
   end
 
   test "match_interval? check if a date match the summary timer interval" do

--- a/test/archethic/beacon_chain_test.exs
+++ b/test/archethic/beacon_chain_test.exs
@@ -23,6 +23,8 @@ defmodule Archethic.BeaconChainTest do
 
   doctest Archethic.BeaconChain
 
+  import Mox
+
   setup do
     start_supervised!({SlotTimer, interval: "0 0 * * * *"})
     Enum.map(BeaconChain.list_subsets(), &start_supervised({Subset, subset: &1}, id: &1))
@@ -35,13 +37,13 @@ defmodule Archethic.BeaconChainTest do
   end
 
   test "summary_transaction_address/2 should return a address using the storage nonce a subset and a date" do
-    assert <<0, 0, 126, 16, 248, 223, 156, 176, 229, 102, 1, 100, 203, 172, 176, 243, 188, 41, 20,
-             170, 58, 159, 173, 181, 185, 11, 231, 174, 223, 115, 196, 88, 243,
-             197>> = BeaconChain.summary_transaction_address(<<1>>, ~U[2021-01-13 00:00:00Z])
+    assert <<0, 0, 248, 132, 24, 218, 125, 28, 234, 1, 67, 220, 132, 122, 57, 168, 19, 36, 154,
+             81, 148, 222, 244, 124, 19, 175, 134, 199, 110, 21, 100, 49, 181,
+             210>> = BeaconChain.summary_transaction_address(<<1>>, ~U[2021-01-13 00:00:00Z])
 
-    assert <<0, 0, 68, 143, 226, 144, 77, 189, 180, 194, 80, 63, 131, 127, 130, 140, 137, 97, 76,
-             39, 74, 19, 34, 182, 174, 179, 89, 117, 149, 203, 58, 89, 67,
-             68>> = BeaconChain.summary_transaction_address(<<1>>, ~U[2021-01-14 00:00:00Z])
+    assert <<0, 0, 15, 150, 229, 125, 70, 53, 7, 122, 235, 195, 14, 164, 62, 53, 217, 55, 181, 13,
+             112, 203, 123, 18, 150, 174, 104, 244, 199, 231, 184, 228, 118,
+             40>> = BeaconChain.summary_transaction_address(<<1>>, ~U[2021-01-14 00:00:00Z])
   end
 
   test "add_end_of_node_sync/2 should register a end of synchronization inside a subset" do
@@ -72,6 +74,11 @@ defmodule Archethic.BeaconChainTest do
         authorized?: true,
         authorization_date: DateTime.utc_now() |> DateTime.add(-10)
       })
+
+      MockDB
+      |> expect(:write_transaction_at, fn _, _ ->
+        :ok
+      end)
 
       tx = %Transaction{
         address: Crypto.derive_beacon_chain_address(<<0>>, DateTime.utc_now()),


### PR DESCRIPTION
# Description

Ensure a transaction notification will be handled by the right slot at the right time

If the transaction timestamp conflicts with the slot time, then we can postpone the transaction with for the next slot

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
