### PR TITLE
Fix bootstrap issue

### DIFF
--- a/lib/archethic/beacon_chain.ex
+++ b/lib/archethic/beacon_chain.ex
@@ -319,11 +319,11 @@ defmodule Archethic.BeaconChain do
     |> Flow.partition(stages: System.schedulers_online() * 4, key: {:key, :summary_time})
     |> Flow.reduce(
       fn -> %{} end,
-      fn summary, acc ->
+      fn summary = %Summary{summary_time: time}, acc ->
         Map.update(
           acc,
-          summary.summary_time,
-          %SummaryAggregate{} |> SummaryAggregate.add_summary(summary),
+          time,
+          %SummaryAggregate{summary_time: time} |> SummaryAggregate.add_summary(summary),
           &SummaryAggregate.add_summary(&1, summary)
         )
       end

--- a/lib/archethic/beacon_chain.ex
+++ b/lib/archethic/beacon_chain.ex
@@ -298,7 +298,7 @@ defmodule Archethic.BeaconChain do
     authorized_nodes = P2P.authorized_and_available_nodes()
 
     list_subsets()
-    |> Flow.from_enumerable()
+    |> Flow.from_enumerable(stages: 256)
     |> Flow.flat_map(fn subset ->
       # Foreach subset and date we compute concurrently the node election
       dates
@@ -316,15 +316,22 @@ defmodule Archethic.BeaconChain do
       fetch_summaries(node, addresses)
     end)
     # We repartition by summary time to aggregate summaries for a date
-    |> Flow.partition(key: {:key, :summary_time})
+    |> Flow.partition(stages: System.schedulers_online() * 4, key: {:key, :summary_time})
     |> Flow.reduce(
-      fn -> %SummaryAggregate{} end,
-      &SummaryAggregate.add_summary(&2, &1)
+      fn -> %{} end,
+      fn summary, acc ->
+        Map.update(
+          acc,
+          summary.summary_time,
+          %SummaryAggregate{} |> SummaryAggregate.add_summary(summary),
+          &SummaryAggregate.add_summary(&1, summary)
+        )
+      end
     )
-    |> Flow.emit(:state)
+    |> Flow.on_trigger(&{Map.values(&1), &1})
     |> Stream.reject(&SummaryAggregate.empty?/1)
     |> Stream.map(&SummaryAggregate.aggregate/1)
-    |> Enum.sort_by(& &1.summary_time)
+    |> Enum.sort_by(& &1.summary_time, {:asc, DateTime})
   end
 
   defp get_summary_address_by_node(date, subset, authorized_nodes) do
@@ -341,9 +348,15 @@ defmodule Archethic.BeaconChain do
   end
 
   defp fetch_summaries(node, addresses) do
+    Logger.info(
+      "Self repair start download #{Enum.count(addresses)} summaries on node #{Base.encode16(node.first_public_key)}"
+    )
+
     addresses
     |> Stream.chunk_every(10)
-    |> Stream.flat_map(&batch_summaries_fetching(&1, node))
+    |> Task.async_stream(&batch_summaries_fetching(&1, node))
+    |> Stream.filter(&match?({:ok, _}, &1))
+    |> Stream.flat_map(&elem(&1, 1))
     |> Enum.to_list()
   end
 

--- a/lib/archethic/bootstrap.ex
+++ b/lib/archethic/bootstrap.ex
@@ -210,6 +210,8 @@ defmodule Archethic.Bootstrap do
     SelfRepair.start_scheduler()
 
     :persistent_term.put(:archethic_up, :up)
+    send(Archethic.P2P.Listener, :start_listener)
+    :ok
   end
 
   defp first_initialization(

--- a/lib/archethic/bootstrap.ex
+++ b/lib/archethic/bootstrap.ex
@@ -13,6 +13,7 @@ defmodule Archethic.Bootstrap do
 
   alias Archethic.P2P
   alias Archethic.P2P.Node
+  alias Archethic.P2P.Listener
 
   alias Archethic.SelfRepair
 
@@ -210,8 +211,7 @@ defmodule Archethic.Bootstrap do
     SelfRepair.start_scheduler()
 
     :persistent_term.put(:archethic_up, :up)
-    send(Archethic.P2P.Listener, :start_listener)
-    :ok
+    Listener.listen()
   end
 
   defp first_initialization(

--- a/lib/archethic/p2p/client.ex
+++ b/lib/archethic/p2p/client.ex
@@ -22,6 +22,4 @@ defmodule Archethic.P2P.Client do
               {:ok, Message.response()}
               | {:error, :timeout}
               | {:error, :closed}
-
-  @callback set_connected(Crypto.key()) :: :ok
 end

--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -80,6 +80,8 @@ defmodule Archethic.P2P.Client.Connection do
       ) do
     Logger.warning("Connection closed", node: Base.encode16(node_public_key))
 
+    MemTable.decrease_node_availability(node_public_key)
+
     # Notify clients the connection is lost
     # and cancel the existing timeouts
     actions =

--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -48,22 +48,6 @@ defmodule Archethic.P2P.Client.Connection do
     end
   end
 
-  @doc """
-  Set the sate to connected
-  """
-  @spec set_connected(Crypto.key()) :: :ok
-  def set_connected(public_key) do
-    GenStateMachine.cast(via_tuple(public_key), {:connect, self()})
-
-    receive do
-      :ok ->
-        :ok
-    after
-      1000 ->
-        :ok
-    end
-  end
-
   # fetch cnnoection details from registery for a node from its public key
   defp via_tuple(public_key), do: {:via, Registry, {ConnectionRegistry, public_key}}
 
@@ -126,12 +110,7 @@ defmodule Archethic.P2P.Client.Connection do
       {:ok, socket} ->
         {:next_state, {:connected, socket}, data}
 
-      {:error, reason} ->
-        Logger.debug(
-          "Error during node connection to #{:inet.ntoa(ip)}:#{port} - #{reason} ",
-          node: Base.encode16(node_public_key)
-        )
-
+      {:error, _} ->
         MemTable.decrease_node_availability(node_public_key)
         actions = [{{:timeout, :reconnect}, 500, nil}]
         {:keep_state_and_data, actions}

--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -102,8 +102,7 @@ defmodule Archethic.P2P.Client.Connection do
         data = %{
           ip: ip,
           port: port,
-          transport: transport,
-          node_public_key: node_public_key
+          transport: transport
         }
       ) do
     case transport.handle_connect(ip, port) do
@@ -111,7 +110,6 @@ defmodule Archethic.P2P.Client.Connection do
         {:next_state, {:connected, socket}, data}
 
       {:error, _} ->
-        MemTable.decrease_node_availability(node_public_key)
         actions = [{{:timeout, :reconnect}, 500, nil}]
         {:keep_state_and_data, actions}
     end

--- a/lib/archethic/p2p/client/default_impl.ex
+++ b/lib/archethic/p2p/client/default_impl.ex
@@ -69,13 +69,4 @@ defmodule Archethic.P2P.Client.DefaultImpl do
       end
     end
   end
-
-  @doc """
-  When receiving a message from a node, we set it connected
-  """
-  @impl Client
-  @spec set_connected(Crypto.key()) :: :ok
-  def set_connected(node_public_key) do
-    Connection.set_connected(node_public_key)
-  end
 end

--- a/lib/archethic/p2p/client/default_impl.ex
+++ b/lib/archethic/p2p/client/default_impl.ex
@@ -8,7 +8,6 @@ defmodule Archethic.P2P.Client.DefaultImpl do
   alias Archethic.P2P.Client.Connection
   alias Archethic.P2P.Client.ConnectionSupervisor
   alias Archethic.P2P.Client.Transport.TCPImpl
-  alias Archethic.P2P.MemTable
   alias Archethic.P2P.Message
   alias Archethic.P2P.Node
 
@@ -62,7 +61,6 @@ defmodule Archethic.P2P.Client.DefaultImpl do
             node: Base.encode16(node_public_key)
           )
 
-          MemTable.decrease_node_availability(node_public_key)
           BeaconUpdate.unsubscribe(node_public_key)
 
           {:error, reason}

--- a/lib/archethic/p2p/listener.ex
+++ b/lib/archethic/p2p/listener.ex
@@ -18,7 +18,11 @@ defmodule Archethic.P2P.Listener do
     {:ok, {transport, port}}
   end
 
-  def handle_info(:start_listener, {transport, port}) do
+  def listen() do
+    GenServer.cast(__MODULE__, :start_listener)
+  end
+
+  def handle_cast(:start_listener, {transport, port}) do
     ranch_transport =
       case transport do
         :tcp ->
@@ -46,13 +50,6 @@ defmodule Archethic.P2P.Listener do
         )
 
         System.stop(1)
-
-      {:error, {:already_started, pid}} ->
-        {:noreply, %{listener_pid: pid}}
     end
-  end
-
-  def handle_info(:start_listener, state) do
-    {:noreply, state}
   end
 end

--- a/lib/archethic/p2p/listener.ex
+++ b/lib/archethic/p2p/listener.ex
@@ -15,6 +15,10 @@ defmodule Archethic.P2P.Listener do
     transport = Keyword.get(opts, :transport)
     port = Keyword.get(opts, :port)
 
+    {:ok, {transport, port}}
+  end
+
+  def handle_info(:start_listener, {transport, port}) do
     ranch_transport =
       case transport do
         :tcp ->
@@ -34,7 +38,7 @@ defmodule Archethic.P2P.Listener do
       {:ok, listener_pid} ->
         Logger.info("P2P #{transport} Endpoint running on port #{port}")
 
-        {:ok, %{listener_pid: listener_pid}}
+        {:noreply, %{listener_pid: listener_pid}}
 
       {:error, :eaddrinuse} ->
         Logger.error(
@@ -42,6 +46,13 @@ defmodule Archethic.P2P.Listener do
         )
 
         System.stop(1)
+
+      {:error, {:already_started, pid}} ->
+        {:noreply, %{listener_pid: pid}}
     end
+  end
+
+  def handle_info(:start_listener, state) do
+    {:noreply, state}
   end
 end

--- a/lib/archethic/p2p/listener_protocol.ex
+++ b/lib/archethic/p2p/listener_protocol.ex
@@ -17,22 +17,17 @@ defmodule Archethic.P2P.ListenerProtocol do
   end
 
   def init({ref, transport, opts}) do
-    if :persistent_term.get(:archethic_up, nil) do
-      {:ok, socket} = :ranch.handshake(ref)
-      :ok = transport.setopts(socket, opts)
+    {:ok, socket} = :ranch.handshake(ref)
+    :ok = transport.setopts(socket, opts)
 
-      {:ok, {ip, port}} = :inet.peername(socket)
+    {:ok, {ip, port}} = :inet.peername(socket)
 
-      :gen_server.enter_loop(__MODULE__, [], %{
-        socket: socket,
-        transport: transport,
-        ip: ip,
-        port: port
-      })
-    else
-      # node is Bootstrapping, reject any incoming request messages
-      {:stop, :node_bootstrapping}
-    end
+    :gen_server.enter_loop(__MODULE__, [], %{
+      socket: socket,
+      transport: transport,
+      ip: ip,
+      port: port
+    })
   end
 
   def handle_info(
@@ -41,15 +36,15 @@ defmodule Archethic.P2P.ListenerProtocol do
       ) do
     :inet.setopts(socket, active: :once)
 
-    %Archethic.P2P.MessageEnvelop{
-      message_id: message_id,
-      message: message,
-      sender_public_key: sender_public_key
-    } = Archethic.P2P.MessageEnvelop.decode(msg)
-
-    Archethic.P2P.MemTable.increase_node_availability(sender_public_key)
-
     Task.Supervisor.start_child(TaskSupervisor, fn ->
+      %Archethic.P2P.MessageEnvelop{
+        message_id: message_id,
+        message: message,
+        sender_public_key: sender_public_key
+      } = Archethic.P2P.MessageEnvelop.decode(msg)
+
+      Archethic.P2P.MemTable.increase_node_availability(sender_public_key)
+
       response = Archethic.P2P.Message.process(message)
 
       encoded_response =

--- a/lib/archethic/p2p/listener_protocol.ex
+++ b/lib/archethic/p2p/listener_protocol.ex
@@ -48,7 +48,6 @@ defmodule Archethic.P2P.ListenerProtocol do
     } = Archethic.P2P.MessageEnvelop.decode(msg)
 
     Archethic.P2P.MemTable.increase_node_availability(sender_public_key)
-    Archethic.P2P.Client.set_connected(sender_public_key)
 
     Task.Supervisor.start_child(TaskSupervisor, fn ->
       response = Archethic.P2P.Message.process(message)

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -34,8 +34,6 @@ defmodule Archethic.BootstrapTest do
   alias Archethic.P2P.Message.GetFirstAddress
   alias Archethic.P2P.Message.NotFound
 
-  alias Archethic.P2P.Listener
-
   alias Archethic.Replication
 
   alias Archethic.SelfRepair.Scheduler, as: SelfRepairScheduler
@@ -60,7 +58,6 @@ defmodule Archethic.BootstrapTest do
     start_supervised!({SelfRepairScheduler, interval: "0 * * * * * *"})
     start_supervised!(BootstrappingSeeds)
     start_supervised!({NodeRenewalScheduler, interval: "0 * * * * * *"})
-    start_supervised!({Listener, transport: :tcp, port: 4000})
 
     MockDB
     |> stub(:write_transaction_chain, fn _ -> :ok end)

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -34,6 +34,8 @@ defmodule Archethic.BootstrapTest do
   alias Archethic.P2P.Message.GetFirstAddress
   alias Archethic.P2P.Message.NotFound
 
+  alias Archethic.P2P.Listener
+
   alias Archethic.Replication
 
   alias Archethic.SelfRepair.Scheduler, as: SelfRepairScheduler
@@ -58,6 +60,7 @@ defmodule Archethic.BootstrapTest do
     start_supervised!({SelfRepairScheduler, interval: "0 * * * * * *"})
     start_supervised!(BootstrappingSeeds)
     start_supervised!({NodeRenewalScheduler, interval: "0 * * * * * *"})
+    start_supervised!({Listener, transport: :tcp, port: 4000})
 
     MockDB
     |> stub(:write_transaction_chain, fn _ -> :ok end)


### PR DESCRIPTION
# Description

Fixe some error hapening on bootstrap :
- Start the tcp listener after the bootstrap to avoid connection and disconnection on the other nodes
- As now a node can send message but without starting the tcp listener, we remove the set_connected function as the node may not be connected
- Fix an error during self repair: if there is more dates to sync than CPU cores, some beacon summaries with different timestamp where aggregated together causing a crash on transaction loading

## Type of change

- Bug fix (non-breaking change which fixes an issue)

Launch a node and wait half an hour to let it generate more than 30 summaries.
Create some transfer transaction
Start a second node and the should load all the transaction sorted by timestamp

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
