### PR TITLE
Update client connection when receive a request

### DIFF
--- a/lib/archethic/p2p/client.ex
+++ b/lib/archethic/p2p/client.ex
@@ -22,4 +22,6 @@ defmodule Archethic.P2P.Client do
               {:ok, Message.response()}
               | {:error, :timeout}
               | {:error, :closed}
+
+  @callback set_connected(Crypto.key()) :: :ok
 end

--- a/lib/archethic/p2p/client/default_impl.ex
+++ b/lib/archethic/p2p/client/default_impl.ex
@@ -66,4 +66,13 @@ defmodule Archethic.P2P.Client.DefaultImpl do
       end
     end
   end
+
+  @doc """
+  When receiving a message from a node, we set it connected
+  """
+  @impl Client
+  @spec set_connected(Crypto.key()) :: :ok
+  def set_connected(node_public_key) do
+    Connection.set_connected(node_public_key)
+  end
 end

--- a/lib/archethic/p2p/listener_protocol/broadway_pipeline.ex
+++ b/lib/archethic/p2p/listener_protocol/broadway_pipeline.ex
@@ -7,6 +7,7 @@ defmodule Archethic.P2P.ListenerProtocol.BroadwayPipeline do
   alias Archethic.P2P.MemTable
   alias Archethic.P2P.Message
   alias Archethic.P2P.MessageEnvelop
+  alias Archethic.P2P.Client
 
   alias Broadway.Message, as: BroadwayMessage
 
@@ -59,6 +60,7 @@ defmodule Archethic.P2P.ListenerProtocol.BroadwayPipeline do
     } = MessageEnvelop.decode(data)
 
     MemTable.increase_node_availability(sender_public_key)
+    Client.set_connected(sender_public_key)
     {System.monotonic_time(:millisecond), message_id, message, sender_public_key}
   end
 


### PR DESCRIPTION
# Description

Sometimes when a node disconnect and reconnect, the state of connection is not set to `:connected` before a node try to send message to it and so message falls in error because the node thinks that the other node is not connected.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run 2 nodes, disconnect one and reconnect it just after, we should not see message `Cannot send message ...... :closed` after the node is reconnected

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
