### PR TITLE
Improve loadtime beacon explorer

### DIFF
--- a/lib/archethic_web/live/chains/beacon_live.ex
+++ b/lib/archethic_web/live/chains/beacon_live.ex
@@ -233,6 +233,7 @@ defmodule ArchethicWeb.BeaconChainLive do
   defp list_transaction_from_chain(date = %DateTime{} \\ DateTime.utc_now()) do
     %Node{network_patch: patch} = P2P.get_node_info()
 
+    # reduce beacon chain load time
     node_list = P2P.authorized_nodes()
 
     ref_time = DateTime.truncate(date, :millisecond)


### PR DESCRIPTION
# Description
The beacon explorer fetches tx's locally if its not available then it fetches remote to avoid loadtime issues.
Fixes #458 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`
./comcast --device=lo --latency=200 --target-bw=1000 --packet-loss=10%
`
simulate and check the loading of tx from local
# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
