### PR TITLE
Fix slot time error on bootstrap

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -68,9 +68,6 @@ config :archethic,
             Archethic.Crypto.NodeKeystore.Origin.TPMImpl
         end)
 
-config :archethic, Archethic.DB.CassandraImpl,
-  host: System.get_env("ARCHETHIC_DB_HOST", "127.0.0.1:9042")
-
 config :archethic, Archethic.Governance.Pools,
   initial_members: [
     technical_council: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -117,6 +117,8 @@ config :archethic, Archethic.SharedSecrets.NodeRenewalScheduler,
 config :archethic, Archethic.P2P.Listener,
   port: System.get_env("ARCHETHIC_P2P_PORT", "3002") |> String.to_integer()
 
+config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 1_000
+
 config :archethic, ArchethicWeb.FaucetController, enabled: true
 
 # For development, we disable any cache and enable

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -212,6 +212,8 @@ config :archethic, Archethic.P2P.BootstrappingSeeds,
   # TODO: define the default list of P2P seeds once the network will be more open to new miners
   genesis_seeds: System.get_env("ARCHETHIC_P2P_BOOTSTRAPPING_SEEDS")
 
+config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 10_000
+
 config :archethic, ArchethicWeb.FaucetController,
   enabled: System.get_env("ARCHETHIC_NETWORK_TYPE") == "testnet"
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -119,9 +119,6 @@ config :archethic,
        Archethic.Crypto.SharedSecretsKeystore,
        Archethic.Crypto.SharedSecretsKeystore.SoftwareImpl
 
-config :archethic, Archethic.DB.CassandraImpl,
-  host: System.get_env("ARCHETHIC_DB_HOST", "127.0.0.1:9042")
-
 config :archethic, Archethic.Governance.Pools,
   # TODO: provide the true addresses of the members
   initial_members: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -142,6 +142,7 @@ config :archethic, Archethic.TransactionChain.MemTables.KOLedger, enabled: false
 config :archethic, Archethic.TransactionChain.MemTablesLoader, enabled: false
 
 config :archethic, ArchethicWeb.FaucetController, enabled: true
+config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 1_000
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/lib/archethic/crypto.ex
+++ b/lib/archethic/crypto.ex
@@ -738,7 +738,7 @@ defmodule Archethic.Crypto do
   @spec ec_decrypt_with_first_node_key(cipher :: binary()) ::
           {:ok, term()} | {:error, :decryption_failed}
   def ec_decrypt_with_first_node_key(encoded_cipher) when is_binary(encoded_cipher) do
-    <<curve_id::8, _::8, _::binary>> = NodeKeystore.last_public_key()
+    <<curve_id::8, _::8, _::binary>> = NodeKeystore.first_public_key()
     key_size = key_size(curve_id)
 
     <<ephemeral_public_key::binary-size(key_size), tag::binary-16, cipher::binary>> =

--- a/lib/archethic/crypto/keystore/node/software_impl.ex
+++ b/lib/archethic/crypto/keystore/node/software_impl.ex
@@ -100,7 +100,15 @@ defmodule Archethic.Crypto.NodeKeystore.SoftwareImpl do
       File.mkdir_p!(Utils.mut_dir("crypto"))
     end
 
-    node_seed = Keyword.get(opts, :seed, read_seed())
+    node_seed =
+      case Keyword.get(opts, :seed) do
+        nil ->
+          read_seed()
+
+        seed ->
+          seed
+      end
+
     nb_keys = read_index()
 
     Logger.info("Start NodeKeystore at #{nb_keys}th key")

--- a/lib/archethic/crypto/keystore/node/software_impl.ex
+++ b/lib/archethic/crypto/keystore/node/software_impl.ex
@@ -106,7 +106,13 @@ defmodule Archethic.Crypto.NodeKeystore.SoftwareImpl do
           read_seed()
 
         seed ->
-          seed
+          case Base.decode16(seed, case: :mixed) do
+            :error ->
+              seed
+
+            {:ok, seed} ->
+              seed
+          end
       end
 
     nb_keys = read_index()

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -169,8 +169,8 @@ defmodule Archethic.Mining do
     |> DistributedWorkflow.add_cross_validation_stamp(stamp)
   end
 
-  defp get_mining_process!(tx_address) do
-    retry_while with: exponential_backoff(100, 2) |> expiry(@mining_timeout) do
+  defp get_mining_process!(tx_address, timeout \\ @mining_timeout) do
+    retry_while with: exponential_backoff(100, 2) |> expiry(timeout) do
       case Registry.lookup(WorkflowRegistry, tx_address) do
         [{pid, _}] ->
           {:halt, pid}
@@ -178,6 +178,20 @@ defmodule Archethic.Mining do
         _ ->
           {:cont, nil}
       end
+    end
+  end
+
+  @doc """
+  Return true if the transaction is in mining process
+  """
+  @spec processing?(binary()) :: boolean()
+  def processing?(tx_address) do
+    case get_mining_process!(tx_address, 100) do
+      nil ->
+        false
+
+      _pid ->
+        true
     end
   end
 

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -986,7 +986,7 @@ defmodule Archethic.Mining.ValidationContext do
          validation_time: validation_time
        }) do
     diff = DateTime.diff(timestamp, validation_time)
-    diff <= 0 and diff > -10
+    diff <= 3 and diff > -10
   end
 
   defp valid_stamp_signature(stamp = %ValidationStamp{}, %__MODULE__{

--- a/lib/archethic/shared_secrets/node_renewal.ex
+++ b/lib/archethic/shared_secrets/node_renewal.ex
@@ -28,12 +28,12 @@ defmodule Archethic.SharedSecrets.NodeRenewal do
   @doc """
   Determine if the local node is the initiator of the node renewal
   """
-  @spec initiator?() :: boolean()
-  def initiator? do
+  @spec initiator? :: boolean()
+  def initiator?(index \\ 0) do
     %Node{first_public_key: initiator_key} =
       next_address()
       |> Election.storage_nodes(P2P.authorized_and_available_nodes())
-      |> List.first()
+      |> Enum.at(index)
 
     initiator_key == Crypto.first_node_public_key()
   end

--- a/lib/archethic/utils/detect_node_responsiveness.ex
+++ b/lib/archethic/utils/detect_node_responsiveness.ex
@@ -1,0 +1,53 @@
+defmodule Archethic.Utils.DetectNodeResponsiveness do
+  @moduledoc """
+  Detects the nodes responsiveness based on timeouts
+  """
+  @default_timeout Application.compile_env(:archethic, __MODULE__) |> Keyword.get(:timeout, 5_000)
+  alias Archethic.P2P
+  alias Archethic.DB
+  alias Archethic.Mining
+
+  use GenStateMachine
+  require Logger
+
+  def start_link(address, replaying_fn, timeout \\ @default_timeout) do
+    GenStateMachine.start_link(__MODULE__, [address, replaying_fn, timeout], [])
+  end
+
+  def init([address, replaying_fn, timeout]) do
+    schedule_timeout(timeout)
+    {:ok, :waiting, %{address: address, replaying_fn: replaying_fn, count: 1, timeout: timeout}}
+  end
+
+  def handle_event(
+        :info,
+        :soft_timeout,
+        :waiting,
+        state = %{
+          address: address,
+          replaying_fn: replaying_fn,
+          count: count,
+          timeout: timeout
+        }
+      ) do
+    with false <- DB.transaction_exists?(address),
+         false <- Mining.processing?(address),
+         true <- count < length(P2P.authorized_and_available_nodes()) do
+      Logger.info("calling replay fn with count=#{count}",
+        transaction_address: Base.encode16(address)
+      )
+
+      replaying_fn.(count)
+      schedule_timeout(timeout)
+      new_count = count + 1
+      {:keep_state, %{state | count: new_count}}
+    else
+      # hard_timeout
+      _ -> :stop
+    end
+  end
+
+  defp schedule_timeout(interval, pid \\ self()) do
+    Process.send_after(pid, :soft_timeout, interval)
+  end
+end

--- a/test/archethic/utils/detect_node_responsiveness_test.exs
+++ b/test/archethic/utils/detect_node_responsiveness_test.exs
@@ -1,0 +1,332 @@
+defmodule Archethic.Utils.DetectNodeResponsivenessTest do
+  use ArchethicCase
+  @timeout 200
+  @sleep_timeout 350
+
+  alias Archethic.Utils.DetectNodeResponsiveness
+
+  alias Archethic.Mining.WorkflowRegistry
+
+  import Mox
+  alias Archethic.Crypto
+  alias Archethic.P2P
+  alias Archethic.P2P.Node
+
+  test "start_link/2 for start state" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    replaying_fn = fn count ->
+      count
+    end
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
+    assert true == Process.alive?(pid)
+  end
+
+  test "start_link/2 for hard timeout state" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    # dummy replaying fn with count as argument
+
+    replaying_fn = fn count ->
+      count
+    end
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
+
+    Process.sleep(@sleep_timeout)
+    assert false == Process.alive?(pid)
+  end
+
+  test "start_link/2 for soft timeout state" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    me = self()
+
+    replaying_fn = fn count ->
+      send(me, :replay)
+      count
+    end
+
+    {pub1, _} = Crypto.derive_keypair("node1", 0)
+    {pub2, _} = Crypto.derive_keypair("node2", 0)
+    {pub3, _} = Crypto.derive_keypair("node3", 0)
+    {pub4, _} = Crypto.derive_keypair("node4", 0)
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      authorized?: true,
+      last_public_key: pub1,
+      first_public_key: pub1,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      enrollment_date: DateTime.utc_now(),
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub2,
+      last_public_key: pub2,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub3,
+      last_public_key: pub3,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub4,
+      last_public_key: pub4,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
+
+    MockDB
+    |> stub(:transaction_exists?, fn ^address ->
+      false
+    end)
+
+    #  first soft_timeout
+    assert true == Process.alive?(pid)
+    assert_receive :replay, @sleep_timeout
+    # second soft_timeout
+    assert_receive :replay, @sleep_timeout
+    assert true == Process.alive?(pid)
+    # third soft_timeout
+    assert_receive :replay, @sleep_timeout
+    assert true == Process.alive?(pid)
+    # last timeout leading to stop as hard_timeout
+    Process.sleep(@sleep_timeout)
+    assert false == Process.alive?(pid)
+  end
+
+  test "should not retry if the transaction exists" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    me = self()
+
+    replaying_fn = fn _count ->
+      send(me, :replay)
+    end
+
+    {pub1, _} = Crypto.derive_keypair("node1", 0)
+    {pub2, _} = Crypto.derive_keypair("node2", 0)
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      authorized?: true,
+      last_public_key: pub1,
+      first_public_key: pub1,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      enrollment_date: DateTime.utc_now(),
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub2,
+      last_public_key: pub2,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
+
+    MockDB
+    |> stub(:transaction_exists?, fn ^address ->
+      Process.send_after(me, :transaction_stored, 50)
+      true
+    end)
+
+    #  first soft_timeout
+    assert_receive :transaction_stored, @sleep_timeout
+    assert !Process.alive?(pid)
+  end
+
+  test "should retry after the first timeout" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    me = self()
+
+    replaying_fn = fn _count ->
+      send(me, :replay)
+    end
+
+    {pub1, _} = Crypto.derive_keypair("node1", 0)
+    {pub2, _} = Crypto.derive_keypair("node2", 0)
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      authorized?: true,
+      last_public_key: pub1,
+      first_public_key: pub1,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      enrollment_date: DateTime.utc_now(),
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub2,
+      last_public_key: pub2,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
+
+    MockDB
+    |> expect(:transaction_exists?, fn ^address ->
+      false
+    end)
+    |> expect(:transaction_exists?, fn ^address ->
+      Process.send_after(me, :transaction_stored, 50)
+      true
+    end)
+
+    assert_receive :replay, @sleep_timeout
+    assert_receive :transaction_stored, @sleep_timeout
+    assert !Process.alive?(pid)
+  end
+
+  test "should run all the nodes to force the retry" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    me = self()
+
+    replaying_fn = fn _count ->
+      send(me, :replay)
+    end
+
+    {pub1, _} = Crypto.derive_keypair("node1", 0)
+    {pub2, _} = Crypto.derive_keypair("node2", 0)
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      authorized?: true,
+      last_public_key: pub1,
+      first_public_key: pub1,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      enrollment_date: DateTime.utc_now(),
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub2,
+      last_public_key: pub2,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
+
+    MockDB
+    |> stub(:transaction_exists?, fn ^address ->
+      false
+    end)
+
+    assert_receive :replay, @sleep_timeout
+    Process.sleep(@sleep_timeout)
+    assert !Process.alive?(pid)
+  end
+
+  test "should not retry if the transaction is in mining process" do
+    address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+    me = self()
+
+    replaying_fn = fn _count ->
+      send(me, :replay)
+    end
+
+    {pub1, _} = Crypto.derive_keypair("node1", 0)
+    {pub2, _} = Crypto.derive_keypair("node2", 0)
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      authorized?: true,
+      last_public_key: pub1,
+      first_public_key: pub1,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      enrollment_date: DateTime.utc_now(),
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: pub2,
+      last_public_key: pub2,
+      authorized?: true,
+      available?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+      enrollment_date: DateTime.utc_now()
+    })
+
+    {:ok, pid} = DetectNodeResponsiveness.start_link(address, replaying_fn, @timeout)
+
+    MockDB
+    |> stub(:transaction_exists?, fn ^address ->
+      false
+    end)
+
+    Registry.register(WorkflowRegistry, address, [])
+
+    #  first soft_timeout
+    Process.sleep(@sleep_timeout)
+    assert !Process.alive?(pid)
+  end
+end


### PR DESCRIPTION
# Description

If a node start just before a slot time and finish its bootstrap after the slot time, the first slot created will have a wrong slot_time ad causes this error during beacon summary : 

![image](https://user-images.githubusercontent.com/26260538/177603754-3dcf3d60-c4a1-430e-bbf6-89bb2ae46e69.png)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Add a `Process.sleep()` before starting bootstrap and run a node before a slot time (every 10 sec in dev mode).
It now do not fall in error during the beacon summary

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
