### PR TITLE
Improved beacon explorer loadtime

### DIFF
--- a/lib/archethic_web/live/chains/beacon_live.ex
+++ b/lib/archethic_web/live/chains/beacon_live.ex
@@ -256,7 +256,7 @@ defmodule ArchethicWeb.BeaconChainLive do
     end)
     |> Flow.partition(key: {:elem, 2})
     |> Flow.reduce(fn -> [] end, fn {address, _nodes, _subset}, acc ->
-      tx_chains =
+      {:ok, tx_chains} =
         try do
           Archethic.get_transaction_chain(address)
         rescue

--- a/lib/archethic_web/live/chains/beacon_live.ex
+++ b/lib/archethic_web/live/chains/beacon_live.ex
@@ -254,7 +254,7 @@ defmodule ArchethicWeb.BeaconChainLive do
 
       {address, nodes, subset}
     end)
-    |> Flow.partition(key: {:elem, 2})
+    |> Flow.partition(key: {:elem, 2}, max_demand: 50, stages: 50)
     |> Flow.reduce(fn -> [] end, fn {address, _nodes, _subset}, acc ->
       {:ok, tx_chains} =
         try do


### PR DESCRIPTION
# Description
The beacon explorer fetches tx's locally if its not available then it fetches remote to avoid loadtime issues.
Fixes #458

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?
Simulate latency and check the loading of tx's from local

`./comcast --device=lo --latency=200 --target-bw=1000 --packet-loss=10%
`
check device name in your machine using `ifconfig -a` and put the loopback device name in the above ci

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
