### PR TITLE
Schedule sending of reward tokens to the node reward address

### DIFF
--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -112,7 +112,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
            }
          }
        }) do
-    case Reward.get_transfers(Reward.last_scheduling_date()) do
+    case Reward.get_transfers() do
       ^token_transfers ->
         :ok
 

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -721,7 +721,7 @@ defmodule Archethic.Mining.ValidationContext do
     initial_movements =
       tx
       |> Transaction.get_movements()
-      |> Enum.map(&{&1.to, &1})
+      |> Enum.map(&{{&1.to, &1.type}, &1})
       |> Enum.into(%{})
 
     fee =
@@ -731,14 +731,18 @@ defmodule Archethic.Mining.ValidationContext do
       )
 
     resolved_movements =
-      Enum.reduce(resolved_addresses, [], fn {to, resolved}, acc ->
-        case Map.get(initial_movements, to) do
-          nil ->
-            acc
+      Enum.reduce(resolved_addresses, [], fn
+        {to, resolved}, acc ->
+          case Map.get(initial_movements, to) do
+            nil ->
+              acc
 
-          movement ->
-            [%{movement | to: resolved} | acc]
-        end
+            movement ->
+              [%{movement | to: resolved} | acc]
+          end
+
+        _, acc ->
+          acc
       end)
 
     resolved_recipients =

--- a/lib/archethic/reward.ex
+++ b/lib/archethic/reward.ex
@@ -85,17 +85,18 @@ defmodule Archethic.Reward do
   @doc """
   Determine if the local node is the initiator of the new rewards mint
   """
-  @spec initiator?() :: boolean()
-  def initiator?(index \\ 0) do
+  @spec initiator?(binary()) :: boolean()
+  def initiator?(address, index \\ 0) do
     %Node{first_public_key: initiator_key} =
-      next_address()
+      address
       |> Election.storage_nodes(P2P.authorized_and_available_nodes())
       |> Enum.at(index)
 
     initiator_key == Crypto.first_node_public_key()
   end
 
-  defp next_address do
+  @spec next_address() :: binary()
+  def next_address do
     key_index = Crypto.number_of_network_pool_keys()
     next_public_key = Crypto.network_pool_public_key(key_index + 1)
     Crypto.derive_address(next_public_key)
@@ -164,6 +165,8 @@ defmodule Archethic.Reward do
   end
 
   defp get_node_transfers(_, network_pool_balance, 0, acc), do: {acc, network_pool_balance}
+
+  defp get_node_transfers(_, [], _, acc), do: {acc, []}
 
   @doc """
   Returns the last date of the rewards scheduling from the network pool

--- a/test/archethic/beacon_chain/subset_test.exs
+++ b/test/archethic/beacon_chain/subset_test.exs
@@ -278,13 +278,6 @@ defmodule Archethic.BeaconChain.SubsetTest do
         fee: 0
       }
 
-      send(
-        pid,
-        {:new_replication_attestation, %ReplicationAttestation{transaction_summary: tx_summary}}
-      )
-
-      me = self()
-
       MockClient
       |> stub(:send_message, fn
         _, %Ping{}, _ ->
@@ -294,6 +287,13 @@ defmodule Archethic.BeaconChain.SubsetTest do
         _, %NewBeaconTransaction{}, _ ->
           {:ok, %Ok{}}
       end)
+
+      send(
+        pid,
+        {:new_replication_attestation, %ReplicationAttestation{transaction_summary: tx_summary}}
+      )
+
+      me = self()
 
       MockDB
       |> stub(:write_transaction_at, fn

--- a/test/archethic/reward_test.exs
+++ b/test/archethic/reward_test.exs
@@ -2,7 +2,92 @@ defmodule Archethic.RewardTest do
   use ArchethicCase
   use ExUnitProperties
 
+  alias Archethic.P2P
+  alias Archethic.P2P.Node
+
   alias Archethic.Reward
+  alias Archethic.TransactionChain.TransactionData.TokenLedger.Transfer
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
+
+  alias Archethic.Account.MemTables.TokenLedger
+
+  alias Archethic.SharedSecrets.MemTables.NetworkLookup
+
+  import Mox
 
   doctest Reward
+
+  setup do
+    P2P.add_and_connect_node(%Node{
+      first_public_key: "KEY1",
+      last_public_key: "KEY1",
+      geo_patch: "AAA",
+      available?: true,
+      authorized?: true,
+      authorization_date: DateTime.utc_now(),
+      average_availability: 1.0,
+      reward_address: "ADR1"
+    })
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: "KEY2",
+      last_public_key: "KEY2",
+      geo_patch: "AAA",
+      available?: true,
+      authorized?: true,
+      authorization_date: DateTime.utc_now(),
+      average_availability: 1.0,
+      reward_address: "ADR2"
+    })
+  end
+
+  test "get_transfers should create transfer transaction" do
+    MockUCOPriceProvider
+    |> stub(:fetch, fn _pairs ->
+      {:ok, %{"eur" => 0.10, "usd" => 0.10}}
+    end)
+
+    address = :crypto.strong_rand_bytes(32)
+    token_address1 = :crypto.strong_rand_bytes(32)
+    token_address2 = :crypto.strong_rand_bytes(32)
+
+    NetworkLookup.set_network_pool_address(address)
+
+    reward_amount = Reward.validation_nodes_reward()
+
+    reward_amount2 = reward_amount - 10
+
+    unspent_outputs1 = %UnspentOutput{
+      from: :crypto.strong_rand_bytes(32),
+      amount: reward_amount * 2,
+      type: {:token, token_address1, 0}
+    }
+
+    unspent_outputs2 = %UnspentOutput{
+      from: :crypto.strong_rand_bytes(32),
+      amount: reward_amount2,
+      type: {:token, token_address2, 0}
+    }
+
+    TokenLedger.add_unspent_output(address, unspent_outputs1, DateTime.utc_now())
+    TokenLedger.add_unspent_output(address, unspent_outputs2, DateTime.utc_now())
+
+    assert [
+             %Transfer{
+               amount: 10,
+               to: "ADR1",
+               token: ^token_address1
+             },
+             %Transfer{
+               amount: ^reward_amount2,
+               to: "ADR1",
+               token: ^token_address2
+             },
+             %Transfer{
+               amount: ^reward_amount,
+               to: "ADR2",
+               token: ^token_address1
+             }
+           ] = Reward.get_transfers()
+  end
 end


### PR DESCRIPTION
# Description

After the mint reward, we send to the node reward to all authorized nodes.

Fixes #382 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

node reward transaction is sent after the mint reward one, or if there is no mint reward transaction to do the node reward tx is directly sent.

Add test in test files.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
