### PR TITLE
Handle end of sync to make node available

### DIFF
--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -96,6 +96,18 @@ defmodule Archethic.P2P do
     as: :set_node_unavailable
 
   @doc """
+  Add a node first public key to the list of nodes globally synced.
+  """
+  @spec set_node_globally_synced(first_public_key :: Crypto.key()) :: :ok
+  defdelegate set_node_globally_synced(first_public_key), to: MemTable, as: :set_node_synced
+
+  @doc """
+  Add a node first public key to the list of nodes globally synced.
+  """
+  @spec set_node_globally_unsynced(first_public_key :: Crypto.key()) :: :ok
+  defdelegate set_node_globally_unsynced(first_public_key), to: MemTable, as: :set_node_unsynced
+
+  @doc """
   Set the node's average availability
   """
   @spec set_node_average_availability(first_public_key :: Crypto.key(), float()) :: :ok
@@ -132,7 +144,7 @@ defmodule Archethic.P2P do
   end
 
   @doc """
-  List all the authorized nodes 
+  List all the authorized nodes
   """
   @spec authorized_nodes() :: list(Node.t())
   def authorized_nodes do

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -99,13 +99,21 @@ defmodule Archethic.P2P do
   Add a node first public key to the list of nodes globally synced.
   """
   @spec set_node_globally_synced(first_public_key :: Crypto.key()) :: :ok
-  defdelegate set_node_globally_synced(first_public_key), to: MemTable, as: :set_node_synced
+  def set_node_globally_synced(first_public_key) do
+    get_node_info!(first_public_key)
+    |> Node.synced()
+    |> MemTable.add_node()
+  end
 
   @doc """
-  Add a node first public key to the list of nodes globally synced.
+  Add a node first public key to the list of nodes globally unsynced.
   """
   @spec set_node_globally_unsynced(first_public_key :: Crypto.key()) :: :ok
-  defdelegate set_node_globally_unsynced(first_public_key), to: MemTable, as: :set_node_unsynced
+  def set_node_globally_unsynced(first_public_key) do
+    get_node_info!(first_public_key)
+    |> Node.unsynced()
+    |> MemTable.add_node()
+  end
 
   @doc """
   Set the node's average availability

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -568,7 +568,7 @@ defmodule Archethic.P2P.Message do
       Utils.deserialize_public_key(rest)
 
     {validation_node_public_keys, rest} =
-      deserialize_public_key_list(rest, nb_validation_nodes, [])
+      Utils.deserialize_public_key_list(rest, nb_validation_nodes, [])
 
     {%StartMining{
        transaction: tx,
@@ -584,7 +584,7 @@ defmodule Archethic.P2P.Message do
       Utils.deserialize_public_key(rest)
 
     {previous_storage_nodes_keys, rest} =
-      deserialize_public_key_list(rest, nb_previous_storage_nodes, [])
+      Utils.deserialize_public_key_list(rest, nb_previous_storage_nodes, [])
 
     <<
       chain_storage_nodes_view_size::8,
@@ -707,7 +707,7 @@ defmodule Archethic.P2P.Message do
   end
 
   def decode(<<19::8, nb_node_public_keys::16, rest::bitstring>>) do
-    {public_keys, rest} = deserialize_public_key_list(rest, nb_node_public_keys, [])
+    {public_keys, rest} = Utils.deserialize_public_key_list(rest, nb_node_public_keys, [])
     {%GetP2PView{node_public_keys: public_keys}, rest}
   end
 
@@ -956,17 +956,6 @@ defmodule Archethic.P2P.Message do
   defp deserialize_tx_list(rest, nb_transactions, acc) do
     {tx, rest} = Transaction.deserialize(rest)
     deserialize_tx_list(rest, nb_transactions, [tx | acc])
-  end
-
-  defp deserialize_public_key_list(rest, 0, _acc), do: {[], rest}
-
-  defp deserialize_public_key_list(rest, nb_keys, acc) when length(acc) == nb_keys do
-    {Enum.reverse(acc), rest}
-  end
-
-  defp deserialize_public_key_list(rest, nb_keys, acc) do
-    {public_key, rest} = Utils.deserialize_public_key(rest)
-    deserialize_public_key_list(rest, nb_keys, [public_key | acc])
   end
 
   defp deserialize_unspent_output_list(rest, 0, _acc), do: {[], rest}

--- a/lib/archethic/p2p/node.ex
+++ b/lib/archethic/p2p/node.ex
@@ -190,7 +190,7 @@ defmodule Archethic.P2P.Node do
   def cast(
         {first_public_key, last_public_key, ip, port, http_port, geo_patch, network_patch,
          average_availability, availability_history, enrollment_date, transport, reward_address,
-         last_address, origin_public_key}
+         last_address, origin_public_key, synced?}
       ) do
     %__MODULE__{
       ip: ip,
@@ -203,6 +203,7 @@ defmodule Archethic.P2P.Node do
       average_availability: average_availability,
       availability_history: availability_history,
       enrollment_date: enrollment_date,
+      synced?: synced?,
       transport: transport,
       reward_address: reward_address,
       last_address: last_address,

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -602,6 +602,17 @@ defmodule Archethic.Utils do
     {<<curve_id::8, origin_id::8, public_key::binary>>, rest}
   end
 
+  def deserialize_public_key_list(rest, 0, _acc), do: {[], rest}
+
+  def deserialize_public_key_list(rest, nb_keys, acc) when length(acc) == nb_keys do
+    {Enum.reverse(acc), rest}
+  end
+
+  def deserialize_public_key_list(rest, nb_keys, acc) do
+    {public_key, rest} = deserialize_public_key(rest)
+    deserialize_public_key_list(rest, nb_keys, [public_key | acc])
+  end
+
   def deserialize_transaction_attestations(rest, 0, _acc), do: {[], rest}
 
   def deserialize_transaction_attestations(rest, nb_attestations, acc)


### PR DESCRIPTION
# Description

In some case, when a node start first self repair and take time to achieve it, other node can consider it as available and authorized before it finish the self repair and it should not as the node can't validate transaction.
To avoid this we can handle the end of synchronization notification to set a node available only if it finished the self repair

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

TODO

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
