### PR TITLE
Added 0 String Length Check on address_type.ex before decoding.

### DIFF
--- a/lib/archethic_web/graphql_schema/address_type.ex
+++ b/lib/archethic_web/graphql_schema/address_type.ex
@@ -16,7 +16,8 @@ defmodule ArchethicWeb.GraphQLSchema.AddressType do
 
   @spec parse_address(Absinthe.Blueprint.Input.String.t()) :: {:ok, binary()} | :error
   defp parse_address(%Absinthe.Blueprint.Input.String{value: address}) do
-    with {:ok, addr} <- Base.decode16(address, case: :mixed),
+    with true <- String.length(address) > 0,
+         {:ok, addr} <- Base.decode16(address, case: :mixed),
          true <- Crypto.valid_address?(addr) do
       {:ok, addr}
     else

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -267,6 +267,16 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
       assert Enum.slice(transactions, slice_range)
              |> Enum.map(&%{"address" => Base.encode16(&1.address)}) == recv_transactions
     end
+
+    test "should return error on 0 length address argument", %{conn: conn} do
+      conn =
+        post(conn, "/api", %{
+          "query" => "query { transactionChain(address: \"\") { address } }"
+        })
+
+      %{"errors" => [%{"message" => message}]} = json_response(conn, 200)
+      assert message |> String.starts_with?("Argument \"address\" has invalid value \"\"")
+    end
   end
 
   describe "query: balance" do


### PR DESCRIPTION
# Description
At the moment, when an empty string is provided to graphql_schema, It was causing an error in ae-node side since, "" can be decoded but it's not a valid address which is not check in Crypto.valid_address/1. To solve this, added a 0 string length check before decoding the string and progressing forward.

Fixes # (issue)
#362 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a test in graphql_schema_test.exs 
 - test "should return error on 0 length address argument"

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
