### PR TITLE
Fix single file error

### DIFF
--- a/lib/archethic_web/controllers/api/web_hosting_controller.ex
+++ b/lib/archethic_web/controllers/api/web_hosting_controller.ex
@@ -136,8 +136,9 @@ defmodule ArchethicWeb.API.WebHostingController do
       1 ->
         # Control if it is a file or a folder
         file_name = Enum.at(keys, 0)
+        file_content = Map.get(json_content, file_name)
 
-        if Map.get(json_content, file_name) |> Map.has_key?("address") do
+        if !is_map(file_content) or Map.has_key?(file_content, "address") do
           file_name
         else
           "index.html"


### PR DESCRIPTION
# Description

Fixes an error when uploading a single file, the file was not retrieve with the root url path.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Uploaded a single file, request the root url (without specifying the file name) and the file is returned

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
