### PR TITLE
Fix Task timeout error

### DIFF
--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -42,6 +42,9 @@ defmodule Archethic.P2P.Client.Connection do
     receive do
       {^ref, msg} ->
         msg
+    after
+      timeout ->
+        {:error, :timeout}
     end
   end
 
@@ -239,13 +242,11 @@ defmodule Archethic.P2P.Client.Connection do
         data = %{node_public_key: node_public_key}
       ) do
     case pop_in(data, [:messages, msg_id]) do
-      {%{from: from, ref: ref, message_name: message_name}, new_data} ->
+      {%{message_name: message_name}, new_data} ->
         Logger.debug("Message #{message_name} reaches its timeout",
           node: Base.encode16(node_public_key),
           message_id: msg_id
         )
-
-        send(from, {ref, {:error, :timeout}})
 
         {:keep_state, new_data}
 

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -158,7 +158,13 @@ defmodule Archethic.P2P.Message do
   """
   @spec get_timeout(__MODULE__.t()) :: non_neg_integer()
   def get_timeout(message) do
-    full_size_message = [GetTransaction, GetLastTransaction]
+    full_size_message = [
+      GetTransaction,
+      GetLastTransaction,
+      NewTransaction,
+      StartMining,
+      ReplicateTransaction
+    ]
 
     if message.__struct__ in full_size_message do
       get_max_timeout()


### PR DESCRIPTION
# Description

During mining process we start a task that ping all nodes (for network transaction) but the timeout for a request start after the request has been sent. If a node is not available and the tcp request takes to much time to be sent, the connection timeout is never started and so the task falls in timeout

Fixes #469

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Add latency for ping message -> we don't get the task timeout error anymore, but we have the warning that we cannot send a message to a node due to timeout

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
