### PR TITLE
Include UCO transfer towards burning address

### DIFF
--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -176,7 +176,6 @@ defmodule Archethic.Bootstrap.NetworkInit do
         fee: Mining.get_transaction_fee(tx, 0.07),
         transaction_movements: Transaction.get_movements(tx)
       }
-      |> LedgerOperations.add_burning_movement()
       |> LedgerOperations.from_transaction(tx)
       |> LedgerOperations.consume_inputs(tx.address, unspent_outputs)
 

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -42,6 +42,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
 
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.TransactionSummary
@@ -175,6 +176,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
       else
         resolved_addresses
         |> Enum.map(fn {_origin, resolved} -> resolved end)
+        |> Enum.concat([LedgerOperations.burning_address()])
         |> Election.io_storage_nodes(authorized_nodes)
       end
 

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -29,6 +29,7 @@ defmodule Archethic.Mining.StandaloneWorkflow do
 
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
   alias Archethic.TransactionChain.TransactionSummary
 
   require Logger
@@ -72,6 +73,7 @@ defmodule Archethic.Mining.StandaloneWorkflow do
       else
         resolved_addresses
         |> Enum.map(fn {_origin, resolved} -> resolved end)
+        |> Enum.concat([LedgerOperations.burning_address()])
         |> Election.io_storage_nodes(authorized_nodes)
       end
 

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -39,6 +39,10 @@ defmodule Archethic.TransactionChain do
   alias __MODULE__.Transaction
   alias __MODULE__.TransactionData
   alias __MODULE__.Transaction.ValidationStamp
+
+  alias __MODULE__.Transaction.ValidationStamp.LedgerOperations.TransactionMovement.Type,
+    as: TransactionMovementType
+
   alias __MODULE__.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
   alias __MODULE__.TransactionSummary
   alias __MODULE__.TransactionInput
@@ -489,7 +493,10 @@ defmodule Archethic.TransactionChain do
   Resolve all the last addresses from the transaction data
   """
   @spec resolve_transaction_addresses(Transaction.t(), DateTime.t()) ::
-          list({origin_address :: binary(), resolved_address :: binary()})
+          list(
+            {{origin_address :: binary(), type :: TransactionMovementType.t()},
+             resolved_address :: binary()}
+          )
   def resolve_transaction_addresses(
         tx = %Transaction{data: %TransactionData{recipients: recipients}},
         time = %DateTime{}

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -144,9 +144,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
           :token => %{binary() => non_neg_integer()}
         }
   def total_to_spend(%__MODULE__{transaction_movements: transaction_movements, fee: fee}) do
-    transaction_movements
-    |> Enum.reject(&(&1.to == @burning_address))
-    |> ledger_balances(%{uco: fee, token: %{}})
+    ledger_balances(transaction_movements, %{uco: fee, token: %{}})
   end
 
   defp ledger_balances(movements, acc \\ %{uco: 0, token: %{}}) do
@@ -424,9 +422,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
   def movement_addresses(%__MODULE__{
         transaction_movements: transaction_movements
       }) do
-    transaction_movements
-    |> Enum.reject(&(&1.to == @burning_address))
-    |> Enum.map(& &1.to)
+    Enum.map(transaction_movements, & &1.to)
   end
 
   @doc """
@@ -595,27 +591,6 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       transaction_movements: Enum.map(transaction_movements, &TransactionMovement.to_map/1),
       unspent_outputs: Enum.map(unspent_outputs, &UnspentOutput.to_map/1),
       fee: fee
-    }
-  end
-
-  @doc """
-  Add the movement to burn the fee
-  """
-  @spec add_burning_movement(t()) :: t()
-  def add_burning_movement(ops = %__MODULE__{}) do
-    burn_movement = get_burning_movement(ops)
-    Map.update(ops, :transaction_movements, [burn_movement], &([burn_movement] ++ &1))
-  end
-
-  @doc """
-  Get the burning transaction movement
-  """
-  @spec get_burning_movement(t()) :: TransactionMovement.t()
-  def get_burning_movement(%__MODULE__{fee: fee}) do
-    %TransactionMovement{
-      to: @burning_address,
-      amount: fee,
-      type: :UCO
     }
   end
 end

--- a/lib/archethic_web/templates/explorer/transaction_details.html.leex
+++ b/lib/archethic_web/templates/explorer/transaction_details.html.leex
@@ -52,13 +52,18 @@
                 </div>
 
                 <div :class=" tab_panel == 'tx' ? '' : 'is-hidden' ">
-                    <%= if assigns[:error] != nil and @error == :not_exists do %>
+                  <%= cond do %>
+
+                    <% @address == burning_address() -> %>
+                      <p class="subtitle is-size-5">This address is not owned by any user being the burn address</p>
+
+                    <% assigns[:error] != nil and @error == :not_exists -> %>
                         <p>The transaction does not exists yet. </p>
                         <hr />
                         <div class="mt-4 box has-background-warning-light">
                             <small>It may appear later. <br />Please retry when the transaction will be processed.</small>
                         </div>
-                    <% else %>
+                   <% true -> %>
                         <div>
                             <div class="columns mt-4">
                                 <div class="column is-2">
@@ -398,7 +403,9 @@
                                             <%= to_float(@transaction.validation_stamp.ledger_operations.fee) %>
                                             <span class="tag is-primary is-light ml-2">UCO</span>
                                             <%= if @transaction.validation_stamp.ledger_operations.fee > 0 do %>
-                                                (<%= format_full_usd_amount(@transaction.validation_stamp.ledger_operations.fee, @uco_price_at_time[:usd], @uco_price_now[:usd]) %>)
+                                              (<%= format_full_usd_amount(@transaction.validation_stamp.ledger_operations.fee, @uco_price_at_time[:usd], @uco_price_now[:usd]) %>)
+                                              <p class="is-size-7 mt-2">The fees have been transfered to the 
+                                              <%= link to: Routes.live_path(@socket, ArchethicWeb.TransactionDetailsLive, Base.encode16(Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.burning_address())) do %><span>burning address</span><% end %></p>
                                             <% end %>
                                         </p>
                                     </div>

--- a/lib/archethic_web/views/explorer_view.ex
+++ b/lib/archethic_web/views/explorer_view.ex
@@ -13,6 +13,7 @@ defmodule ArchethicWeb.ExplorerView do
   alias Archethic.P2P.Node
 
   alias Archethic.TransactionChain.TransactionSummary
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
 
   alias Archethic.Utils
 
@@ -248,4 +249,6 @@ defmodule ArchethicWeb.ExplorerView do
 
     {family, key, key_certificate}
   end
+
+  def burning_address, do: LedgerOperations.burning_address()
 end

--- a/test/archethic/bootstrap/network_init_test.exs
+++ b/test/archethic/bootstrap/network_init_test.exs
@@ -113,17 +113,12 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
 
     tx_fee = tx.validation_stamp.ledger_operations.fee
     unspent_output = 1_000_000_000_000 - (tx_fee + 500_000_000_000)
-    burning_address = LedgerOperations.burning_address()
 
     assert %Transaction{
              validation_stamp: %ValidationStamp{
                ledger_operations: %LedgerOperations{
+                 fee: ^tx_fee,
                  transaction_movements: [
-                   %TransactionMovement{
-                     to: ^burning_address,
-                     amount: ^tx_fee,
-                     type: :UCO
-                   },
                    %TransactionMovement{to: "@Alice2", amount: 500_000_000_000, type: :UCO}
                  ],
                  unspent_outputs: [

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -204,7 +204,6 @@ defmodule Archethic.Mining.ValidationContextTest do
           fee: Fee.calculate(tx, 0.07),
           transaction_movements: Transaction.get_movements(tx)
         }
-        |> LedgerOperations.add_burning_movement()
         |> LedgerOperations.from_transaction(tx)
         |> LedgerOperations.consume_inputs(tx.address, unspent_outputs),
       signature: :crypto.strong_rand_bytes(32)
@@ -225,7 +224,6 @@ defmodule Archethic.Mining.ValidationContextTest do
           fee: Fee.calculate(tx, 0.07),
           transaction_movements: Transaction.get_movements(tx)
         }
-        |> LedgerOperations.add_burning_movement()
         |> LedgerOperations.from_transaction(tx)
         |> LedgerOperations.consume_inputs(tx.address, unspent_outputs)
     }
@@ -246,7 +244,6 @@ defmodule Archethic.Mining.ValidationContextTest do
           fee: 2_020_000_000,
           transaction_movements: Transaction.get_movements(tx)
         }
-        |> LedgerOperations.add_burning_movement()
         |> LedgerOperations.consume_inputs(tx.address, unspent_outputs)
     }
     |> ValidationStamp.sign()
@@ -291,19 +288,17 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-      ledger_operations:
-        %LedgerOperations{
-          fee: Fee.calculate(tx, 0.07),
-          transaction_movements: Transaction.get_movements(tx),
-          unspent_outputs: [
-            %UnspentOutput{
-              amount: 100_000_000_000,
-              from: tx.address,
-              type: :UCO
-            }
-          ]
-        }
-        |> LedgerOperations.add_burning_movement()
+      ledger_operations: %LedgerOperations{
+        fee: Fee.calculate(tx, 0.07),
+        transaction_movements: Transaction.get_movements(tx),
+        unspent_outputs: [
+          %UnspentOutput{
+            amount: 100_000_000_000,
+            from: tx.address,
+            type: :UCO
+          }
+        ]
+      }
     }
     |> ValidationStamp.sign()
   end
@@ -322,7 +317,6 @@ defmodule Archethic.Mining.ValidationContextTest do
           fee: Fee.calculate(tx, 0.07),
           transaction_movements: Transaction.get_movements(tx)
         }
-        |> LedgerOperations.add_burning_movement()
         |> LedgerOperations.consume_inputs(tx.address, unspent_outputs),
       errors: [:contract_validation]
     }

--- a/test/archethic/replication_test.exs
+++ b/test/archethic/replication_test.exs
@@ -192,7 +192,6 @@ defmodule Archethic.ReplicationTest do
         fee: Fee.calculate(tx, 0.07)
       }
       |> LedgerOperations.consume_inputs(tx.address, unspent_outputs)
-      |> LedgerOperations.add_burning_movement()
 
     validation_stamp =
       %ValidationStamp{

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -37,7 +37,6 @@ defmodule Archethic.TransactionFactory do
         transaction_movements: Transaction.get_movements(tx)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs)
-      |> LedgerOperations.add_burning_movement()
 
     validation_stamp =
       %ValidationStamp{
@@ -74,7 +73,6 @@ defmodule Archethic.TransactionFactory do
         fee: Fee.calculate(tx, 0.07)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs)
-      |> LedgerOperations.add_burning_movement()
 
     validation_stamp =
       %ValidationStamp{
@@ -103,7 +101,6 @@ defmodule Archethic.TransactionFactory do
       %LedgerOperations{
         fee: Fee.calculate(tx, 0.07)
       }
-      |> LedgerOperations.add_burning_movement()
       |> LedgerOperations.consume_inputs(tx.address, inputs)
 
     validation_stamp = %ValidationStamp{
@@ -131,7 +128,6 @@ defmodule Archethic.TransactionFactory do
       %LedgerOperations{
         fee: Fee.calculate(tx, 0.07)
       }
-      |> LedgerOperations.add_burning_movement()
       |> LedgerOperations.consume_inputs(tx.address, inputs)
 
     validation_stamp = %ValidationStamp{
@@ -159,7 +155,6 @@ defmodule Archethic.TransactionFactory do
       %LedgerOperations{
         fee: 1_000_000_000
       }
-      |> LedgerOperations.add_burning_movement()
       |> LedgerOperations.consume_inputs(tx.address, inputs)
 
     validation_stamp =


### PR DESCRIPTION
The fee burning has been removed from the transaction movements to remove confusion between manual token burn and the fee burning.

This allows also the display of all the transactions targeting the
burning address as included as input.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #474 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Any fee should be redirected to the burning address as input
As well, we can mention burning address as UCO transfers to burn explicitly more tokens.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
