### PR TITLE
Schedule The Scheduler after a node boot or scheduler crash.

### DIFF
--- a/lib/archethic/beacon_chain/slot_timer.ex
+++ b/lib/archethic/beacon_chain/slot_timer.ex
@@ -14,6 +14,7 @@ defmodule Archethic.BeaconChain.SlotTimer do
   alias Archethic.Crypto
 
   alias Archethic.P2P.Node
+  alias Archethic.P2P
 
   alias Archethic.PubSub
 
@@ -96,7 +97,19 @@ defmodule Archethic.BeaconChain.SlotTimer do
 
     PubSub.register_to_node_update()
 
-    {:ok, %{interval: interval}}
+    Logger.info("Starting SlotTimer")
+
+    case Crypto.first_node_public_key() |> P2P.get_node_info() |> elem(1) do
+      %Node{authorized?: true} ->
+        Logger.info("SlotTimer scheduled during init")
+
+        {:ok, %{interval: interval, timer: schedule_new_slot(interval)}, :hibernate}
+
+      _ ->
+        Logger.info("SlotTimer scheduler waitng for Node Update Message")
+
+        {:ok, %{interval: interval}}
+    end
   end
 
   @doc false

--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -57,6 +57,7 @@ defmodule Archethic.OracleChain.Scheduler do
     summary_interval = Keyword.fetch!(args, :summary_interval)
 
     PubSub.register_to_node_update()
+    Logger.info("Starting Oracle Scheduler")
 
     current_time = DateTime.utc_now() |> DateTime.truncate(:second)
     polling_date = next_date(polling_interval, current_time)
@@ -66,6 +67,8 @@ defmodule Archethic.OracleChain.Scheduler do
       # Schedule polling for authorized node
       # This case may happen in case of process restart after crash
       {:ok, %Node{authorized?: true}} ->
+        Logger.info("Oracle Scheduler: Scheduled during init")
+
         polling_timer = schedule_new_polling(polling_date, current_time)
 
         {:ok, :ready,
@@ -79,6 +82,8 @@ defmodule Archethic.OracleChain.Scheduler do
          }}
 
       _ ->
+        Logger.info("Oracle Scheduler: waiting for Node Update Message")
+
         {:ok, :idle,
          %{
            polling_interval: polling_interval,

--- a/lib/archethic/reward/scheduler.ex
+++ b/lib/archethic/reward/scheduler.ex
@@ -14,6 +14,8 @@ defmodule Archethic.Reward.Scheduler do
 
   alias Archethic.P2P.Node
 
+  alias Archethic.P2P
+
   alias Archethic.Reward
 
   alias Archethic.Utils
@@ -36,6 +38,20 @@ defmodule Archethic.Reward.Scheduler do
   def init(args) do
     interval = Keyword.fetch!(args, :interval)
     PubSub.register_to_node_update()
+    Logger.info("Starting Reward Scheduler")
+
+    case Crypto.first_node_public_key() |> P2P.get_node_info() |> elem(1) do
+      %Node{authorized?: true, available?: true} ->
+        Logger.info("Reward Scheduler scheduled during init")
+
+        {:ok, %{interval: interval, timer: schedule(interval)}, :hibernate}
+
+      _ ->
+        Logger.info("Reward Scheduler waitng for Node Update Message")
+
+        {:ok, %{interval: interval}, :hibernate}
+    end
+
     {:ok, %{interval: interval}, :hibernate}
   end
 


### PR DESCRIPTION
Problem : 
Process affected: Reward, Slot-Timer ,  Oracle Scheduler, Node_renewal_scheduler   
`-Whenever The node is  restarted and or doing a first time boot, There is a possibility that   
 processes are not notified to by pub-sub :node_update message as they are not started yet,
 and notification was there from P2P loading nodes.

Whenever the process crashes , during re-initialisation of the process , it must check for 
whether to schedule a :node_update message depending upon authorised or not.
It was not scheduled before

There was possibility that 
`
# Description
    # When a scheduler crashes and restarts, not registered to node updates
    # After Scheduler restart we wait for 1_000 to get node updates
    # if it does we dont update :timer in the scheduler
    # it it don't we update timer
    # in  case of node boot , the p2p notifyes but
    # scheduler are not registered to node updates
    # causing schedluer to not schedule updates waiting forever for
    # waiting for node update
    # PubSub.notify_node_update(Crypto.first_node_public_key() |> P2P.get_node_info() |> elem(1))

Fixes # (#478)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
