### PR TITLE
Fix self repair error

### DIFF
--- a/lib/archethic/application.ex
+++ b/lib/archethic/application.ex
@@ -26,6 +26,7 @@ defmodule Archethic.Application do
   alias Archethic.Networking.Supervisor, as: NetworkingSupervisor
 
   alias Archethic.P2P.Supervisor, as: P2PSupervisor
+  alias Archethic.P2P.ListenerSupervisor
 
   alias Archethic.OracleChain
   alias Archethic.OracleChain.Supervisor, as: OracleChainSupervisor
@@ -69,7 +70,7 @@ defmodule Archethic.Application do
       TransactionChainSupervisor,
       CryptoSupervisor,
       ElectionSupervisor,
-      {P2PSupervisor, port: port},
+      P2PSupervisor,
       MiningSupervisor,
       BeaconChainSupervisor,
       SharedSecretsSupervisor,
@@ -79,6 +80,7 @@ defmodule Archethic.Application do
       OracleChainSupervisor,
       ContractsSupervisor,
       RewardSupervisor,
+      {ListenerSupervisor, port: port},
       WebSupervisor,
       NetworkingSupervisor,
       {Bootstrap,

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -152,6 +152,15 @@ defmodule Archethic.P2P do
   end
 
   @doc """
+  Determine if the node public key is available
+  """
+  @spec available_node?(Crypto.key()) :: boolean()
+  def available_node?(node_public_key \\ Crypto.first_node_public_key())
+      when is_binary(node_public_key) do
+    Utils.key_in_node_list?(available_nodes(), node_public_key)
+  end
+
+  @doc """
   List all the authorized nodes
   """
   @spec authorized_nodes() :: list(Node.t())

--- a/lib/archethic/p2p/listener_supervisor.ex
+++ b/lib/archethic/p2p/listener_supervisor.ex
@@ -1,0 +1,33 @@
+defmodule Archethic.P2P.ListenerSupervisor do
+  @moduledoc false
+
+  alias Archethic.P2P.BootstrappingSeeds
+  alias Archethic.P2P.Listener
+  alias Archethic.P2P.ListenerProtocol.BroadwayPipeline
+
+  alias Archethic.Utils
+
+  use Supervisor
+
+  def start_link(args \\ []) do
+    Supervisor.start_link(__MODULE__, args, name: Archethic.P2PListenerSupervisor)
+  end
+
+  def init(args) do
+    port = Keyword.fetch!(args, :port)
+
+    listener_conf = Application.get_env(:archethic, Listener, [])
+
+    bootstraping_seeds_conf = Application.get_env(:archethic, BootstrappingSeeds)
+
+    optional_children = [
+      BroadwayPipeline,
+      {Listener, Keyword.put(listener_conf, :port, port)},
+      {BootstrappingSeeds, bootstraping_seeds_conf}
+    ]
+
+    children = Utils.configurable_children(optional_children)
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/archethic/p2p/supervisor.ex
+++ b/lib/archethic/p2p/supervisor.ex
@@ -1,11 +1,8 @@
 defmodule Archethic.P2P.Supervisor do
   @moduledoc false
 
-  alias Archethic.P2P.BootstrappingSeeds
   alias Archethic.P2P.Client.ConnectionRegistry
   alias Archethic.P2P.Client.ConnectionSupervisor
-  alias Archethic.P2P.Listener
-  alias Archethic.P2P.ListenerProtocol.BroadwayPipeline
   alias Archethic.P2P.MemTable
   alias Archethic.P2P.MemTableLoader
   alias Archethic.P2P.GeoPatch.GeoIP.MaxMindDB
@@ -18,22 +15,13 @@ defmodule Archethic.P2P.Supervisor do
     Supervisor.start_link(__MODULE__, args, name: Archethic.P2PSupervisor)
   end
 
-  def init(args) do
-    port = Keyword.fetch!(args, :port)
-
-    listener_conf = Application.get_env(:archethic, Listener, [])
-
-    bootstraping_seeds_conf = Application.get_env(:archethic, BootstrappingSeeds)
-
+  def init(_args) do
     optional_children = [
       {Registry, name: ConnectionRegistry, keys: :unique},
       ConnectionSupervisor,
       MaxMindDB,
       MemTable,
-      MemTableLoader,
-      BroadwayPipeline,
-      {Listener, Keyword.put(listener_conf, :port, port)},
-      {BootstrappingSeeds, bootstraping_seeds_conf}
+      MemTableLoader
     ]
 
     children = Utils.configurable_children(optional_children)

--- a/lib/archethic/self_repair/scheduler.ex
+++ b/lib/archethic/self_repair/scheduler.ex
@@ -14,6 +14,8 @@ defmodule Archethic.SelfRepair.Scheduler do
 
   alias Archethic.Utils
 
+  alias Archethic.Bootstrap.Sync, as: BootstrapSync
+
   require Logger
 
   @doc """
@@ -106,6 +108,9 @@ defmodule Archethic.SelfRepair.Scheduler do
   end
 
   def handle_info({ref, {:ok, date}}, state) do
+    # If the node is still unavailable after self repair, we send the postpone the
+    # end of node sync message
+    if !P2P.available_node?(), do: BootstrapSync.publish_end_of_sync()
     update_last_sync_date(date)
     Process.demonitor(ref, [:flush])
     {:noreply, state}


### PR DESCRIPTION
# Description

This PR fixes 2 errors : 
- During replication, when retrieving the previous chain, Embedded_impl.write_transaction_chain is called, but this function do not retrieve the genesis chain if it exist to append the new transactions to the same file. And so mutuiple file was created for the same chain.
- If an authorized node disconnect and is globally unavailable, of it reconnect at the end of a cycle, it will send the en of node sync flag, but it will stay unavailable because it has not enough connection time in the cycle to be globally available. And so the synced flag stay to false.

Correction: 
- Retrieve the previous address to get the genesis addres if the chain
- Send the end of node sync flag until the node is available

Fixes #460 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Run 2 nodes and shut down one after it gets authorized and let the other run for a while. Then reconnect the other node and the first node shared secrets transaction should retrieve the while chain and write it in the same file and not in a new file each 10 transactions
- Run 2 nodes and shut down one after it gets authorized. Wait the node goes globally unavailable and reconnect it just before a summary time, the end of node sync should be sent on the next self repair

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
