### PR TITLE
Improve Transaction API validation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -58,7 +58,8 @@ config :archethic, :marker, "-=%=-=%=-=%=-"
 config :archethic, :transaction_data_content_max_size, 3_145_728
 
 # size represents in bytes binary
-config :archethic, :transaction_data_code_max_size, 5_242_880
+# 24KB Max
+config :archethic, :transaction_data_code_max_size, 24576
 
 config :archethic, Archethic.Crypto,
   supported_curves: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -57,6 +57,9 @@ config :archethic, :marker, "-=%=-=%=-=%=-"
 # size represents in bytes binary
 config :archethic, :transaction_data_content_max_size, 3_145_728
 
+# size represents in bytes binary
+config :archethic, :transaction_data_code_max_size, 5_242_880
+
 config :archethic, Archethic.Crypto,
   supported_curves: [
     :ed25519,

--- a/lib/archethic_web/controllers/api/schema/nft_ledger.ex
+++ b/lib/archethic_web/controllers/api/schema/nft_ledger.ex
@@ -18,7 +18,10 @@ defmodule ArchethicWeb.API.Schema.NFTLedger do
     changeset
     |> cast(params, [])
     |> cast_embed(:transfers, with: &changeset_transfers/2)
-    |> validate_length(:transfers, max: 256, message: "maximum nft transfers in a transaction can be 256")
+    |> validate_length(:transfers,
+      max: 256,
+      message: "maximum nft transfers in a transaction can be 256"
+    )
   end
 
   defp changeset_transfers(changeset, params) do

--- a/lib/archethic_web/controllers/api/schema/nft_ledger.ex
+++ b/lib/archethic_web/controllers/api/schema/nft_ledger.ex
@@ -18,6 +18,7 @@ defmodule ArchethicWeb.API.Schema.NFTLedger do
     changeset
     |> cast(params, [])
     |> cast_embed(:transfers, with: &changeset_transfers/2)
+    |> validate_length(:transfers, max: 256, message: "maximum nft transfers in a transaction can be 256")
   end
 
   defp changeset_transfers(changeset, params) do

--- a/lib/archethic_web/controllers/api/schema/ownership.ex
+++ b/lib/archethic_web/controllers/api/schema/ownership.ex
@@ -17,7 +17,10 @@ defmodule ArchethicWeb.API.Schema.Ownership do
     |> cast(params, [:secret])
     |> cast_embed(:authorizedKeys)
     |> validate_required([:secret, :authorizedKeys])
-    |> validate_length(:authorizedKeys, max: 256, message: "maximum number of authorized keys can be 256")
+    |> validate_length(:authorizedKeys,
+      max: 256,
+      message: "maximum number of authorized keys can be 256"
+    )
     |> format_authorized_keys()
   end
 

--- a/lib/archethic_web/controllers/api/schema/ownership.ex
+++ b/lib/archethic_web/controllers/api/schema/ownership.ex
@@ -17,6 +17,7 @@ defmodule ArchethicWeb.API.Schema.Ownership do
     |> cast(params, [:secret])
     |> cast_embed(:authorizedKeys)
     |> validate_required([:secret, :authorizedKeys])
+    |> validate_length(:authorizedKeys, max: 256, message: "maximum number of authorized keys can be 256")
     |> format_authorized_keys()
   end
 

--- a/lib/archethic_web/controllers/api/schema/transaction_data.ex
+++ b/lib/archethic_web/controllers/api/schema/transaction_data.ex
@@ -23,31 +23,16 @@ defmodule ArchethicWeb.API.Schema.TransactionData do
     changeset
     |> cast(params, [:code, :content, :recipients])
     |> cast_embed(:ledger)
-    # Ownerhips can be 256 address Public Keys
     |> cast_embed(:ownerships)
+    |> validate_length(:content,
+      max: @content_max_size,
+      message: "content size must be lessthan content_max_size"
+    )
     |> validate_length(:code,
       max: @code_max_size,
-      message: "code size can't be more than " <> Integer.to_string(@code_max_size) <> " bytes"
+      message: "code size can't be more than #{Integer.to_string(@code_max_size)} bytes"
     )
     |> validate_length(:ownerships, max: 256, message: "ownerships can not be more that 256")
-    |> validate_content_size()
     |> validate_length(:recipients, max: 256, message: "maximum number of recipients can be 256")
   end
-
-  defp validate_content_size(changeset = %Ecto.Changeset{}) do
-    validate_change(changeset, :content, fn field, content ->
-      content_size = byte_size(content)
-
-      if content_size >= @content_max_size do
-        [{field, "content size must be lessthan content_max_size"}]
-      else
-        []
-      end
-    end)
-  end
-
-  # Validate data size here
-  # Calculate max. content size here based on args
-  # Custom validators in ecto
-  # validate_length // works with lists, strings
 end

--- a/lib/archethic_web/controllers/api/schema/transaction_data.ex
+++ b/lib/archethic_web/controllers/api/schema/transaction_data.ex
@@ -1,6 +1,7 @@
 defmodule ArchethicWeb.API.Schema.TransactionData do
   @moduledoc false
   @content_max_size Application.compile_env!(:archethic, :transaction_data_content_max_size)
+  @code_max_size Application.compile_env!(:archethic, :transaction_data_code_max_size)
 
   use Ecto.Schema
   import Ecto.Changeset
@@ -22,8 +23,15 @@ defmodule ArchethicWeb.API.Schema.TransactionData do
     changeset
     |> cast(params, [:code, :content, :recipients])
     |> cast_embed(:ledger)
+    # Ownerhips can be 256 address Public Keys
     |> cast_embed(:ownerships)
+    |> validate_length(:code,
+      max: @code_max_size,
+      message: "code size can't be more than " <> Integer.to_string(@code_max_size) <> " bytes"
+    )
+    |> validate_length(:ownerships, max: 256, message: "ownerships can not be more that 256")
     |> validate_content_size()
+    |> validate_length(:recipients, max: 256, message: "maximum number of recipients can be 256")
   end
 
   defp validate_content_size(changeset = %Ecto.Changeset{}) do
@@ -37,4 +45,9 @@ defmodule ArchethicWeb.API.Schema.TransactionData do
       end
     end)
   end
+
+  # Validate data size here
+  # Calculate max. content size here based on args
+  # Custom validators in ecto
+  # validate_length // works with lists, strings
 end

--- a/lib/archethic_web/controllers/api/schema/uco_ledger.ex
+++ b/lib/archethic_web/controllers/api/schema/uco_ledger.ex
@@ -17,6 +17,7 @@ defmodule ArchethicWeb.API.Schema.UCOLedger do
     changeset
     |> cast(params, [])
     |> cast_embed(:transfers, with: &changeset_transfers/2)
+    |> validate_length(:transfers, max: 256, message: "maximum uco transfers in a transaction can be 256")
   end
 
   defp changeset_transfers(changeset, params) do

--- a/lib/archethic_web/controllers/api/schema/uco_ledger.ex
+++ b/lib/archethic_web/controllers/api/schema/uco_ledger.ex
@@ -17,7 +17,10 @@ defmodule ArchethicWeb.API.Schema.UCOLedger do
     changeset
     |> cast(params, [])
     |> cast_embed(:transfers, with: &changeset_transfers/2)
-    |> validate_length(:transfers, max: 256, message: "maximum uco transfers in a transaction can be 256")
+    |> validate_length(:transfers,
+      max: 256,
+      message: "maximum uco transfers in a transaction can be 256"
+    )
   end
 
   defp changeset_transfers(changeset, params) do

--- a/test/archethic_web/controllers/api/transaction_payload_test.exs
+++ b/test/archethic_web/controllers/api/transaction_payload_test.exs
@@ -538,7 +538,6 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
               end)
           }
         })
-
     end
 
     test "should return an error authorized keys in a ownership can't be more than 256" do
@@ -564,11 +563,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
                     %{
                       "publicKey" =>
                         Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
-                      "encryptedSecretKey" =>
-                        Base.encode16(:crypto.strong_rand_bytes(64))
+                      "encryptedSecretKey" => Base.encode16(:crypto.strong_rand_bytes(64))
                     }
                   end),
-                  "secret" => Base.encode16(:crypto.strong_rand_bytes(64))
+                "secret" => Base.encode16(:crypto.strong_rand_bytes(64))
               }
             ]
           }

--- a/test/archethic_web/controllers/api/transaction_payload_test.exs
+++ b/test/archethic_web/controllers/api/transaction_payload_test.exs
@@ -573,7 +573,8 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
         }
       })
 
-    assert ["maximum number of recipients can be 256"] = changeset |> get_errors() |> get_in([:data, :recipients])
+    assert ["maximum number of recipients can be 256"] =
+             changeset |> get_errors() |> get_in([:data, :recipients])
   end
 
   test "to_map/1 should return a map of the changeset" do

--- a/test/archethic_web/controllers/api/transaction_payload_test.exs
+++ b/test/archethic_web/controllers/api/transaction_payload_test.exs
@@ -119,6 +119,27 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
       assert {"is invalid", _} = Keyword.get(errors, :code)
     end
 
+    test "should return an error if the code length is more than 5 MB" do
+      %Ecto.Changeset{
+        valid?: false,
+        changes: %{data: %{errors: errors}}
+      } =
+        TransactionPayload.changeset(%{
+          "version" => 1,
+          "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+          "type" => "transfer",
+          "timestamp" => DateTime.utc_now() |> DateTime.to_unix(:millisecond),
+          "previousPublicKey" =>
+            Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+          "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+          "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+          "data" => %{"code" => Base.encode16(:crypto.strong_rand_bytes(5 * 1024 * 1024 + 1))}
+        })
+
+      {error_message, _} = Keyword.get(errors, :code)
+      assert String.starts_with?(error_message, "code size can't be more than ")
+    end
+
     test "should return an error if the uco ledger transfer address is invalid" do
       changeset =
         %Ecto.Changeset{
@@ -174,6 +195,42 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
 
       assert [%{amount: ["is invalid"]}] =
                changeset |> get_errors() |> get_in([:data, :ledger, :uco, :transfers])
+    end
+
+    # Add test for uco's here
+    test "should return an error if the uco ledger transfers are more than 256" do
+      changeset =
+        %Ecto.Changeset{
+          valid?: false
+        } =
+        TransactionPayload.changeset(%{
+          "version" => 1,
+          "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+          "type" => "transfer",
+          "timestamp" => DateTime.utc_now() |> DateTime.to_unix(:millisecond),
+          "previousPublicKey" =>
+            Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+          "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+          "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+          "data" => %{
+            "ledger" => %{
+              "uco" => %{
+                "transfers" =>
+                  1..257
+                  |> Enum.map(fn _ ->
+                    %{
+                      "to" =>
+                        Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+                      "amount" => Enum.random(1..100)
+                    }
+                  end)
+              }
+            }
+          }
+        })
+
+      assert %{transfers: ["maximum uco transfers in a transaction can be 256"]} =
+               changeset |> get_errors() |> get_in([:data, :ledger, :uco])
     end
 
     test "should return an error if the nft ledger transfer address is invalid" do
@@ -278,6 +335,43 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
 
       assert [%{nft: ["must be hexadecimal"]}] =
                changeset |> get_errors |> get_in([:data, :ledger, :nft, :transfers])
+    end
+
+    test "should return an error if the nft ledger transfers are more than 256" do
+      changeset =
+        %Ecto.Changeset{
+          valid?: false
+        } =
+        TransactionPayload.changeset(%{
+          "version" => 1,
+          "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+          "type" => "transfer",
+          "timestamp" => DateTime.utc_now() |> DateTime.to_unix(:millisecond),
+          "previousPublicKey" =>
+            Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+          "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+          "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+          "data" => %{
+            "ledger" => %{
+              "nft" => %{
+                "transfers" =>
+                  1..257
+                  |> Enum.map(fn _ ->
+                    %{
+                      "to" =>
+                        Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+                      "amount" => Enum.random(1..100),
+                      "nft" =>
+                        Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>)
+                    }
+                  end)
+              }
+            }
+          }
+        })
+
+      assert %{transfers: ["maximum nft transfers in a transaction can be 256"]} =
+               changeset |> get_errors |> get_in([:data, :ledger, :nft])
     end
 
     test "should return an error if the encrypted secret is not an hexadecimal" do
@@ -454,6 +548,32 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
 
       assert ["invalid hash"] = changeset |> get_errors() |> get_in([:data, :recipients])
     end
+  end
+
+  test "should return an error if the recipients are more that 256" do
+    changeset =
+      %Ecto.Changeset{
+        valid?: false
+      } =
+      TransactionPayload.changeset(%{
+        "version" => 1,
+        "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+        "type" => "transfer",
+        "timestamp" => DateTime.utc_now() |> DateTime.to_unix(:millisecond),
+        "previousPublicKey" =>
+          Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "recipients" =>
+            1..257
+            |> Enum.map(fn _ ->
+              Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>)
+            end)
+        }
+      })
+
+    assert ["maximum number of recipients can be 256"] = changeset |> get_errors() |> get_in([:data, :recipients])
   end
 
   test "to_map/1 should return a map of the changeset" do


### PR DESCRIPTION
# Description

Additional Checks on Structure Changesets to validate proper lengths for following
- Ownerships
   - ownership recipients
- UCOLedger transfers
- NFTLedger transfers
- recipients in a transaction
- Code Length (Fetched from the config)

Fixes #330 

## Type of change

- New feature (non-breaking change which adds functionality)
Forces API to precheck the sizes which are supported by transaction encoding before serializing

# How Has This Been Tested?

- test "should return an error if the code length is more than 5 MB"
- test "should return an error if the uco ledger transfers are more than 256"
- test "should return an error if the nft ledger transfers are more than 256"
- test "should return an error if the recipients are more that 256"
- test "should return an error ownerships are more than 256."
- test "should return an error authorized keys in a ownership can't be more than 256"

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
