### PR TITLE
Fix dialyzer plts folder creation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -133,7 +133,9 @@ defmodule Archethic.MixProject do
       "prod.run": ["cmd  MIX_ENV=prod ARCHETHIC_CRYPTO_NODE_KEYSTORE_IMPL=SOFTWARE
       ARCHETHIC_NODE_ALLOWED_KEY_ORIGINS=SOFTWARE ARCHETHIC_NODE_IP_VALIDATION='true' iex -S mix"],
       # dry-run,
-      "run.dry": ["cmd iex -S mix run --no-start"]
+      "run.dry": ["cmd iex -S mix run --no-start"],
+      # Make sure the plts folder is created
+      dialyzer: ["cmd mkdir -p priv/plts", "dialyzer"]
     ]
   end
 end


### PR DESCRIPTION
# Description

When we install the code repository for the first time, the priv/plts folder is not created.
Hence we should create it before to run `mix dialyzer`

Fixes #524 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Clone the repository and run `mix dialyzer`.
The `priv/plts` should be created and dialyzer run without error.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
