### PR TITLE
Fix get transaction chain lookup

### DIFF
--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -35,7 +35,12 @@ defmodule Archethic.DB do
   @callback get_last_chain_address(binary(), DateTime.t()) :: {binary(), DateTime.t()}
   @callback get_first_chain_address(binary()) :: binary()
   @callback get_first_public_key(Crypto.key()) :: binary()
-
+  @callback scan_chain(
+              genesis_address :: binary(),
+              limit_address :: binary(),
+              fields :: list(),
+              paging_state :: nil | binary()
+            ) :: Enumerable.t()
   @callback register_stats(DateTime.t(), float(), non_neg_integer(), non_neg_integer()) :: :ok
   @callback get_latest_tps() :: float()
   @callback get_latest_burned_fees() :: non_neg_integer()

--- a/lib/archethic/db/embedded_impl.ex
+++ b/lib/archethic/db/embedded_impl.ex
@@ -312,4 +312,13 @@ defmodule Archethic.DB.EmbeddedImpl do
           }
         }
   defdelegate get_last_p2p_summaries, to: P2PView, as: :get_views
+
+  @doc """
+  Read chain from the beginning until a given limit address
+  """
+  @spec scan_chain(binary(), binary(), list(), binary() | nil) ::
+          {list(Transaction.t()), boolean(), binary() | nil}
+  def scan_chain(genesis_address, limit_address, fields \\ [], paging_state \\ nil) do
+    ChainReader.scan_chain(genesis_address, limit_address, fields, paging_state, db_path())
+  end
 end

--- a/test/archethic_test.exs
+++ b/test/archethic_test.exs
@@ -10,12 +10,12 @@ defmodule ArchethicTest do
   alias Archethic.P2P
   alias Archethic.P2P.Message.Balance
   alias Archethic.P2P.Message.GetBalance
+  alias Archethic.P2P.Message.GetFirstAddress
   alias Archethic.P2P.Message.GetLastTransactionAddress
   alias Archethic.P2P.Message.GetTransaction
   alias Archethic.P2P.Message.GetTransactionChain
   alias Archethic.P2P.Message.GetTransactionChainLength
   alias Archethic.P2P.Message.GetTransactionInputs
-  alias Archethic.P2P.Message.GetFirstAddress
 
   alias Archethic.P2P.Message.FirstAddress
   alias Archethic.P2P.Message.LastTransactionAddress
@@ -300,6 +300,9 @@ defmodule ArchethicTest do
 
       MockClient
       |> stub(:send_message, fn
+        _, %GetFirstAddress{address: "@Alice2"}, _ ->
+          {:ok, %FirstAddress{address: "@Alice0"}}
+
         _, %GetTransactionChain{}, _ ->
           {:ok,
            %TransactionList{
@@ -309,12 +312,6 @@ defmodule ArchethicTest do
                %Transaction{address: "@Alice2"}
              ]
            }}
-
-        _, %GetTransactionChainLength{}, _ ->
-          %TransactionChainLength{length: 3}
-
-        _, %GetFirstAddress{}, _ ->
-          {:ok, %NotFound{}}
       end)
 
       assert {:ok,
@@ -348,116 +345,40 @@ defmodule ArchethicTest do
       })
 
       MockDB
-      |> stub(:get_last_chain_address, fn _address ->
-        {"@Alice5", DateTime.utc_now()}
-      end)
-
-      MockDB
-      |> stub(:get_transaction_chain, fn _address, _, _ ->
+      |> stub(:scan_chain, fn "@Alice0", _, _, _ ->
         {[
-           %Transaction{address: "@Alice0"},
            %Transaction{address: "@Alice1"},
            %Transaction{address: "@Alice2"},
            %Transaction{address: "@Alice3"},
-           %Transaction{address: "@Alice4"},
-           %Transaction{address: "@Alice5"}
+           %Transaction{address: "@Alice4"}
          ], false, nil}
       end)
 
       MockClient
       |> stub(:send_message, fn
-        _, %GetTransactionChain{address: "@Alice2", paging_state: "@Alice5"}, _ ->
+        _, %GetFirstAddress{address: "@Alice6"}, _ ->
+          {:ok, %FirstAddress{address: "@Alice0"}}
+
+        _, %GetTransactionChain{address: "@Alice6", paging_state: "@Alice4"}, _ ->
           {:ok,
            %TransactionList{
              transactions: [
+               %Transaction{address: "@Alice5"},
                %Transaction{address: "@Alice6"},
                %Transaction{address: "@Alice7"}
              ]
            }}
-
-        _, %GetTransactionChainLength{}, _ ->
-          %TransactionChainLength{length: 2}
-
-        _, %GetFirstAddress{}, _ ->
-          {:ok, %FirstAddress{address: "@Alice0"}}
       end)
 
       assert {:ok,
               [
-                %Transaction{address: "@Alice0"},
                 %Transaction{address: "@Alice1"},
                 %Transaction{address: "@Alice2"},
                 %Transaction{address: "@Alice3"},
                 %Transaction{address: "@Alice4"},
                 %Transaction{address: "@Alice5"},
-                %Transaction{address: "@Alice6"},
-                %Transaction{address: "@Alice7"}
-              ]} = Archethic.get_transaction_chain("@Alice2")
-    end
-
-    test "should get_transaction_chain from network when GetFirstAddress fails" do
-      P2P.add_and_connect_node(%Node{
-        ip: {127, 0, 0, 1},
-        port: 3000,
-        first_public_key: Crypto.last_node_public_key(),
-        last_public_key: Crypto.last_node_public_key(),
-        network_patch: "AAA",
-        geo_patch: "AAA"
-      })
-
-      P2P.add_and_connect_node(%Node{
-        ip: {127, 0, 0, 1},
-        port: 3000,
-        first_public_key: "key1",
-        last_public_key: "key1",
-        network_patch: "AAA",
-        geo_patch: "AAA",
-        available?: true,
-        authorized?: true,
-        authorization_date: DateTime.utc_now()
-      })
-
-      MockClient
-      |> expect(:send_message, fn _, %GetFirstAddress{}, _ ->
-        {:ok, %NotFound{}}
-      end)
-
-      MockDB
-      |> stub(:get_last_chain_address, fn address ->
-        address
-      end)
-
-      MockClient
-      |> stub(:send_message, fn
-        _, %GetTransactionChain{address: "@Alice2", paging_state: nil}, _ ->
-          {:ok,
-           %TransactionList{
-             transactions: [
-               %Transaction{address: "@Alice0"},
-               %Transaction{address: "@Alice1"},
-               %Transaction{address: "@Alice2"},
-               %Transaction{address: "@Alice3"},
-               %Transaction{address: "@Alice4"},
-               %Transaction{address: "@Alice5"}
-             ]
-           }}
-
-        _, %GetTransactionChainLength{}, _ ->
-          %TransactionChainLength{length: 6}
-
-        _, %GetFirstAddress{}, _ ->
-          {:ok, %NotFound{}}
-      end)
-
-      assert {:ok,
-              [
-                %Transaction{address: "@Alice0"},
-                %Transaction{address: "@Alice1"},
-                %Transaction{address: "@Alice2"},
-                %Transaction{address: "@Alice3"},
-                %Transaction{address: "@Alice4"},
-                %Transaction{address: "@Alice5"}
-              ]} = Archethic.get_transaction_chain("@Alice2")
+                %Transaction{address: "@Alice6"}
+              ]} = Archethic.get_transaction_chain("@Alice6")
     end
   end
 

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -38,6 +38,7 @@ defmodule ArchethicCase do
     |> stub(:write_transaction_chain, fn _ -> :ok end)
     |> stub(:get_transaction, fn _, _ -> {:error, :transaction_not_exists} end)
     |> stub(:get_transaction_chain, fn _, _, _ -> {[], false, nil} end)
+    |> stub(:scan_chain, fn _, _, _, _ -> {[], false, nil} end)
     |> stub(:list_last_transaction_addresses, fn -> [] end)
     |> stub(:add_last_transaction_address, fn _, _, _ -> :ok end)
     |> stub(:get_last_chain_address, fn addr -> {addr, DateTime.utc_now()} end)


### PR DESCRIPTION
# Description

Fix the transaction chain reading to make sure the chain is one expected, so bigger.
Since d244b1dad8562e8ec614c963527d3274529d24df, the chain was downloaded using a diff between local and remote fetch.

The problem being, if a local chain was bigger than the address of the chain requested (pointer) we would include more transaction than expected. And also we might cause database issues, because the pagination address was the latest one, which don't provide much transactions to load.

This fix makes sure we only download the right transactions until the desired transaction's address.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
