### PR TITLE
Add API to get last oracle value

### DIFF
--- a/lib/archethic/oracle_chain.ex
+++ b/lib/archethic/oracle_chain.ex
@@ -103,13 +103,20 @@ defmodule Archethic.OracleChain do
   @spec get_uco_price(DateTime.t()) :: list({binary(), float()})
   def get_uco_price(date = %DateTime{}) do
     case MemTable.get_oracle_data("uco", date) do
-      {:ok, prices} ->
+      {:ok, prices, _} ->
         Enum.map(prices, fn {pair, price} -> {String.to_existing_atom(pair), price} end)
 
       _ ->
         [eur: 0.05, usd: 0.07]
     end
   end
+
+  @doc """
+  Get the oracle data by date for a given service
+  """
+  @spec get_oracle_data(binary(), DateTime.t()) ::
+          {:ok, map(), DateTime.t()} | {:error, :not_found}
+  defdelegate get_oracle_data(service, date), to: MemTable
 
   def config_change(changed_conf) do
     changed_conf

--- a/lib/archethic/oracle_chain/mem_table.ex
+++ b/lib/archethic/oracle_chain/mem_table.ex
@@ -52,12 +52,13 @@ defmodule Archethic.OracleChain.MemTable do
       iex> MemTable.add_oracle_data("uco", %{ "eur" => 0.02 }, ~U[2021-06-04 10:00:00Z])
       iex> MemTable.add_oracle_data("uco", %{ "eur" => 0.04 }, ~U[2021-06-04 15:00:00Z])
       iex> MemTable.get_oracle_data("uco", ~U[2021-06-04 10:10:00Z])
-      {:ok, %{ "eur" => 0.02 }}
+      {:ok, %{ "eur" => 0.02 }, ~U[2021-06-04 10:00:00Z]}
       iex> MemTable.get_oracle_data("uco", ~U[2021-06-04 20:10:40Z])
-      {:ok, %{ "eur" => 0.04 }}
+      {:ok, %{ "eur" => 0.04 }, ~U[2021-06-04 15:00:00Z]}
 
   """
-  @spec get_oracle_data(any(), DateTime.t()) :: {:ok, map()} | {:error, :not_found}
+  @spec get_oracle_data(any(), DateTime.t()) ::
+          {:ok, data :: map(), oracle_datetime :: DateTime.t()} | {:error, :not_found}
   def get_oracle_data(type, date = %DateTime{}) do
     timestamp =
       date
@@ -70,13 +71,13 @@ defmodule Archethic.OracleChain.MemTable do
           :"$end_of_table" ->
             {:error, :not_found}
 
-          key ->
+          key = {time, _} ->
             [{_, data}] = :ets.lookup(:archethic_oracle, key)
-            {:ok, data}
+            {:ok, data, DateTime.from_unix!(time)}
         end
 
       [{_, data}] ->
-        {:ok, data}
+        {:ok, data, date}
     end
   end
 end

--- a/lib/archethic/oracle_chain/mem_table_loader.ex
+++ b/lib/archethic/oracle_chain/mem_table_loader.ex
@@ -43,6 +43,16 @@ defmodule Archethic.OracleChain.MemTableLoader do
 
     content
     |> Jason.decode!()
+    |> tap(fn data ->
+      Absinthe.Subscription.publish(
+        ArchethicWeb.Endpoint,
+        %{
+          services: data,
+          timestamp: timestamp
+        },
+        oracle_update: "oracle-topic"
+      )
+    end)
     |> Enum.each(fn {service, data} ->
       MemTable.add_oracle_data(service, data, timestamp)
     end)

--- a/lib/archethic_web/graphql_schema/datetime_type.ex
+++ b/lib/archethic_web/graphql_schema/datetime_type.ex
@@ -8,5 +8,22 @@ defmodule ArchethicWeb.GraphQLSchema.DateTimeType do
   """
   scalar :timestamp do
     serialize(&DateTime.to_unix/1)
+    parse(&parse_datetime/1)
   end
+
+  defp parse_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
+    with {timestamp, ""} <- Integer.parse(value),
+         {:ok, datetime} <- DateTime.from_unix(timestamp) do
+      {:ok, datetime}
+    else
+      _ ->
+        :error
+    end
+  end
+
+  defp parse_datetime(%Absinthe.Blueprint.Input.Integer{value: value}) do
+    DateTime.from_unix(value)
+  end
+
+  defp parse_datetime(_), do: :error
 end

--- a/lib/archethic_web/graphql_schema/oracle_data.ex
+++ b/lib/archethic_web/graphql_schema/oracle_data.ex
@@ -1,0 +1,22 @@
+defmodule ArchethicWeb.GraphQLSchema.OracleData do
+  @moduledoc false
+
+  use Absinthe.Schema.Notation
+
+  @desc """
+  [OracleData] represents an oracle data.
+  """
+  object :oracle_data do
+    field(:services, :oracle_services)
+    field(:timestamp, :timestamp)
+  end
+
+  object :oracle_services do
+    field(:uco, :uco_data)
+  end
+
+  object :uco_data do
+    field(:usd, :float)
+    field(:eur, :float)
+  end
+end

--- a/test/archethic/oracle_chain/mem_table_loader_test.exs
+++ b/test/archethic/oracle_chain/mem_table_loader_test.exs
@@ -21,7 +21,7 @@ defmodule Archethic.OracleChain.MemTableLoaderTest do
                  }
                })
 
-      assert {:ok, %{"eur" => 0.02}} = MemTable.get_oracle_data("uco", DateTime.utc_now())
+      assert {:ok, %{"eur" => 0.02}, _} = MemTable.get_oracle_data("uco", DateTime.utc_now())
     end
 
     test "should load an oracle summary transaction and the related changes" do
@@ -42,7 +42,7 @@ defmodule Archethic.OracleChain.MemTableLoaderTest do
                  }
                })
 
-      assert {:ok, %{"eur" => 0.07}} =
+      assert {:ok, %{"eur" => 0.07}, _} =
                MemTable.get_oracle_data("uco", DateTime.from_unix!(1_614_677_925))
     end
   end


### PR DESCRIPTION
# Description

Provide GraphQL API for oracles:
- Subscription of the latest changes (real time with ws)
- Get the latest value of the oracle data
- Get the oracle data at a given time

Fixes #451 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

We can use the following query to get the last updates:
```graphql
subscription {
   oracleUpdate {
      services {
         uco {
            eur
         }
      }
   }
}
```

We can get latest oracle data with:

```graphql
query {
   oracleData {
      timestamp
      services {
         uco {
            eur
         }
      }
   } 
}
```

To fetch for a given date
```graphql
query {
   oracleData(timestamp: ....) {
      services {
         uco {
            eur
         }
      }
   } 
}
```

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
