### PR TITLE
Improve P2P

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -103,6 +103,9 @@ config :archethic, Archethic.P2P.Listener,
   transport: :tcp,
   port: 3002
 
+# Floor upload speed in bytes/sec (1Mb/sec -> 0.125MB/s)
+config :archethic, Archethic.P2P.Message, floor_upload_speed: 125_000
+
 config :archethic, Archethic.SelfRepair.Sync, last_sync_file: "p2p/last_sync"
 
 # Configure the endpoint

--- a/config/config.exs
+++ b/config/config.exs
@@ -120,7 +120,7 @@ config :archethic, ArchethicWeb.Endpoint,
 
 config :archethic, Archethic.Mining.DistributedWorkflow,
   global_timeout: 60_000,
-  coordinator_notification_timeout: 5_000,
+  coordinator_timeout_supplement: 2_000,
   context_notification_timeout: 3_000
 
 config :archethic, Archethic.OracleChain,

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -951,12 +951,17 @@ defmodule Archethic.Mining.DistributedWorkflow do
           1
 
         previous_transaction ->
-          {:ok, chain_size} = Archethic.get_transaction_chain_length(previous_transaction.address)
+          # Get transaction chain size to calculate timeout
+          case Archethic.get_transaction_chain_length(previous_transaction.address) do
+            {:ok, chain_size} ->
+              chain_size
 
-            if chain_size <= 0, do: 1, else: chain_size
+            _ ->
+              1
+          end
       end
 
-    timeout = Message.get_max_timeout() * chain_size
+    timeout = Message.get_max_timeout() + Message.get_max_timeout() * chain_size
 
     validated_tx = ValidationContext.get_validated_transaction(context)
 

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -127,13 +127,12 @@ defmodule Archethic.Mining.DistributedWorkflow do
     GenStateMachine.cast(pid, {:add_cross_validation_stamp, stamp})
   end
 
-  defp get_context_timeout(type) when type == :hosting, do: Message.get_max_timeout()
-  defp get_context_timeout(type) when type == :oracle, do: @context_notification_timeout + 1_000
+  defp get_context_timeout(:hosting), do: Message.get_max_timeout()
+  defp get_context_timeout(:oracle), do: @context_notification_timeout + 1_000
   defp get_context_timeout(_type), do: @context_notification_timeout
 
-  defp get_coordinator_timeout(type) do
-    get_context_timeout(type) + @coordinator_timeout_supplement
-  end
+  defp get_coordinator_timeout(type),
+    do: get_context_timeout(type) + @coordinator_timeout_supplement
 
   defp get_mining_timeout(type) when type == :hosting, do: @mining_timeout * 3
   defp get_mining_timeout(_type), do: @mining_timeout

--- a/lib/archethic/mining/transaction_context.ex
+++ b/lib/archethic/mining/transaction_context.ex
@@ -130,8 +130,7 @@ defmodule Archethic.Mining.TransactionContext do
         fn node_public_key ->
           {node_public_key, P2P.send_message(node_public_key, %Ping{}, 500)}
         end,
-        on_timeout: :kill_task,
-        timeout: 500
+        on_timeout: :kill_task
       )
       |> Stream.filter(&match?({:ok, _}, &1))
       |> Enum.map(fn

--- a/lib/archethic/mining/transaction_context.ex
+++ b/lib/archethic/mining/transaction_context.ex
@@ -10,6 +10,7 @@ defmodule Archethic.Mining.TransactionContext do
   alias Archethic.Election
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message
   alias Archethic.P2P.Message.Ok
   alias Archethic.P2P.Message.Ping
   alias Archethic.P2P.Node
@@ -61,7 +62,7 @@ defmodule Archethic.Mining.TransactionContext do
     utxo_task = request_utxo(previous_address, unspent_outputs_nodes_split)
     nodes_view_task = request_nodes_view(node_public_keys)
 
-    prev_tx = Task.await(prev_tx_task)
+    prev_tx = Task.await(prev_tx_task, Message.get_max_timeout())
     utxos = Task.await(utxo_task)
     nodes_view = Task.await(nodes_view_task)
 

--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -42,9 +42,6 @@ defmodule Archethic.P2P.Client.Connection do
     receive do
       {^ref, msg} ->
         msg
-    after
-      timeout ->
-        {:error, :timeout}
     end
   end
 
@@ -242,11 +239,13 @@ defmodule Archethic.P2P.Client.Connection do
         data = %{node_public_key: node_public_key}
       ) do
     case pop_in(data, [:messages, msg_id]) do
-      {%{message_name: message_name}, new_data} ->
+      {%{from: from, ref: ref, message_name: message_name}, new_data} ->
         Logger.debug("Message #{message_name} reaches its timeout",
           node: Base.encode16(node_public_key),
           message_id: msg_id
         )
+
+        send(from, {ref, {:error, :timeout}})
 
         {:keep_state, new_data}
 

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -155,14 +155,23 @@ defmodule Archethic.P2P.Message do
   @doc """
   Return timeout depending of message type
   """
+  @spec get_timeout(__MODULE__.t()) :: non_neg_integer()
   def get_timeout(message) do
     full_size_message = [GetTransaction, GetLastTransaction]
 
     if message.__struct__ in full_size_message do
-      trunc(@content_max_size / @floor_upload_speed * 1_000)
+      get_max_timeout()
     else
       3_000
     end
+  end
+
+  @doc """
+  Return the maximum timeout for a full sized transaction
+  """
+  @spec get_max_timeout() :: non_neg_integer()
+  def get_max_timeout() do
+    trunc(@content_max_size / @floor_upload_speed * 1_000)
   end
 
   @doc """

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -129,7 +129,6 @@ defmodule Archethic.P2P.Message do
           | EncryptedStorageNonce.t()
           | BootstrappingNodes.t()
           | P2PView.t()
-          | Transaction.t()
           | TransactionSummary.t()
           | LastTransactionAddress.t()
           | FirstPublicKey.t()
@@ -140,6 +139,9 @@ defmodule Archethic.P2P.Message do
           | BeaconSummaryList.t()
           | FirstAddress.t()
 
+  @floor_upload_speed Application.compile_env!(:archethic, [__MODULE__, :floor_upload_speed])
+  @content_max_size Application.compile_env!(:archethic, :transaction_data_content_max_size)
+
   @doc """
   Extract the Message Struct name
   """
@@ -148,6 +150,19 @@ defmodule Archethic.P2P.Message do
     message.__struct__
     |> Module.split()
     |> List.last()
+  end
+
+  @doc """
+  Return timeout depending of message type
+  """
+  def get_timeout(message) do
+    full_size_message = [GetTransaction, GetLastTransaction]
+
+    if message.__struct__ in full_size_message do
+      trunc(@content_max_size / @floor_upload_speed * 1_000)
+    else
+      3_000
+    end
   end
 
   @doc """

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -20,6 +20,7 @@ defmodule Archethic.Replication do
   alias Archethic.Election
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message
   alias Archethic.P2P.Message.NotifyLastTransactionAddress
 
   alias Archethic.P2P.Node
@@ -256,7 +257,7 @@ defmodule Archethic.Replication do
 
     t2 = Task.Supervisor.async(TaskSupervisor, fn -> fetch_inputs(tx) end)
 
-    previous_transaction = Task.await(t1)
+    previous_transaction = Task.await(t1, Message.get_max_timeout())
     inputs = Task.await(t2)
 
     Logger.debug("Previous transaction #{inspect(previous_transaction)}",

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -11,6 +11,8 @@ defmodule Archethic.SelfRepair.Sync do
 
   alias Archethic.P2P
   alias Archethic.P2P.Node
+  alias Archethic.P2P.Message
+  alias Archethic.P2P.Message.GetTransaction
 
   alias __MODULE__.TransactionHandler
 
@@ -171,7 +173,8 @@ defmodule Archethic.SelfRepair.Sync do
       TaskSupervisor,
       transaction_summaries,
       &TransactionHandler.download_transaction(&1, node_patch),
-      on_timeout: :kill_task
+      on_timeout: :kill_task,
+      timeout: Message.get_timeout(GetTransaction)
     )
     |> Stream.filter(&match?({:ok, _}, &1))
     |> Stream.each(fn {:ok, tx} ->

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -12,7 +12,6 @@ defmodule Archethic.SelfRepair.Sync do
   alias Archethic.P2P
   alias Archethic.P2P.Node
   alias Archethic.P2P.Message
-  alias Archethic.P2P.Message.GetTransaction
 
   alias __MODULE__.TransactionHandler
 
@@ -174,7 +173,7 @@ defmodule Archethic.SelfRepair.Sync do
       transaction_summaries,
       &TransactionHandler.download_transaction(&1, node_patch),
       on_timeout: :kill_task,
-      timeout: Message.get_timeout(GetTransaction)
+      timeout: Message.get_max_timeout()
     )
     |> Stream.filter(&match?({:ok, _}, &1))
     |> Stream.each(fn {:ok, tx} ->

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -686,10 +686,16 @@ defmodule Archethic.TransactionChain do
     end
 
     # Get transaction chain size to calculate timeout
-    {:ok, chain_size} = Archethic.get_transaction_chain_length(address)
-    chain_size = if chain_size == 0, do: 1, else: chain_size
+    chain_size =
+      case Archethic.get_transaction_chain_length(address) do
+        {:ok, chain_size} ->
+          chain_size
 
-    timeout = Message.get_max_timeout() * chain_size
+        _ ->
+          1
+      end
+
+    timeout = Message.get_max_timeout() + Message.get_max_timeout() * chain_size
 
     case P2P.quorum_read(
            nodes,

--- a/test/archethic/bootstrap/network_init_test.exs
+++ b/test/archethic/bootstrap/network_init_test.exs
@@ -14,6 +14,8 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
   alias Archethic.Bootstrap.NetworkInit
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message.GetTransactionChainLength
+  alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.GetLastTransactionAddress
   alias Archethic.P2P.Message.GetTransaction
   alias Archethic.P2P.Message.GetTransactionChain
@@ -148,6 +150,9 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
 
       _, %GetTransactionInputs{}, _ ->
         {:ok, %TransactionInputList{inputs: inputs}}
+
+      _, %GetTransactionChainLength{}, _ ->
+        %TransactionChainLength{length: 1}
     end)
 
     Crypto.generate_deterministic_keypair("daily_nonce_seed")
@@ -201,6 +206,9 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
 
       _, %GetTransactionInputs{}, _ ->
         {:ok, %TransactionInputList{inputs: []}}
+
+      _, %GetTransactionChainLength{}, _ ->
+        %TransactionChainLength{length: 1}
     end)
 
     me = self()
@@ -252,6 +260,9 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
 
       _, %GetLastTransactionAddress{address: address}, _ ->
         {:ok, %LastTransactionAddress{address: address}}
+
+      _, %GetTransactionChainLength{}, _ ->
+        %TransactionChainLength{length: 1}
     end)
 
     P2P.add_and_connect_node(%Node{
@@ -294,6 +305,9 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
 
       _, %GetLastTransactionAddress{address: address}, _ ->
         {:ok, %LastTransactionAddress{address: address}}
+
+      _, %GetTransactionChainLength{}, _ ->
+        %TransactionChainLength{length: 1}
     end)
 
     network_pool_seed = :crypto.strong_rand_bytes(32)
@@ -335,6 +349,9 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
 
       _, %GetLastTransactionAddress{address: address}, _ ->
         {:ok, %LastTransactionAddress{address: address}}
+
+      _, %GetTransactionChainLength{}, _ ->
+        %TransactionChainLength{length: 1}
     end)
 
     me = self()

--- a/test/archethic/bootstrap/sync_test.exs
+++ b/test/archethic/bootstrap/sync_test.exs
@@ -10,6 +10,8 @@ defmodule Archethic.Bootstrap.SyncTest do
   alias Archethic.Crypto
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message.GetTransactionChainLength
+  alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.EncryptedStorageNonce
   alias Archethic.P2P.Message.GetLastTransactionAddress
   alias Archethic.P2P.Message.GetStorageNonce
@@ -56,6 +58,9 @@ defmodule Archethic.Bootstrap.SyncTest do
 
       _, %GetTransactionChain{}, _ ->
         {:ok, %TransactionList{transactions: []}}
+
+      _, %GetTransactionChainLength{}, _ ->
+        %TransactionChainLength{length: 1}
     end)
 
     :ok

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -10,6 +10,8 @@ defmodule Archethic.BootstrapTest do
 
   alias Archethic.P2P
   alias Archethic.P2P.BootstrappingSeeds
+  alias Archethic.P2P.Message.GetTransactionChainLength
+  alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.BootstrappingNodes
   alias Archethic.P2P.Message.EncryptedStorageNonce
   alias Archethic.P2P.Message.GetBootstrappingNodes
@@ -75,6 +77,9 @@ defmodule Archethic.BootstrapTest do
 
         _, %NotifyEndOfNodeSync{}, _ ->
           {:ok, %Ok{}}
+
+        _, %GetTransactionChainLength{}, _ ->
+          %TransactionChainLength{length: 1}
       end)
 
       {:ok, daily_nonce_agent} = Agent.start_link(fn -> %{} end)

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -907,4 +907,9 @@ defmodule Archethic.P2P.MessageTest do
                |> elem(0)
     end
   end
+
+  test "get_timeout should return timeout according to message type" do
+    assert 3_000 == Message.get_timeout(%GetBalance{address: "123"})
+    assert 25_165 == Message.get_timeout(%GetTransaction{address: "123"})
+  end
 end

--- a/test/archethic/replication/transaction_context_test.exs
+++ b/test/archethic/replication/transaction_context_test.exs
@@ -6,6 +6,8 @@ defmodule Archethic.Replication.TransactionContextTest do
   alias Archethic.Crypto
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message.GetTransactionChainLength
+  alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.GetTransaction
   alias Archethic.P2P.Message.GetTransactionChain
   alias Archethic.P2P.Message.GetTransactionInputs
@@ -44,8 +46,12 @@ defmodule Archethic.Replication.TransactionContextTest do
 
   test "stream_transaction_chain/1 should retrieve the previous transaction chain" do
     MockClient
-    |> stub(:send_message, fn _, %GetTransactionChain{}, _ ->
-      {:ok, %TransactionList{transactions: [%Transaction{}]}}
+    |> stub(:send_message, fn
+      _, %GetTransactionChain{}, _ ->
+        {:ok, %TransactionList{transactions: [%Transaction{}]}}
+
+      _, %GetTransactionChainLength{}, _ ->
+        %TransactionChainLength{length: 1}
     end)
 
     P2P.add_and_connect_node(%Node{

--- a/test/archethic/replication_test.exs
+++ b/test/archethic/replication_test.exs
@@ -8,6 +8,8 @@ defmodule Archethic.ReplicationTest do
   alias Archethic.Mining.Fee
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message.GetTransactionChainLength
+  alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.GetTransaction
   alias Archethic.P2P.Message.GetTransactionChain
   alias Archethic.P2P.Message.GetTransactionInputs
@@ -94,6 +96,9 @@ defmodule Archethic.ReplicationTest do
 
       _, %GetTransaction{}, _ ->
         {:ok, %NotFound{}}
+
+      _, %GetTransactionChainLength{}, _ ->
+        %TransactionChainLength{length: 1}
     end)
 
     assert :ok = Replication.validate_and_store_transaction_chain(tx, [])

--- a/test/archethic/self_repair/sync/transaction_handler_test.exs
+++ b/test/archethic/self_repair/sync/transaction_handler_test.exs
@@ -8,6 +8,8 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
   alias Archethic.Crypto
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message.GetTransactionChainLength
+  alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.GetTransaction
   alias Archethic.P2P.Message.GetTransactionChain
   alias Archethic.P2P.Message.GetTransactionInputs
@@ -147,6 +149,9 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
 
       _, %GetTransactionChain{}, _ ->
         {:ok, %TransactionList{transactions: []}}
+
+      _, %GetTransactionChainLength{}, _ ->
+        %TransactionChainLength{length: 1}
     end)
 
     MockDB

--- a/test/archethic/self_repair/sync_test.exs
+++ b/test/archethic/self_repair/sync_test.exs
@@ -12,6 +12,8 @@ defmodule Archethic.SelfRepair.SyncTest do
   alias Archethic.Election
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message.GetTransactionChainLength
+  alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.BeaconSummaryList
   alias Archethic.P2P.Message.GetBeaconSummaries
   alias Archethic.P2P.Message.GetTransaction
@@ -246,6 +248,9 @@ defmodule Archethic.SelfRepair.SyncTest do
 
         _, %GetTransactionChain{}, _ ->
           {:ok, %TransactionList{transactions: []}}
+
+        _, %GetTransactionChainLength{}, _ ->
+          %TransactionChainLength{length: 1}
       end)
 
       MockDB
@@ -320,6 +325,9 @@ defmodule Archethic.SelfRepair.SyncTest do
 
         _, %GetUnspentOutputs{}, _ ->
           {:ok, %UnspentOutputList{unspent_outputs: inputs}}
+
+        _, %GetTransactionChainLength{}, _ ->
+          %TransactionChainLength{length: 1}
       end)
 
       MockDB

--- a/test/archethic/transaction_chain_test.exs
+++ b/test/archethic/transaction_chain_test.exs
@@ -157,13 +157,17 @@ defmodule Archethic.TransactionChainTest do
       Enum.each(nodes, &P2P.add_and_connect_node/1)
 
       MockClient
-      |> stub(:send_message, fn _, %GetTransactionChain{address: _}, _ ->
-        {:ok,
-         %TransactionList{
-           transactions: [
-             %Transaction{}
-           ]
-         }}
+      |> stub(:send_message, fn
+        _, %GetTransactionChain{address: _}, _ ->
+          {:ok,
+           %TransactionList{
+             transactions: [
+               %Transaction{}
+             ]
+           }}
+
+        _, %GetTransactionChainLength{}, _ ->
+          %TransactionChainLength{length: 1}
       end)
 
       assert 1 =
@@ -226,6 +230,9 @@ defmodule Archethic.TransactionChainTest do
              ],
              more?: false
            }}
+
+        _, %GetTransactionChainLength{}, _ ->
+          %TransactionChainLength{length: 1}
       end)
 
       assert 5 =

--- a/test/archethic_test.exs
+++ b/test/archethic_test.exs
@@ -296,14 +296,18 @@ defmodule ArchethicTest do
       })
 
       MockClient
-      |> expect(:send_message, fn _, %GetTransactionChain{}, _ ->
-        {:ok,
-         %TransactionList{
-           transactions: [
-             %Transaction{address: "@Alice2"},
-             %Transaction{address: "@Alice1"}
-           ]
-         }}
+      |> stub(:send_message, fn
+        _, %GetTransactionChain{}, _ ->
+          {:ok,
+           %TransactionList{
+             transactions: [
+               %Transaction{address: "@Alice2"},
+               %Transaction{address: "@Alice1"}
+             ]
+           }}
+
+        _, %GetTransactionChainLength{}, _ ->
+          %TransactionChainLength{length: 1}
       end)
 
       assert {:ok, [%Transaction{address: "@Alice2"}, %Transaction{address: "@Alice1"}]} =

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -9,6 +9,8 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
   alias Archethic.BeaconChain.ReplicationAttestation
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message.GetTransactionChainLength
+  alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.Balance
   alias Archethic.P2P.Message.GetBalance
   alias Archethic.P2P.Message.GetLastTransactionAddress
@@ -210,13 +212,17 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
         end)
 
       MockClient
-      |> stub(:send_message, fn _, %GetTransactionChain{}, _ ->
-        slice_range = 1..@transaction_chain_page_size
+      |> stub(:send_message, fn
+        _, %GetTransactionChain{}, _ ->
+          slice_range = 1..@transaction_chain_page_size
 
-        {:ok,
-         %TransactionList{
-           transactions: Enum.slice(transactions, slice_range)
-         }}
+          {:ok,
+           %TransactionList{
+             transactions: Enum.slice(transactions, slice_range)
+           }}
+
+        _, %GetTransactionChainLength{}, _ ->
+          %TransactionChainLength{length: 1}
       end)
 
       last_addr = List.last(transactions).address
@@ -246,11 +252,15 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
       slice_range = @transaction_chain_page_size..(2 * @transaction_chain_page_size)
 
       MockClient
-      |> stub(:send_message, fn _, %GetTransactionChain{}, _ ->
-        {:ok,
-         %TransactionList{
-           transactions: Enum.slice(transactions, slice_range)
-         }}
+      |> stub(:send_message, fn
+        _, %GetTransactionChain{}, _ ->
+          {:ok,
+           %TransactionList{
+             transactions: Enum.slice(transactions, slice_range)
+           }}
+
+        _, %GetTransactionChainLength{}, _ ->
+          %TransactionChainLength{length: 1}
       end)
 
       last_addr = List.last(transactions).address


### PR DESCRIPTION
# Description

During mining process, there is several request to get a previous transaction or a the while tranaction chain.
Request and mining process have some timeout of 3sec.
But transactions can have a maximum size of 3MB and if the node connection is low (especially in upload), send 3MB can take more time than 3 sec

So to avoid te timeout behavior for low connection speed, we can dynamically adapt the timeout depending on the maximum request size expected.

Fixes poart of #425 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To simulate low connection, we can update the connection.ex file with this on line 299: 
```
time = trunc(byte_size(msg) / @floor_upload_speed * 1_000)
Process.send_after(from, {ref, {:ok, message}}, time)
# send(from, {ref, {:ok, message}})
```
and this in top of the file
```
@floor_upload_speed Application.compile_env!(:archethic, [Message, :floor_upload_speed])
```

To test with big transaction size we can use Aeweb cli

Transaction will take a lot of time to be validated, but will not fall in timeout due to low speed connection

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
