### PR TITLE
Verify scheduled transaction only happens once 

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -115,7 +115,7 @@ config :archethic, Archethic.Mining.PendingTransactionValidation, validate_node_
 config :archethic, Archethic.Metrics.Poller, enabled: false
 config :archethic, Archethic.Metrics.Collector, MockMetricsCollector
 
-config :archethic, Archethic.Reward.Scheduler, enabled: false
+config :archethic, Archethic.Reward.Scheduler, enabled: false, interval: "0 0 * * * * *"
 config :archethic, Archethic.Reward.MemTables.RewardTokens, enabled: false
 config :archethic, Archethic.Reward.MemTablesLoader, enabled: false
 

--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -355,16 +355,25 @@ defmodule Archethic.Mining.PendingTransactionValidation do
     end
   end
 
-  defp do_accept_transaction(%Transaction{
-         type: :oracle,
-         data: %TransactionData{
-           content: content
+  defp do_accept_transaction(
+         tx = %Transaction{
+           type: :oracle,
+           data: %TransactionData{
+             content: content
+           }
          }
-       }) do
-    if OracleChain.valid_services_content?(content) do
+       ) do
+    last_scheduling_date = OracleChain.get_last_scheduling_date(DateTime.utc_now())
+
+    with :ok <- validate_scheduling_network_tx_time(last_scheduling_date, tx),
+         true <- OracleChain.valid_services_content?(content) do
       :ok
     else
-      {:error, "Invalid oracle transaction"}
+      {:error, :time} ->
+        {:error, "Invalid oracle trigger time "}
+
+      false ->
+        {:error, "Invalid oracle transaction"}
     end
   end
 

--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -156,7 +156,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
           transaction_address: Base.encode16(tx.address)
         )
 
-        {:error, "Invalid node rewards trigger time "}
+        {:error, "Invalid node rewards trigger time"}
 
       _ ->
         {:error, "Invalid network pool transfers"}
@@ -261,7 +261,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
       :ok
     else
       {:error, :time} ->
-        {:error, "Invalid node node shared secrets trigger time "}
+        {:error, "Invalid node shared secrets trigger time"}
 
       :error ->
         {:error, "Invalid node shared secrets transaction content"}
@@ -439,7 +439,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
       :ok
     else
       {:error, :time} ->
-        {:error, "Invalid oracle trigger time "}
+        {:error, "Invalid oracle trigger time"}
 
       false ->
         {:error, "Invalid oracle transaction"}
@@ -543,8 +543,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
   defp validate_scheduling_network_tx_time(last_scheduling_date, tx) do
     case TransactionChain.get_transaction(Transaction.previous_address(tx)) do
       {:ok, %Transaction{validation_stamp: %ValidationStamp{timestamp: timestamp}}} ->
-        if DateTime.compare(timestamp, last_scheduling_date) ==
-             :gt do
+        if DateTime.compare(timestamp, last_scheduling_date) in [:gt, :eq] do
           Logger.debug(
             "Last scheduling date: #{last_scheduling_date} - Previous Tx date: #{timestamp} - Now: #{DateTime.utc_now()}"
           )

--- a/lib/archethic/oracle_chain.ex
+++ b/lib/archethic/oracle_chain.ex
@@ -149,6 +149,21 @@ defmodule Archethic.OracleChain do
   end
 
   @doc """
+  Return the previous oracle summary date
+  """
+  @spec previous_summary_date(DateTime.t()) :: DateTime.t()
+  def previous_summary_date(date_from = %DateTime{}) do
+    interval =
+      Application.get_env(:archethic, Scheduler)
+      |> Keyword.fetch!(:summary_interval)
+
+    interval
+    |> CronParser.parse!(true)
+    |> CronScheduler.get_previous_run_date!(DateTime.to_naive(date_from))
+    |> DateTime.from_naive!("Etc/UTC")
+  end
+
+  @doc """
   Get the previous polling date from the given date
   """
   @spec get_last_scheduling_date(DateTime.t()) :: DateTime.t()

--- a/lib/archethic/oracle_chain.ex
+++ b/lib/archethic/oracle_chain.ex
@@ -157,7 +157,7 @@ defmodule Archethic.OracleChain do
     naive_from_date = from_date |> DateTime.truncate(:second) |> DateTime.to_naive()
 
     if Crontab.DateChecker.matches_date?(cron_expression, naive_from_date) do
-      DateTime.truncate(from_date, :millisecond)
+      DateTime.truncate(from_date, :second)
     else
       cron_expression
       |> Crontab.Scheduler.get_previous_run_date!(naive_from_date)

--- a/lib/archethic/oracle_chain.ex
+++ b/lib/archethic/oracle_chain.ex
@@ -138,7 +138,11 @@ defmodule Archethic.OracleChain do
   """
   @spec next_summary_date(DateTime.t()) :: DateTime.t()
   def next_summary_date(date_from = %DateTime{}) do
-    Scheduler.get_summary_interval()
+    interval =
+      Application.get_env(:archethic, Scheduler)
+      |> Keyword.fetch!(:summary_interval)
+
+    interval
     |> CronParser.parse!(true)
     |> CronScheduler.get_next_run_date!(DateTime.to_naive(date_from))
     |> DateTime.from_naive!("Etc/UTC")

--- a/lib/archethic/reward.ex
+++ b/lib/archethic/reward.ex
@@ -230,11 +230,11 @@ defmodule Archethic.Reward do
 
     naive_date_from =
       date_from
-      |> DateTime.truncate(:millisecond)
+      |> DateTime.truncate(:second)
       |> DateTime.to_naive()
 
     if Crontab.DateChecker.matches_date?(cron_expression, naive_date_from) do
-      DateTime.truncate(date_from, :millisecond)
+      DateTime.truncate(date_from, :second)
     else
       cron_expression
       |> Crontab.Scheduler.get_previous_run_date!(naive_date_from)

--- a/lib/archethic/shared_secrets.ex
+++ b/lib/archethic/shared_secrets.ex
@@ -130,11 +130,11 @@ defmodule Archethic.SharedSecrets do
 
     naive_date_from =
       date_from
-      |> DateTime.truncate(:millisecond)
+      |> DateTime.truncate(:second)
       |> DateTime.to_naive()
 
     if Crontab.DateChecker.matches_date?(cron_expression, naive_date_from) do
-      DateTime.truncate(date_from, :millisecond)
+      DateTime.truncate(date_from, :second)
     else
       cron_expression
       |> Crontab.Scheduler.get_previous_run_date!(naive_date_from)

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -19,7 +19,6 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Ownership
-  alias Archethic.TransactionChain.Transaction.ValidationStamp
 
   import Mox
 
@@ -493,6 +492,9 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
       MockDB
       |> expect(:get_last_chain_address, fn _, _ ->
         {"OtherAddress", DateTime.utc_now()}
+      end)
+      |> expect(:get_transaction, fn _, _ ->
+        {:ok, %Transaction{type: :node_rewards}}
       end)
 
       tx =

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -453,13 +453,8 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
 
     test "should return error when there is already a oracle transaction since the last schedule" do
       MockDB
-      |> expect(:get_transaction, fn _, _ ->
-        {:ok,
-         %Transaction{
-           validation_stamp: %ValidationStamp{
-             timestamp: ~U[2022-01-01 00:10:00Z]
-           }
-         }}
+      |> expect(:get_last_chain_address, fn _, _ ->
+        {"OtherAddress", DateTime.utc_now()}
       end)
 
       tx = Transaction.new(:oracle, %TransactionData{}, "seed", 0)
@@ -470,13 +465,8 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
 
     test "should return error when there is already a node shared secrets transaction since the last schedule" do
       MockDB
-      |> expect(:get_transaction, fn _, _ ->
-        {:ok,
-         %Transaction{
-           validation_stamp: %ValidationStamp{
-             timestamp: ~U[2022-01-01 00:00:00Z]
-           }
-         }}
+      |> expect(:get_last_chain_address, fn _, _ ->
+        {"OtherAddress", DateTime.utc_now()}
       end)
 
       tx =
@@ -501,14 +491,8 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
 
     test "should return error when there is already a node rewards transaction since the last schedule" do
       MockDB
-      |> expect(:get_transaction, fn _, _ ->
-        {:ok,
-         %Transaction{
-           type: :node_rewards,
-           validation_stamp: %ValidationStamp{
-             timestamp: ~U[2022-01-01 00:00:00Z]
-           }
-         }}
+      |> expect(:get_last_chain_address, fn _, _ ->
+        {"OtherAddress", DateTime.utc_now()}
       end)
 
       tx =


### PR DESCRIPTION
# Description

Ensure network transactions which are scheduled to happen only once in their interval.

Fixes #421 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Start multiple nodes, at some point nodes will have different time synchronization.
Hence one might send a node shared secrets tx just after one have been already sent (until #420 is implemented)

The validation should catch it and the tx would not be validated.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
