### PR TITLE
Fix beacon live transaction chain loading

### DIFF
--- a/lib/archethic/crypto.ex
+++ b/lib/archethic/crypto.ex
@@ -906,9 +906,9 @@ defmodule Archethic.Crypto do
   defp do_hash(data, :blake2b), do: :crypto.hash(:blake2b, data)
 
   @doc """
-  Generate an address as per ARCHEthic specification
+  Generate an address as per Archethic specification
 
-  The fist-byte representing the curve type second-byte representing hash algorithm used and rest is the hash of publicKey as per ARCHEthic specifications .
+  The fist-byte representing the curve type second-byte representing hash algorithm used and rest is the hash of publicKey as per Archethic specifications .
 
   ## Examples
 

--- a/lib/archethic_web/templates/explorer/beacon_chain_index.html.leex
+++ b/lib/archethic_web/templates/explorer/beacon_chain_index.html.leex
@@ -3,7 +3,7 @@
    <h1 class="subtitle is-size-4 heading has-text-white">Beacon chain</h2>
   </div>
   <div class="message-body">
-    Beacon Chains are the entire summary of all the transactions based on time slots of the <strong>ARCHEThic</strong> P2P network.
+    Beacon Chains are the entire summary of all the transactions based on time slots of the <strong>Archethic</strong> P2P network.
     Since no node has the physical ability to know the status of each transaction in an unlimited network, Beacon Chains are a specific set of transaction chains responsible for the global synchronization of the network. </a>   </div>
 </article>
 <p class="heading is-size-7 has-text-white">Last Changes From <span><%= format_date(@update_time) %></span></p>


### PR DESCRIPTION
# Description

Fix the transaction loading issue in the beacon chain from the first page.

It targets the transaction chain of the current day to retrieve the beacon slots transaction and aggregate them.

Related to #291 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

When a transaction is submitted and stored on the beacon chain, when the next slot is sealed and send through a transaction, when you are refreshing the first page, you should be able to see the transaction and the previous ones.


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
