### PR TITLE
Detection of unresponsive trigger node Contd of 376 

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -120,6 +120,8 @@ config :archethic, Archethic.SharedSecrets.NodeRenewalScheduler,
 config :archethic, Archethic.P2P.Listener,
   port: System.get_env("ARCHETHIC_P2P_PORT", "3002") |> String.to_integer()
 
+config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 5_000
+
 config :archethic, ArchethicWeb.FaucetController, enabled: true
 
 # For development, we disable any cache and enable

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -120,7 +120,7 @@ config :archethic, Archethic.SharedSecrets.NodeRenewalScheduler,
 config :archethic, Archethic.P2P.Listener,
   port: System.get_env("ARCHETHIC_P2P_PORT", "3002") |> String.to_integer()
 
-config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 5_000
+config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 1_000
 
 config :archethic, ArchethicWeb.FaucetController, enabled: true
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -217,8 +217,6 @@ config :archethic, Archethic.P2P.BootstrappingSeeds,
 
 config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 10_000
 
-config :archethic, Archethic.Mining.DistributedWorkflow, global_timeout: 60_000
-
 config :archethic, ArchethicWeb.FaucetController,
   enabled: System.get_env("ARCHETHIC_NETWORK_TYPE") == "testnet"
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -217,6 +217,8 @@ config :archethic, Archethic.P2P.BootstrappingSeeds,
 
 config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 10_000
 
+config :archethic, Archethic.Mining.DistributedWorkflow, global_timeout: 60_000
+
 config :archethic, ArchethicWeb.FaucetController,
   enabled: System.get_env("ARCHETHIC_NETWORK_TYPE") == "testnet"
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -215,6 +215,8 @@ config :archethic, Archethic.P2P.BootstrappingSeeds,
   # TODO: define the default list of P2P seeds once the network will be more open to new miners
   genesis_seeds: System.get_env("ARCHETHIC_P2P_BOOTSTRAPPING_SEEDS")
 
+config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 10_000
+
 config :archethic, ArchethicWeb.FaucetController,
   enabled: System.get_env("ARCHETHIC_NETWORK_TYPE") == "testnet"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -142,7 +142,7 @@ config :archethic, Archethic.TransactionChain.MemTables.KOLedger, enabled: false
 config :archethic, Archethic.TransactionChain.MemTablesLoader, enabled: false
 
 config :archethic, ArchethicWeb.FaucetController, enabled: true
-config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 5_000
+config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 1_000
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/config/test.exs
+++ b/config/test.exs
@@ -142,6 +142,7 @@ config :archethic, Archethic.TransactionChain.MemTables.KOLedger, enabled: false
 config :archethic, Archethic.TransactionChain.MemTablesLoader, enabled: false
 
 config :archethic, ArchethicWeb.FaucetController, enabled: true
+config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 5_000
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -32,7 +32,7 @@ defmodule Archethic.Contracts.Worker do
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.TransactionMovement
 
   alias Archethic.Utils
-
+  alias Archethic.Utils.DetectNodeResponsiveness
   require Logger
 
   use GenServer
@@ -256,21 +256,35 @@ defmodule Archethic.Contracts.Worker do
   defp schedule_trigger(_), do: :ok
 
   defp handle_new_transaction(next_transaction = %Transaction{}) do
-    [%Node{first_public_key: key} | _] =
-      next_transaction
-      |> Transaction.previous_address()
-      |> Election.chain_storage_nodes(P2P.authorized_and_available_nodes())
-
+    validation_nodes = P2P.authorized_and_available_nodes()
     # The first storage node of the contract initiate the sending of the new transaction
-    if key == Crypto.first_node_public_key() do
-      validation_nodes = P2P.authorized_and_available_nodes()
-
+    if trigger_node?(next_transaction) do
       P2P.broadcast_message(validation_nodes, %StartMining{
         transaction: next_transaction,
         validation_node_public_keys: Enum.map(validation_nodes, & &1.last_public_key),
         welcome_node_public_key: Crypto.last_node_public_key()
       })
+    else
+      DetectNodeResponsiveness.start_link(next_transaction.address, fn count ->
+        if trigger_node?(count) do
+          P2P.broadcast_message(validation_nodes, %StartMining{
+            transaction: next_transaction,
+            validation_node_public_keys: Enum.map(validation_nodes, & &1.last_public_key),
+            welcome_node_public_key: Crypto.last_node_public_key()
+          })
+        end
+      end)
     end
+  end
+
+  defp trigger_node?(next_transaction = %Transaction{}, count \\ 0) do
+    %Node{first_public_key: key} =
+      next_transaction
+      |> Transaction.previous_address()
+      |> Election.chain_storage_nodes(P2P.authorized_and_available_nodes())
+      |> Enum.at(count)
+
+    key == Crypto.first_node_public_key()
   end
 
   defp chain_transaction(

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -169,8 +169,8 @@ defmodule Archethic.Mining do
     |> DistributedWorkflow.add_cross_validation_stamp(stamp)
   end
 
-  defp get_mining_process!(tx_address) do
-    retry_while with: exponential_backoff(100, 2) |> expiry(@mining_timeout) do
+  defp get_mining_process!(tx_address, timeout \\ @mining_timeout) do
+    retry_while with: exponential_backoff(100, 2) |> expiry(timeout) do
       case Registry.lookup(WorkflowRegistry, tx_address) do
         [{pid, _}] ->
           {:halt, pid}
@@ -178,6 +178,20 @@ defmodule Archethic.Mining do
         _ ->
           {:cont, nil}
       end
+    end
+  end
+
+  @doc """
+  Return true if the transaction is in mining process
+  """
+  @spec processing?(binary()) :: boolean()
+  def processing?(tx_address) do
+    case get_mining_process!(tx_address, 100) do
+      nil ->
+        false
+
+      _pid ->
+        true
     end
   end
 

--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -173,6 +173,7 @@ defmodule Archethic.OracleChain.Scheduler do
                   transaction_address: Base.encode16(tx.address),
                   transaction_type: :oracle
                 )
+
                 new_oracle_data = get_new_oracle_data(summary_date, index)
                 tx = build_oracle_transaction(summary_date, index, new_oracle_data)
                 send_polling_transaction(tx)
@@ -606,7 +607,6 @@ defmodule Archethic.OracleChain.Scheduler do
   end
 
   defp get_new_oracle_data(summary_date, index) do
-
     summary_date
     |> Crypto.derive_oracle_address(index)
     |> get_oracle_data()

--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -146,60 +146,52 @@ defmodule Archethic.OracleChain.Scheduler do
       |> get_oracle_data()
       |> Services.fetch_new_data()
 
-    if generate_oracle_tx?(new_oracle_data) do
-      # build transaction
-      {prev_pub, prev_pv} = Crypto.derive_oracle_keypair(summary_date, index)
+    authorized_nodes =
+      summary_date
+      |> P2P.authorized_nodes()
+      |> Enum.filter(& &1.available?)
 
-      {next_pub, _} = Crypto.derive_oracle_keypair(summary_date, index + 1)
+    storage_nodes =
+      summary_date
+      |> Crypto.derive_oracle_address(index)
+      |> Election.storage_nodes(authorized_nodes)
 
-      tx =
-        Transaction.new_with_keys(
-          :oracle,
-          %TransactionData{
-            content: Jason.encode!(new_oracle_data),
-            code: ~S"""
-            condition inherit: [
-              # We need to ensure the type stays consistent
-              # So we can apply specific rules during the transaction validation
-              type: in?([oracle, oracle_summary]),
+    tx = build_oracle_transaction(summary_date, index, new_oracle_data)
 
-              # We discard the content and code verification
-              content: true,
-
-              # We ensure the code stay the same
-              code: if type == oracle_summary do
-                regex_match?("condition inherit: \\[[\\s].*content: \\\"\\\"[\\s].*]")
-              else
-                previous.code
-              end
-            ]
-            """
-          },
-          prev_pv,
-          prev_pub,
-          next_pub
-        )
-
-      authorized_nodes = P2P.authorized_nodes(summary_date) |> Enum.filter(& &1.available?)
-
-      storage_nodes =
-        summary_date
-        |> Crypto.derive_oracle_address(index)
-        |> Election.storage_nodes(authorized_nodes)
-
-      if trigger_node?(storage_nodes) and !DB.transaction_exists?(tx.address) do
+    watcher_pid =
+      with {:empty, false} <- {:empty, Enum.empty?(new_oracle_data)},
+           {:trigger, true} <- {:trigger, trigger_node?(storage_nodes)},
+           {:exists, false} <- {:exists, DB.transaction_exists?(tx.address)} do
         send_polling_transaction(tx)
+        nil
       else
-        DetectNodeResponsiveness.start_link(tx.address, fn count ->
-          if trigger_node?(storage_nodes, count) do
-            Logger.info("Oracle polling transaction ...attempt #{count}")
-            send_polling_transaction(tx)
-          end
-        end)
+        {:empty, true} ->
+          Logger.debug("Oracle transaction skipped - no new data")
+          nil
+
+        {:trigger, false} ->
+          {:ok, pid} =
+            DetectNodeResponsiveness.start_link(tx.address, fn count ->
+              if trigger_node?(storage_nodes, count) do
+                Logger.info("Oracle polling transaction ...attempt #{count}",
+                  transaction_address: Base.encode16(tx.address),
+                  transaction_type: :oracle
+                )
+
+                send_polling_transaction(tx)
+              end
+            end)
+
+          pid
+
+        {:exists, true} ->
+          Logger.warning("Transaction already exists - before sending",
+            transaction_address: Base.encode16(tx.address),
+            transaction_type: :oracle
+          )
+
+          nil
       end
-    else
-      Logger.debug("Oracle transaction skipped - no new data")
-    end
 
     current_time = DateTime.utc_now() |> DateTime.truncate(:second)
     next_polling_date = next_date(polling_interval, current_time)
@@ -208,6 +200,7 @@ defmodule Archethic.OracleChain.Scheduler do
       data
       |> Map.put(:polling_date, next_polling_date)
       |> Map.put(:polling_timer, schedule_new_polling(next_polling_date, current_time))
+      |> Map.put(:oracle_watcher_pid, watcher_pid)
 
     {:next_state, :ready, new_data}
   end
@@ -224,12 +217,60 @@ defmodule Archethic.OracleChain.Scheduler do
     index = Map.fetch!(indexes, summary_date)
     validation_nodes = get_validation_nodes(summary_date, index + 1)
 
-    if trigger_node?(validation_nodes) do
-      Logger.debug("Oracle transaction summary sending")
-      send_summary_transaction(summary_date, index)
-    else
-      Logger.debug("Oracle summary skipped - not the trigger node")
+    # Stop previous oracle retries when the summary is triggered
+    case Map.get(data, :oracle_watcher_pid) do
+      nil ->
+        :ok
+
+      pid ->
+        Process.exit(pid, :normal)
     end
+
+    tx_address =
+      summary_date
+      |> Crypto.derive_oracle_keypair(index + 1)
+      |> elem(0)
+      |> Crypto.derive_address()
+
+    summary_watcher_pid =
+      with {:trigger, true} <- {:trigger, trigger_node?(validation_nodes)},
+           {:exists, false} <- {:exists, DB.transaction_exists?(tx_address)} do
+        Logger.debug("Oracle transaction summary sending",
+          transaction_address: Base.encode16(tx_address),
+          transaction_type: :oracle_summary
+        )
+
+        send_summary_transaction(summary_date, index)
+        nil
+      else
+        {:trigger, false} ->
+          Logger.debug("Oracle summary skipped - not the trigger node",
+            transaction_address: Base.encode16(tx_address),
+            transaction_type: :oracle_summary
+          )
+
+          {:ok, pid} =
+            DetectNodeResponsiveness.start_link(tx_address, fn count ->
+              if trigger_node?(validation_nodes, count) do
+                Logger.info("Oracle summary transaction ...attempt #{count}",
+                  transaction_address: Base.encode16(tx_address),
+                  transaction_type: :oracle_summary
+                )
+
+                send_summary_transaction(summary_date, index)
+              end
+            end)
+
+          pid
+
+        {:exists, true} ->
+          Logger.warning("Oracle transaction already exists",
+            transaction_address: Base.encode16(tx_address),
+            transaction_type: :oracle_summary
+          )
+
+          nil
+      end
 
     current_time = DateTime.utc_now() |> DateTime.truncate(:second)
     next_summary_date = next_date(summary_interval, current_time)
@@ -237,6 +278,8 @@ defmodule Archethic.OracleChain.Scheduler do
 
     new_data =
       data
+      |> Map.put(:summary_watcher_pid, summary_watcher_pid)
+      |> Map.delete(:oracle_watcher_pid)
       |> Map.put(:summary_date, next_summary_date)
       |> Map.update!(:indexes, fn indexes ->
         # Clean previous indexes
@@ -434,6 +477,39 @@ defmodule Archethic.OracleChain.Scheduler do
     )
   end
 
+  defp build_oracle_transaction(summary_date, index, oracle_data) do
+    {prev_pub, prev_pv} = Crypto.derive_oracle_keypair(summary_date, index)
+
+    {next_pub, _} = Crypto.derive_oracle_keypair(summary_date, index + 1)
+
+    Transaction.new_with_keys(
+      :oracle,
+      %TransactionData{
+        content: Jason.encode!(oracle_data),
+        code: ~S"""
+        condition inherit: [
+          # We need to ensure the type stays consistent
+          # So we can apply specific rules during the transaction validation
+          type: in?([oracle, oracle_summary]),
+
+          # We discard the content and code verification
+          content: true,
+
+          # We ensure the code stay the same
+          code: if type == oracle_summary do
+            regex_match?("condition inherit: \\[[\\s].*content: \\\"\\\"[\\s].*]")
+          else
+            previous.code
+          end
+        ]
+        """
+      },
+      prev_pv,
+      prev_pub,
+      next_pub
+    )
+  end
+
   defp send_summary_transaction(summary_date, index) do
     oracle_chain =
       summary_date
@@ -530,13 +606,5 @@ defmodule Archethic.OracleChain.Scheduler do
     summary_date
     |> Crypto.derive_oracle_address(index)
     |> Election.storage_nodes(authorized_nodes)
-  end
-
-  defp generate_oracle_tx?(data) do
-    if Enum.empty?(data) do
-      false
-    else
-      true
-    end
   end
 end

--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -140,11 +140,7 @@ defmodule Archethic.OracleChain.Scheduler do
 
     index = Map.fetch!(indexes, summary_date)
 
-    new_oracle_data =
-      summary_date
-      |> Crypto.derive_oracle_address(index)
-      |> get_oracle_data()
-      |> Services.fetch_new_data()
+    new_oracle_data = get_new_oracle_data(summary_date, index)
 
     authorized_nodes =
       summary_date
@@ -177,7 +173,8 @@ defmodule Archethic.OracleChain.Scheduler do
                   transaction_address: Base.encode16(tx.address),
                   transaction_type: :oracle
                 )
-
+                new_oracle_data = get_new_oracle_data(summary_date, index)
+                tx = build_oracle_transaction(summary_date, index, new_oracle_data)
                 send_polling_transaction(tx)
               end
             end)
@@ -606,5 +603,13 @@ defmodule Archethic.OracleChain.Scheduler do
     summary_date
     |> Crypto.derive_oracle_address(index)
     |> Election.storage_nodes(authorized_nodes)
+  end
+
+  defp get_new_oracle_data(summary_date, index) do
+
+    summary_date
+    |> Crypto.derive_oracle_address(index)
+    |> get_oracle_data()
+    |> Services.fetch_new_data()
   end
 end

--- a/lib/archethic/shared_secrets/node_renewal.ex
+++ b/lib/archethic/shared_secrets/node_renewal.ex
@@ -28,12 +28,12 @@ defmodule Archethic.SharedSecrets.NodeRenewal do
   @doc """
   Determine if the local node is the initiator of the node renewal
   """
-  @spec initiator?() :: boolean()
-  def initiator? do
+  @spec initiator? :: boolean()
+  def initiator?(index \\ 0) do
     %Node{first_public_key: initiator_key} =
       next_address()
       |> Election.storage_nodes(P2P.authorized_and_available_nodes())
-      |> List.first()
+      |> Enum.at(index)
 
     initiator_key == Crypto.first_node_public_key()
   end

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -131,7 +131,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
     else
       DetectNodeResponsiveness.start_link(tx.address, fn count ->
         if NodeRenewal.initiator?(count) do
-          Logger.info("Node shared secret renewal creation...attempt#{count}")
+          Logger.info("Node shared secret renewal creation...attempt #{count}")
           make_renewal(tx)
         end
       end)

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -28,6 +28,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
   alias Archethic.SharedSecrets.NodeRenewal
 
   alias Archethic.Utils
+  alias Archethic.Utils.DetectNodeResponsiveness
 
   require Logger
 
@@ -117,9 +118,23 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
       "Node shared secrets will be renewed in #{Utils.remaining_seconds_from_timer(timer)}"
     )
 
+    tx =
+      NodeRenewal.next_authorized_node_public_keys()
+      |> NodeRenewal.new_node_shared_secrets_transaction(
+        :crypto.strong_rand_bytes(32),
+        :crypto.strong_rand_bytes(32)
+      )
+
     if NodeRenewal.initiator?() do
       Logger.info("Node shared secrets renewal creation...")
-      make_renewal()
+      make_renewal(tx)
+    else
+      DetectNodeResponsiveness.start_link(tx.address, fn count ->
+        if NodeRenewal.initiator?(count) do
+          Logger.info("Node shared secret renewal creation...attempt#{count}")
+          make_renewal(tx)
+        end
+      end)
     end
 
     {:noreply, Map.put(state, :timer, timer), :hibernate}
@@ -135,14 +150,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
     end
   end
 
-  defp make_renewal do
-    tx =
-      NodeRenewal.next_authorized_node_public_keys()
-      |> NodeRenewal.new_node_shared_secrets_transaction(
-        :crypto.strong_rand_bytes(32),
-        :crypto.strong_rand_bytes(32)
-      )
-
+  defp make_renewal(tx) do
     Archethic.send_new_transaction(tx)
 
     Logger.info(

--- a/lib/archethic/utils/detect_node_responsiveness.ex
+++ b/lib/archethic/utils/detect_node_responsiveness.ex
@@ -1,0 +1,41 @@
+defmodule Archethic.Utils.DetectNodeResponsiveness do
+  @moduledoc """
+  Detects the nodes responsiveness based on timeouts
+  """
+  @default_timeout 3 * 1000
+  alias Archethic.PubSub
+  alias Archethic.P2P
+
+  use GenStateMachine
+
+  def start_link(address, replaying_fn) do
+    GenStateMachine.start_link(__MODULE__, [address, replaying_fn], [])
+  end
+
+  def init([address, replaying_fn]) do
+    PubSub.register_to_new_transaction_by_address(address)
+    schedule_timeout()
+    {:ok, :waiting, %{address: address, replaying_fn: replaying_fn, count: 0}}
+  end
+
+  def handle_event(:info, :soft_timeout, :waiting, %{replaying_fn: replaying_fn, count: count}) do
+    if count < length(P2P.authorized_and_available_nodes()) do
+      replaying_fn.(count)
+      schedule_timeout()
+      count = count + 1
+      {:keep_state, %{count: count, replaying_fn: replaying_fn}}
+    else
+      # hard_timeout
+
+      :stop
+    end
+  end
+
+  def handle_event(:info, {:new_transaction, _, _, _}, :waiting, _) do
+    :stop
+  end
+
+  defp schedule_timeout(interval \\ @default_timeout, pid \\ self()) do
+    Process.send_after(pid, :soft_timeout, interval)
+  end
+end

--- a/lib/archethic/utils/detect_node_responsiveness.ex
+++ b/lib/archethic/utils/detect_node_responsiveness.ex
@@ -30,7 +30,7 @@ defmodule Archethic.Utils.DetectNodeResponsiveness do
       ) do
     with false <- DB.transaction_exists?(address),
          true <- count < length(P2P.authorized_and_available_nodes()) do
-      Logger.error("calling replay fn with count=#{count}")
+      Logger.info("calling replay fn with count=#{count}")
       replaying_fn.(count)
       schedule_timeout()
       new_count = count + 1

--- a/lib/archethic/utils/detect_node_responsiveness.ex
+++ b/lib/archethic/utils/detect_node_responsiveness.ex
@@ -2,7 +2,7 @@ defmodule Archethic.Utils.DetectNodeResponsiveness do
   @moduledoc """
   Detects the nodes responsiveness based on timeouts
   """
-  @default_timeout 3 * 1000
+  @default_timeout 10 * 1000
   alias Archethic.P2P
   alias Archethic.DB
 

--- a/lib/archethic/utils/detect_node_responsiveness.ex
+++ b/lib/archethic/utils/detect_node_responsiveness.ex
@@ -2,20 +2,20 @@ defmodule Archethic.Utils.DetectNodeResponsiveness do
   @moduledoc """
   Detects the nodes responsiveness based on timeouts
   """
-  @default_timeout 10 * 1000
+  @default_timeout Application.compile_env(:archethic, __MODULE__) |> Keyword.get(:timeout, 5_000)
   alias Archethic.P2P
   alias Archethic.DB
 
   use GenStateMachine
   require Logger
 
-  def start_link(address, replaying_fn) do
-    GenStateMachine.start_link(__MODULE__, [address, replaying_fn], [])
+  def start_link(address, replaying_fn, timeout \\ @default_timeout) do
+    GenStateMachine.start_link(__MODULE__, [address, replaying_fn, timeout], [])
   end
 
-  def init([address, replaying_fn]) do
-    schedule_timeout()
-    {:ok, :waiting, %{address: address, replaying_fn: replaying_fn, count: 1}}
+  def init([address, replaying_fn, timeout]) do
+    schedule_timeout(timeout)
+    {:ok, :waiting, %{address: address, replaying_fn: replaying_fn, count: 1, timeout: timeout}}
   end
 
   def handle_event(
@@ -25,14 +25,15 @@ defmodule Archethic.Utils.DetectNodeResponsiveness do
         state = %{
           address: address,
           replaying_fn: replaying_fn,
-          count: count
+          count: count,
+          timeout: timeout
         }
       ) do
     with false <- DB.transaction_exists?(address),
          true <- count < length(P2P.authorized_and_available_nodes()) do
       Logger.info("calling replay fn with count=#{count}")
       replaying_fn.(count)
-      schedule_timeout()
+      schedule_timeout(timeout)
       new_count = count + 1
       {:keep_state, %{state | count: new_count}}
     else
@@ -41,7 +42,7 @@ defmodule Archethic.Utils.DetectNodeResponsiveness do
     end
   end
 
-  defp schedule_timeout(interval \\ @default_timeout, pid \\ self()) do
+  defp schedule_timeout(interval, pid \\ self()) do
     Process.send_after(pid, :soft_timeout, interval)
   end
 end

--- a/lib/archethic/utils/detect_node_responsiveness.ex
+++ b/lib/archethic/utils/detect_node_responsiveness.ex
@@ -3,36 +3,42 @@ defmodule Archethic.Utils.DetectNodeResponsiveness do
   Detects the nodes responsiveness based on timeouts
   """
   @default_timeout 3 * 1000
-  alias Archethic.PubSub
   alias Archethic.P2P
+  alias Archethic.DB
 
   use GenStateMachine
+  require Logger
 
   def start_link(address, replaying_fn) do
     GenStateMachine.start_link(__MODULE__, [address, replaying_fn], [])
   end
 
   def init([address, replaying_fn]) do
-    PubSub.register_to_new_transaction_by_address(address)
     schedule_timeout()
-    {:ok, :waiting, %{address: address, replaying_fn: replaying_fn, count: 0}}
+    {:ok, :waiting, %{address: address, replaying_fn: replaying_fn, count: 1}}
   end
 
-  def handle_event(:info, :soft_timeout, :waiting, %{replaying_fn: replaying_fn, count: count}) do
-    if count < length(P2P.authorized_and_available_nodes()) do
+  def handle_event(
+        :info,
+        :soft_timeout,
+        :waiting,
+        state = %{
+          address: address,
+          replaying_fn: replaying_fn,
+          count: count
+        }
+      ) do
+    with false <- DB.transaction_exists?(address),
+         true <- count < length(P2P.authorized_and_available_nodes()) do
+      Logger.error("calling replay fn with count=#{count}")
       replaying_fn.(count)
       schedule_timeout()
-      count = count + 1
-      {:keep_state, %{count: count, replaying_fn: replaying_fn}}
+      new_count = count + 1
+      {:keep_state, %{state | count: new_count}}
     else
       # hard_timeout
-
-      :stop
+      _ -> :stop
     end
-  end
-
-  def handle_event(:info, {:new_transaction, _, _, _}, :waiting, _) do
-    :stop
   end
 
   defp schedule_timeout(interval \\ @default_timeout, pid \\ self()) do

--- a/test/archethic/utils/detect_node_responsiveness_test.exs
+++ b/test/archethic/utils/detect_node_responsiveness_test.exs
@@ -1,5 +1,7 @@
 defmodule Archethic.Utils.DetectNodeResponsivenessTest do
   use ArchethicCase
+  @timeout 5_000
+  @sleep_timeout 5_500
 
   alias Archethic.Utils.DetectNodeResponsiveness
 
@@ -15,7 +17,7 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
       count
     end
 
-    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
     assert true == Process.alive?(pid)
   end
 
@@ -26,8 +28,8 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
       count
     end
 
-    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
-    Process.sleep(11_000)
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
+    Process.sleep(@sleep_timeout)
     assert false == Process.alive?(pid)
   end
 
@@ -96,7 +98,7 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
       enrollment_date: DateTime.utc_now()
     })
 
-    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
 
     MockDB
     |> stub(:transaction_exists?, fn ^address ->
@@ -105,18 +107,17 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
 
     #  first soft_timeout
     assert true == Process.alive?(pid)
-    Process.sleep(10_500)
-    assert_received :replay
+    assert_receive :replay, @sleep_timeout
     # second soft_timeout
-    Process.sleep(10_500)
-    assert_received :replay
+    Process.sleep(@sleep_timeout)
+    assert_receive :replay, @sleep_timeout
     assert true == Process.alive?(pid)
     # third soft_timeout
-    Process.sleep(10_500)
-    assert_received :replay
+    Process.sleep(@sleep_timeout)
+    assert_receive :replay, @sleep_timeout
     assert true == Process.alive?(pid)
     # last timeout leading to stop as hard_timeout
-    Process.sleep(10_500)
+    Process.sleep(@sleep_timeout)
     assert false == Process.alive?(pid)
   end
 
@@ -159,7 +160,7 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
       enrollment_date: DateTime.utc_now()
     })
 
-    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
 
     MockDB
     |> stub(:transaction_exists?, fn ^address ->
@@ -168,9 +169,8 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
 
     #  first soft_timeout
     assert true == Process.alive?(pid)
-    Process.sleep(10_500)
+    Process.sleep(@sleep_timeout)
     assert false == Process.alive?(pid)
-    # assert_received :replay
   end
 
   test "check to second soft_timeout" do
@@ -212,7 +212,7 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
       enrollment_date: DateTime.utc_now()
     })
 
-    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
 
     MockDB
     |> expect(:transaction_exists?, fn ^address ->
@@ -224,11 +224,10 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
 
     #  first soft_timeout
     assert true == Process.alive?(pid)
-    Process.sleep(10_500)
+    Process.sleep(@sleep_timeout)
     assert true == Process.alive?(pid)
-    assert_received :replay
-
-    Process.sleep(10_500)
+    assert_receive :replay, @sleep_timeout
+    Process.sleep(@sleep_timeout)
     assert false == Process.alive?(pid)
   end
 
@@ -271,7 +270,7 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
       enrollment_date: DateTime.utc_now()
     })
 
-    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
 
     MockDB
     |> stub(:transaction_exists?, fn ^address ->
@@ -280,11 +279,12 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
 
     #  After first soft_timeout it goes to hard_timeout
     assert true == Process.alive?(pid)
-    Process.sleep(10_500)
-    assert true == Process.alive?(pid)
-    assert_received :replay
+    Process.sleep(@sleep_timeout)
 
-    Process.sleep(10_500)
+    assert true == Process.alive?(pid)
+    assert_receive :replay, @sleep_timeout
+
+    Process.sleep(@sleep_timeout)
     assert false == Process.alive?(pid)
   end
 end

--- a/test/archethic/utils/detect_node_responsiveness_test.exs
+++ b/test/archethic/utils/detect_node_responsiveness_test.exs
@@ -1,0 +1,290 @@
+defmodule Archethic.Utils.DetectNodeResponsivenessTest do
+  use ArchethicCase
+
+  alias Archethic.Utils.DetectNodeResponsiveness
+
+  import Mox
+  alias Archethic.Crypto
+  alias Archethic.P2P
+  alias Archethic.P2P.Node
+
+  test "start_link/2 for start state" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    replaying_fn = fn count ->
+      count
+    end
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+    assert true == Process.alive?(pid)
+  end
+
+  test "start_link/2 for hard timeout state" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    # dummy replaying fn with count as argument
+    replaying_fn = fn count ->
+      count
+    end
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+    Process.sleep(11_000)
+    assert false == Process.alive?(pid)
+  end
+
+  test "start_link/2 for soft timeout state" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    me = self()
+
+    replaying_fn = fn count ->
+      send(me, :replay)
+      count
+    end
+
+    {pub1, _} = Crypto.derive_keypair("node1", 0)
+    {pub2, _} = Crypto.derive_keypair("node2", 0)
+    {pub3, _} = Crypto.derive_keypair("node3", 0)
+    {pub4, _} = Crypto.derive_keypair("node4", 0)
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      authorized?: true,
+      last_public_key: pub1,
+      first_public_key: pub1,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      enrollment_date: DateTime.utc_now(),
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub2,
+      last_public_key: pub2,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub3,
+      last_public_key: pub3,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub4,
+      last_public_key: pub4,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+
+    MockDB
+    |> stub(:transaction_exists?, fn ^address ->
+      false
+    end)
+
+    #  first soft_timeout
+    assert true == Process.alive?(pid)
+    Process.sleep(10_500)
+    assert_received :replay
+    # second soft_timeout
+    Process.sleep(10_500)
+    assert_received :replay
+    assert true == Process.alive?(pid)
+    # third soft_timeout
+    Process.sleep(10_500)
+    assert_received :replay
+    assert true == Process.alive?(pid)
+    # last timeout leading to stop as hard_timeout
+    Process.sleep(10_500)
+    assert false == Process.alive?(pid)
+  end
+
+  test "check to first soft_timeout" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    me = self()
+
+    replaying_fn = fn count ->
+      send(me, :replay)
+      count
+    end
+
+    {pub1, _} = Crypto.derive_keypair("node1", 0)
+    {pub2, _} = Crypto.derive_keypair("node2", 0)
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      authorized?: true,
+      last_public_key: pub1,
+      first_public_key: pub1,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      enrollment_date: DateTime.utc_now(),
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub2,
+      last_public_key: pub2,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+
+    MockDB
+    |> stub(:transaction_exists?, fn ^address ->
+      true
+    end)
+
+    #  first soft_timeout
+    assert true == Process.alive?(pid)
+    Process.sleep(10_500)
+    assert false == Process.alive?(pid)
+    # assert_received :replay
+  end
+
+  test "check to second soft_timeout" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    me = self()
+
+    replaying_fn = fn count ->
+      send(me, :replay)
+      count
+    end
+
+    {pub1, _} = Crypto.derive_keypair("node1", 0)
+    {pub2, _} = Crypto.derive_keypair("node2", 0)
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      authorized?: true,
+      last_public_key: pub1,
+      first_public_key: pub1,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      enrollment_date: DateTime.utc_now(),
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub2,
+      last_public_key: pub2,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+
+    MockDB
+    |> expect(:transaction_exists?, fn ^address ->
+      false
+    end)
+    |> expect(:transaction_exists?, fn ^address ->
+      true
+    end)
+
+    #  first soft_timeout
+    assert true == Process.alive?(pid)
+    Process.sleep(10_500)
+    assert true == Process.alive?(pid)
+    assert_received :replay
+
+    Process.sleep(10_500)
+    assert false == Process.alive?(pid)
+  end
+
+  test "check to all timeouts" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    me = self()
+
+    replaying_fn = fn count ->
+      send(me, :replay)
+      count
+    end
+
+    {pub1, _} = Crypto.derive_keypair("node1", 0)
+    {pub2, _} = Crypto.derive_keypair("node2", 0)
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      authorized?: true,
+      last_public_key: pub1,
+      first_public_key: pub1,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      enrollment_date: DateTime.utc_now(),
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub2,
+      last_public_key: pub2,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn)
+
+    MockDB
+    |> stub(:transaction_exists?, fn ^address ->
+      false
+    end)
+
+    #  After first soft_timeout it goes to hard_timeout
+    assert true == Process.alive?(pid)
+    Process.sleep(10_500)
+    assert true == Process.alive?(pid)
+    assert_received :replay
+
+    Process.sleep(10_500)
+    assert false == Process.alive?(pid)
+  end
+end


### PR DESCRIPTION
# Description
It detects the unresponsive nodes and resends the transaction to the next trigger next node.

Continuation of PR #376 
Fixes #338 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test with 4 three nodes
`>ARCHETHIC_CRYPTO_SEED=node1 ARCHETHIC_P2P_PORT=3002 ARCHETHIC_HTTP_PORT=4000 iex -S mix`
`>ARCHETHIC_CRYPTO_SEED=node2 ARCHETHIC_P2P_PORT=3003 ARCHETHIC_HTTP_PORT=4001 iex -S mix`
`>ARCHETHIC_CRYPTO_SEED=node3 ARCHETHIC_P2P_PORT=3004 ARCHETHIC_HTTP_PORT=4002 iex -S mix`
`>ARCHETHIC_CRYPTO_SEED=node4 ARCHETHIC_P2P_PORT=3005 ARCHETHIC_HTTP_PORT=4003 iex -S mix`

If we stop the node1 the node shared secret transactions , oracle etc must be fall back to node2, node2 as trigger node and shall be validated.

But for me if a Node is removed the Nodes raised No cross validator node available error and let to #282 kind of error after sometime, otherwise the if the oracle polling transaction was not yet confirmed then other nodes were detecting and resent the tx.
# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
