### PR TITLE
Get token id in the API

### DIFF
--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -43,13 +43,14 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
     with {:ok, {:ok, genesis_address}} <- Task.yield(t1),
          {:ok,
           {:ok,
-           %{
+           definition = %{
              "name" => name,
              "supply" => supply,
              "symbol" => symbol,
-             "type" => type,
-             "properties" => properties
+             "type" => type
            }}} <- Task.yield(t2) do
+      properties = Map.get(definition, "properties", [])
+
       data_to_digest =
         case type do
           "fungible" ->

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -54,14 +54,18 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
       data_to_digest =
         case type do
           "fungible" ->
-            %{genesis_address: Base.encode16(genesis_address), name: name, symbol: symbol}
-
-          "non-fungible" ->
             %{
               genesis_address: Base.encode16(genesis_address),
               name: name,
               symbol: symbol,
               properties: properties
+            }
+
+          "non-fungible" ->
+            %{
+              genesis_address: Base.encode16(genesis_address),
+              name: name,
+              symbol: symbol
             }
         end
 

--- a/lib/archethic_web/graphql_schema/transaction_type.ex
+++ b/lib/archethic_web/graphql_schema/transaction_type.ex
@@ -239,7 +239,8 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
     field(:symbol, :string)
     field(:supply, :integer)
     field(:type, :string)
-    field(:properties, list_of(:tokenProperty))
+    field(:properties, list_of(list_of(:tokenProperty)))
+    field(:id, :string)
   end
 
   @desc """

--- a/lib/archethic_web/graphql_schema/transaction_type.ex
+++ b/lib/archethic_web/graphql_schema/transaction_type.ex
@@ -232,6 +232,7 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
   - supply: Supply of the token
   - type: Type of the token
   - properties: Properties of the token (if any)
+  - id: Unique identification of the token on the chain
   """
   object :token do
     field(:genesis, :address)


### PR DESCRIPTION
# Description

Provide an unique identification of a token for genesis address.
This make possible to host multiple tokens on the same chain while being able to identify them.

Fixes #503 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
