### PR TITLE
Update database folder for prod mode

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -6,6 +6,7 @@ config :logger,
   handle_sasl_reports: true
 
 config :archethic, :mut_dir, System.get_env("ARCHETHIC_MUT_DIR", "data")
+config :archethic, :root_mut_dir, System.get_env("ARCHETHIC_ROOT_MUT_DIR", "~/aebot")
 
 config :archethic, Archethic.Bootstrap,
   reward_address: System.get_env("ARCHETHIC_REWARD_ADDRESS", "") |> Base.decode16!(case: :mixed)

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -526,7 +526,7 @@ defmodule Archethic.Utils do
   @spec mut_dir(String.t() | nonempty_list(Path.t())) :: Path.t()
   def mut_dir(path) when is_binary(path) do
     [
-      Application.app_dir(:archethic),
+      get_root_mut_dir(),
       Application.get_env(:archethic, :mut_dir),
       path
     ]
@@ -536,7 +536,7 @@ defmodule Archethic.Utils do
 
   def mut_dir(path = [_]) when is_list(path) do
     [
-      Application.app_dir(:archethic),
+      get_root_mut_dir(),
       Application.get_env(:archethic, :mut_dir) | path
     ]
     |> Path.join()
@@ -544,6 +544,13 @@ defmodule Archethic.Utils do
   end
 
   def mut_dir, do: mut_dir("")
+
+  defp get_root_mut_dir() do
+    case Application.get_env(:archethic, :root_mut_dir) do
+      nil -> Application.app_dir(:archethic)
+      dir -> dir
+    end
+  end
 
   @doc """
   Return the remaining seconds from timer


### PR DESCRIPTION
# Description

For production, we add a specific folder to store the database, by default to `~/aebot` instead of app dir

Fixes #461 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Runned a node with `MIX_ENV=prod iex -S mix`, `~/aebot/data` folder was created and fillled with datas

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
