### PR TITLE
Resovles:Enforce resync of last network transactions after bootstrap#508 

### DIFF
--- a/lib/archethic/bootstrap.ex
+++ b/lib/archethic/bootstrap.ex
@@ -15,7 +15,9 @@ defmodule Archethic.Bootstrap do
     P2P,
     P2P.Node,
     P2P.Listener,
-    SelfRepair
+    SelfRepair,
+    TransactionChain,
+    Replication
   }
 
   require Logger
@@ -209,11 +211,70 @@ defmodule Archethic.Bootstrap do
     end
 
     Archethic.Bootstrap.NetworkConstraints.persist_genesis_address()
+    resync_network_chain()
+
     Sync.publish_end_of_sync()
     SelfRepair.start_scheduler()
 
     :persistent_term.put(:archethic_up, :up)
     Listener.listen()
+  end
+
+  def resync_network_chain() do
+    Logger.info("Enforced Resync: Started!")
+
+    if P2P.authorized_node?() && P2P.available_node?() do
+      # evict this node
+      nodes =
+        Enum.reject(
+          P2P.authorized_and_available_nodes(),
+          &(&1.first_public_key == Crypto.first_node_public_key())
+        )
+
+      do_resync_network_chain([:oracle, :node_shared_secrets], nodes)
+    end
+  end
+
+  @spec do_resync_network_chain(list(atom), list(P2P.Node.t()) | []) :: :ok
+  def do_resync_network_chain(_type_list, _nodes = []),
+    do: Logger.info("Enforce Reync of Network Txs: failure, No-Nodes")
+
+  # by type: Get gen addr, get last address (remotely  & locally)
+  # compare, if dont match, fetch last tx remotely
+  def do_resync_network_chain(type_list, nodes) when is_list(nodes) do
+    Task.Supervisor.async_stream_nolink(Archethic.TaskSupervisor, type_list, fn type ->
+      with addr when is_binary(addr) <- get_genesis_addr(type),
+           {:ok, rem_last_addr} <- TransactionChain.resolve_last_address(addr),
+           {local_last_addr, _} <- TransactionChain.get_last_address(addr),
+           false <- rem_last_addr == local_last_addr,
+           {:ok, tx} <- TransactionChain.fetch_transaction_remotely(rem_last_addr, nodes),
+           :ok <- Replication.validate_and_store_transaction_chain(tx) do
+        Logger.info("Enforced Resync: Success", transaction_type: type)
+        :ok
+      else
+        true ->
+          Logger.info("Enforced Resync: No new transaction to sync", transaction_type: type)
+          :ok
+
+        e when e in [nil, []] ->
+          Logger.debug("Enforced Resync: Transaction not available", transaction_type: type)
+          :ok
+
+        e ->
+          Logger.debug("Enforced Resync: Unexpected Error", transaction_type: type)
+          Logger.debug(e)
+      end
+    end)
+    |> Stream.run()
+  end
+
+  @spec get_genesis_addr(:node_shared_secrets | :oracle) :: binary() | nil
+  defp get_genesis_addr(:oracle) do
+    Archethic.OracleChain.get_gen_addr().current |> elem(0)
+  end
+
+  defp get_genesis_addr(:node_shared_secrets) do
+    Archethic.SharedSecrets.get_gen_addr(:node_shared_secrets)
   end
 
   defp first_initialization(

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -1,11 +1,12 @@
 defmodule Archethic.TransactionFactory do
   @moduledoc false
 
-  alias Archethic.Crypto
-
-  alias Archethic.Election
-
-  alias Archethic.Mining.Fee
+  alias Archethic.{
+    Crypto,
+    Election,
+    Mining.Fee,
+    SharedSecrets
+  }
 
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
@@ -207,5 +208,52 @@ defmodule Archethic.TransactionFactory do
       )
 
     %{tx | validation_stamp: validation_stamp, cross_validation_stamps: [cross_validation_stamp]}
+  end
+
+  @doc """
+  Creates a valid Node Shared Secrets Tx with parameters index, timestamp, prev_txn
+  """
+  @spec create_network_tx(:node_shared_secrets, keyword) ::
+          Archethic.TransactionChain.Transaction.t()
+  def create_network_tx(_type = :node_shared_secrets, opts) do
+    inputs = Keyword.get(opts, :inputs, [])
+    seed = Keyword.get(opts, :seed, "daily_nonce_seed")
+    index = Keyword.get(opts, :index)
+    timestamp = Keyword.get(opts, :timestamp)
+    aes_key = :crypto.strong_rand_bytes(32)
+    prev_txn = Keyword.get(opts, :prev_txn, [])
+
+    tx =
+      SharedSecrets.new_node_shared_secrets_transaction(
+        [Crypto.last_node_public_key()],
+        seed,
+        aes_key,
+        index
+      )
+
+    ledger_operations =
+      %LedgerOperations{
+        fee: Fee.calculate(tx, 0.07),
+        transaction_movements: Transaction.get_movements(tx)
+      }
+      |> LedgerOperations.consume_inputs(tx.address, inputs)
+
+    validation_stamp =
+      %ValidationStamp{
+        timestamp: timestamp,
+        proof_of_work: Crypto.origin_node_public_key(),
+        proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
+        proof_of_integrity: TransactionChain.proof_of_integrity([tx | prev_txn]),
+        ledger_operations: ledger_operations
+      }
+      |> ValidationStamp.sign()
+
+    cross_validation_stamp = CrossValidationStamp.sign(%CrossValidationStamp{}, validation_stamp)
+
+    %{
+      tx
+      | validation_stamp: validation_stamp,
+        cross_validation_stamps: [cross_validation_stamp]
+    }
   end
 end


### PR DESCRIPTION
# Description

If there is quick disconnection and re-connection of a (authorised and available) node, it is a possibility that it will miss some oracle and node shared secrets transactions , which results in inconsistent node state.Post Bootstrap ,we must resync  nss and oracle txs so that current node state is same as other nodes state. So during validation it will not report invalid tx

Fixes # (#508 )

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit test cases
- [x] Distributed testing with 3 nodes

## How to test?
- Start 3 nodes, wait for all of them to get authorised.
- Shutdown one of the node.
- wait for other nodes for one or two cycle of (nss ,oc) txs.
- restart the node And look of enforced re-sync in logs.
- after quick restart of that node 

![Screenshot_20220907_163030](https://user-images.githubusercontent.com/90304197/188862648-35f19975-8828-46c3-8bb8-1e93a7c17f54.png)



# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
