### PR TITLE
Detection of unresponsive trigger nodes

### DIFF
--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -32,7 +32,7 @@ defmodule Archethic.Contracts.Worker do
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.TransactionMovement
 
   alias Archethic.Utils
-
+  alias Archethic.Utils.DetectNodeResponsiveness
   require Logger
 
   use GenServer
@@ -256,21 +256,35 @@ defmodule Archethic.Contracts.Worker do
   defp schedule_trigger(_), do: :ok
 
   defp handle_new_transaction(next_transaction = %Transaction{}) do
-    [%Node{first_public_key: key} | _] =
-      next_transaction
-      |> Transaction.previous_address()
-      |> Election.chain_storage_nodes(P2P.authorized_and_available_nodes())
-
+    validation_nodes = P2P.authorized_and_available_nodes()
     # The first storage node of the contract initiate the sending of the new transaction
-    if key == Crypto.first_node_public_key() do
-      validation_nodes = P2P.authorized_and_available_nodes()
-
+    if trigger_node?(next_transaction) do
       P2P.broadcast_message(validation_nodes, %StartMining{
         transaction: next_transaction,
         validation_node_public_keys: Enum.map(validation_nodes, & &1.last_public_key),
         welcome_node_public_key: Crypto.last_node_public_key()
       })
+    else
+      DetectNodeResponsiveness.start_link(next_transaction.address, fn count ->
+        if trigger_node?(count) do
+          P2P.broadcast_message(validation_nodes, %StartMining{
+            transaction: next_transaction,
+            validation_node_public_keys: Enum.map(validation_nodes, & &1.last_public_key),
+            welcome_node_public_key: Crypto.last_node_public_key()
+          })
+        end
+      end)
     end
+  end
+
+  defp trigger_node?(next_transaction = %Transaction{}, count \\ 0) do
+    %Node{first_public_key: key} =
+      next_transaction
+      |> Transaction.previous_address()
+      |> Election.chain_storage_nodes(P2P.authorized_and_available_nodes())
+      |> Enum.at(count)
+
+    key == Crypto.first_node_public_key()
   end
 
   defp chain_transaction(

--- a/lib/archethic/shared_secrets/node_renewal.ex
+++ b/lib/archethic/shared_secrets/node_renewal.ex
@@ -28,12 +28,12 @@ defmodule Archethic.SharedSecrets.NodeRenewal do
   @doc """
   Determine if the local node is the initiator of the node renewal
   """
-  @spec initiator?() :: boolean()
-  def initiator? do
+  @spec initiator? :: boolean()
+  def initiator?(index \\ 0) do
     %Node{first_public_key: initiator_key} =
       next_address()
       |> Election.storage_nodes(P2P.authorized_and_available_nodes())
-      |> List.first()
+      |> Enum.at(index)
 
     initiator_key == Crypto.first_node_public_key()
   end

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -28,6 +28,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
   alias Archethic.SharedSecrets.NodeRenewal
 
   alias Archethic.Utils
+  alias Archethic.Utils.DetectNodeResponsiveness
 
   require Logger
 
@@ -117,9 +118,23 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
       "Node shared secrets will be renewed in #{Utils.remaining_seconds_from_timer(timer)}"
     )
 
+    tx =
+      NodeRenewal.next_authorized_node_public_keys()
+      |> NodeRenewal.new_node_shared_secrets_transaction(
+        :crypto.strong_rand_bytes(32),
+        :crypto.strong_rand_bytes(32)
+      )
+
     if NodeRenewal.initiator?() do
       Logger.info("Node shared secrets renewal creation...")
-      make_renewal()
+      make_renewal(tx)
+    else
+      DetectNodeResponsiveness.start_link(tx.address, fn count ->
+        if NodeRenewal.initiator?(count) do
+          Logger.info("Node shared secret renewal creation...attempt#{count}")
+          make_renewal(tx)
+        end
+      end)
     end
 
     {:noreply, Map.put(state, :timer, timer), :hibernate}
@@ -135,14 +150,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
     end
   end
 
-  defp make_renewal do
-    tx =
-      NodeRenewal.next_authorized_node_public_keys()
-      |> NodeRenewal.new_node_shared_secrets_transaction(
-        :crypto.strong_rand_bytes(32),
-        :crypto.strong_rand_bytes(32)
-      )
-
+  defp make_renewal(tx) do
     Archethic.send_new_transaction(tx)
 
     Logger.info(

--- a/lib/archethic/utils/detect_node_responsiveness.ex
+++ b/lib/archethic/utils/detect_node_responsiveness.ex
@@ -1,0 +1,41 @@
+defmodule Archethic.Utils.DetectNodeResponsiveness do
+  @moduledoc """
+  Detects the nodes responsiveness based on timeouts
+  """
+  @default_timeout 3 * 1000
+  alias Archethic.PubSub
+  alias Archethic.P2P
+
+  use GenStateMachine
+
+  def start_link(address, replaying_fn) do
+    GenStateMachine.start_link(__MODULE__, [address, replaying_fn], [])
+  end
+
+  def init([address, replaying_fn]) do
+    PubSub.register_to_new_transaction_by_address(address)
+    schedule_timeout()
+    {:ok, :waiting, %{address: address, replaying_fn: replaying_fn, count: 0}}
+  end
+
+  def handle_event(:info, :soft_timeout, :waiting, %{replaying_fn: replaying_fn, count: count}) do
+    if count < length(P2P.authorized_and_available_nodes()) do
+      replaying_fn.(count)
+      schedule_timeout()
+      count = count + 1
+      {:keep_state, %{count: count, replaying_fn: replaying_fn}}
+    else
+      # hard_timeout
+
+      :stop
+    end
+  end
+
+  def handle_event(:info, {:new_transaction, _, _, _}, :waiting, _) do
+    :stop
+  end
+
+  defp schedule_timeout(interval \\ @default_timeout, pid \\ self()) do
+    Process.send_after(pid, :soft_timeout, interval)
+  end
+end


### PR DESCRIPTION
# Description

It detects the unresponsive nodes and resends the transaction to the next trigger next node.

Fixes #338

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Test with 3 three nodes
`>ARCHETHIC_CRYPTO_SEED=node1 ARCHETHIC_P2P_PORT=3001 ARCHETHIC_HTTP_PORT=4001 iex -S mix`
similary change the seed, ports for other nodes.
If we stop the node1 the node shared secret transactions , oracle etc must be fall back to node2, node2 as trigger node and shall be validated.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
