### PR TITLE
Fixed Read Blog link

### DIFF
--- a/lib/archethic_web/templates/faucet/index.html.eex
+++ b/lib/archethic_web/templates/faucet/index.html.eex
@@ -44,7 +44,7 @@
             Don't have a wallet address? Learn how to create a new one!
             <br>
             <br>
-            <a href="https://uniris.io/blog/introducing-archethic-testnet-faucet/" target="_blank" ><button class="button is-light " >
+            <a href="https://blog.archethic.net/introducing-archethic-testnet-faucet/" target="_blank" ><button class="button is-light " >
             Read Blog
         </button></a>
     </h2>


### PR DESCRIPTION
# Description

The objective of this PR is to redirect users from Read Blog button on Faucet Page (https://testnet.archethic.net/faucet) directly to https://blog.archethic.net/introducing-archethic-testnet-faucet/ instead of https://blog.archethic.net/. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Change of link for **Read Blog** button.

# How Has This Been Tested?

The mentioned change has been tested manually on http://localhost:4000/faucet.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
