### PR TITLE
Prevent scheduling network tx

### DIFF
--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -78,7 +78,8 @@ defmodule Archethic.Bootstrap.NetworkInit do
       SharedSecrets.new_node_shared_secrets_transaction(
         [Crypto.first_node_public_key()],
         daily_nonce_seed,
-        secret_key
+        secret_key,
+        0
       )
 
     tx

--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -150,7 +150,7 @@ defmodule Archethic.Bootstrap.NetworkInit do
   def init_network_reward_pool() do
     Logger.info("Create mining reward pool")
 
-    Reward.new_rewards_mint(@genesis_network_pool_amount)
+    Reward.new_rewards_mint(@genesis_network_pool_amount, 0)
     |> self_validation()
     |> self_replication()
   end

--- a/lib/archethic/oracle_chain.ex
+++ b/lib/archethic/oracle_chain.ex
@@ -12,7 +12,6 @@ defmodule Archethic.OracleChain do
   alias __MODULE__.Summary
 
   alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.Transaction.ValidationStamp
 
   alias Crontab.CronExpression.Parser, as: CronParser
   alias Crontab.Scheduler, as: CronScheduler
@@ -79,11 +78,8 @@ defmodule Archethic.OracleChain do
   Load the transaction in the memtable
   """
   @spec load_transaction(Transaction.t()) :: :ok
-  def load_transaction(
-        tx = %Transaction{type: :oracle, validation_stamp: %ValidationStamp{timestamp: timestamp}}
-      ) do
+  def load_transaction(tx = %Transaction{type: :oracle}) do
     MemTableLoader.load_transaction(tx)
-    Scheduler.ack_transaction(timestamp)
   end
 
   def load_transaction(tx = %Transaction{type: :oracle_summary}) do

--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -35,15 +35,8 @@ defmodule Archethic.OracleChain.Scheduler do
   """
   @spec get_summary_interval :: binary()
   def get_summary_interval do
-    GenStateMachine.call(__MODULE__, :summary_interval)
-  end
-
-  @doc """
-  Notify the scheduler about the replication of an oracle transaction
-  """
-  @spec ack_transaction(DateTime.t()) :: :ok
-  def ack_transaction(timestamp = %DateTime{}) do
-    GenStateMachine.cast(__MODULE__, {:inc_index, timestamp})
+    Application.get_env(:archethic, __MODULE__)
+    |> Keyword.fetch!(:summary_interval)
   end
 
   def config_change(nil), do: :ok
@@ -59,27 +52,24 @@ defmodule Archethic.OracleChain.Scheduler do
     PubSub.register_to_node_update()
     Logger.info("Starting Oracle Scheduler")
 
-    current_time = DateTime.utc_now() |> DateTime.truncate(:second)
-    polling_date = next_date(polling_interval, current_time)
-    summary_date = next_date(summary_interval, current_time)
-
     case P2P.get_node_info(Crypto.first_node_public_key()) do
       # Schedule polling for authorized node
       # This case may happen in case of process restart after crash
-      {:ok, %Node{authorized?: true}} ->
+      {:ok, %Node{authorized?: true, available?: true}} ->
         Logger.info("Oracle Scheduler: Scheduled during init")
 
-        polling_timer = schedule_new_polling(polling_date, current_time)
+        summary_date =
+          next_date(summary_interval, DateTime.utc_now() |> DateTime.truncate(:second))
 
-        {:ok, :ready,
+        PubSub.register_to_new_transaction_by_type(:oracle)
+
+        {:ok, :idle,
          %{
            polling_interval: polling_interval,
-           polling_date: polling_date,
            summary_interval: summary_interval,
            summary_date: summary_date,
-           indexes: %{summary_date => chain_size(summary_date)},
-           polling_timer: polling_timer
-         }}
+           indexes: %{summary_date => chain_size(summary_date)}
+         }, {:next_event, :internal, :schedule}}
 
       _ ->
         Logger.info("Oracle Scheduler: waiting for Node Update Message")
@@ -87,61 +77,131 @@ defmodule Archethic.OracleChain.Scheduler do
         {:ok, :idle,
          %{
            polling_interval: polling_interval,
-           polling_date: polling_date,
            summary_interval: summary_interval,
-           summary_date: summary_date,
            indexes: %{}
          }}
     end
   end
 
   def handle_event(
-        :cast,
-        {:inc_index, timestamp},
-        :ready,
-        data = %{summary_interval: summary_interval, indexes: indexes}
+        :internal,
+        :schedule,
+        _state,
+        data = %{polling_interval: polling_interval}
       ) do
-    next_summary_date = next_date(summary_interval, timestamp)
+    current_time = DateTime.utc_now() |> DateTime.truncate(:second)
+    polling_date = next_date(polling_interval, current_time)
 
-    case Map.get(indexes, next_summary_date) do
+    polling_timer =
+      case Map.get(data, :polling_timer) do
+        nil ->
+          schedule_new_polling(polling_date, current_time)
+
+        timer ->
+          Process.cancel_timer(timer)
+          schedule_new_polling(polling_date, current_time)
+      end
+
+    new_data =
+      data
+      |> Map.put(:polling_timer, polling_timer)
+      |> Map.put(:polling_date, polling_date)
+
+    {:next_state, :scheduled, new_data}
+  end
+
+  def handle_event(:internal, {:schedule_at, polling_date}, :idle, data) do
+    current_time = DateTime.utc_now() |> DateTime.truncate(:second)
+    polling_timer = schedule_new_polling(polling_date, current_time)
+
+    new_data =
+      data
+      |> Map.put(:polling_timer, polling_timer)
+      |> Map.put(:polling_date, polling_date)
+
+    {:next_state, :scheduled, new_data}
+  end
+
+  def handle_event(
+        :info,
+        {:new_transaction, address, :oracle, _timestamp},
+        :triggered,
+        data = %{summary_date: summary_date, indexes: indexes}
+      ) do
+    PubSub.unregister_to_new_transaction_by_address(address)
+
+    case Map.get(data, :oracle_watcher) do
       nil ->
-        # The scheduler is in ready (aka started) but it's not in a summary cycle
-        :keep_state_and_data
+        :ignore
 
-      index ->
-        new_data = Map.update!(data, :indexes, &Map.put(&1, next_summary_date, index + 1))
-        Logger.debug("Next state #{inspect(new_data)}")
-        {:keep_state, new_data}
+      pid ->
+        Process.exit(pid, :normal)
     end
+
+    new_data =
+      case Map.get(indexes, summary_date) do
+        nil ->
+          # The schedule is started but it's not in a summary cycle
+          data
+
+        index ->
+          # We increment the index since the tx is replicated
+          Map.update!(data, :indexes, &Map.put(&1, summary_date, index + 1))
+      end
+
+    {:next_state, :confirmed, new_data, {:next_event, :internal, :schedule}}
+  end
+
+  def handle_event(
+        :info,
+        {:new_transaction, _address, :oracle, _timestamp},
+        :scheduled,
+        data = %{summary_date: summary_date, indexes: indexes}
+      ) do
+    Logger.debug(
+      "Reschedule polling after reception of an oracle transaction in scheduled state instead of triggered state"
+    )
+
+    new_data =
+      case Map.get(indexes, summary_date) do
+        nil ->
+          # The schedule is started but it's not in a summary cycle
+          data
+
+        index ->
+          # We increment the index since the tx is replicated
+          Map.update!(data, :indexes, &Map.put(&1, summary_date, index + 1))
+      end
+
+    {:keep_state, new_data, {:next_event, :internal, :schedule}}
   end
 
   def handle_event(
         :info,
         :poll,
-        :ready,
+        :scheduled,
         data = %{
           polling_date: polling_date,
           summary_date: summary_date
         }
       ) do
     if DateTime.diff(polling_date, summary_date, :second) == 0 do
-      {:next_state, :summary, data, {:next_event, :internal, :aggregate}}
+      {:next_state, :triggered, data, {:next_event, :internal, :aggregate}}
     else
-      {:next_state, :polling, data, {:next_event, :internal, :fetch_data}}
+      {:next_state, :triggered, data, {:next_event, :internal, :fetch_data}}
     end
   end
 
   def handle_event(
         :internal,
         :fetch_data,
-        :polling,
+        :triggered,
         data = %{
-          polling_interval: polling_interval,
           summary_date: summary_date,
           indexes: indexes
         }
       ) do
-    Logger.debug("Oracle Poll - state: #{inspect(data)}")
+    Logger.debug("Oracle poll - state: #{inspect(data)}")
 
     index = Map.fetch!(indexes, summary_date)
 
@@ -159,61 +219,50 @@ defmodule Archethic.OracleChain.Scheduler do
 
     tx = build_oracle_transaction(summary_date, index, new_oracle_data)
 
-    watcher_pid =
-      with {:empty, false} <- {:empty, Enum.empty?(new_oracle_data)},
-           {:trigger, true} <- {:trigger, trigger_node?(storage_nodes)},
-           {:exists, false} <- {:exists, DB.transaction_exists?(tx.address)} do
-        send_polling_transaction(tx)
-        nil
-      else
-        {:empty, true} ->
-          Logger.debug("Oracle transaction skipped - no new data")
-          nil
+    with {:empty, false} <- {:empty, Enum.empty?(new_oracle_data)},
+         {:trigger, true} <- {:trigger, trigger_node?(storage_nodes)},
+         {:exists, false} <- {:exists, DB.transaction_exists?(tx.address)} do
+      send_polling_transaction(tx)
+      :keep_state_and_data
+    else
+      {:empty, true} ->
+        Logger.debug("Oracle transaction skipped - no new data")
+        {:keep_state_and_data, [{:next_event, :internal, :schedule}]}
 
-        {:trigger, false} ->
-          {:ok, pid} =
-            DetectNodeResponsiveness.start_link(tx.address, fn count ->
-              new_oracle_data = get_new_oracle_data(summary_date, index)
-              new_data? = !Enum.empty?(new_oracle_data)
+      {:trigger, false} ->
+        {:ok, pid} =
+          DetectNodeResponsiveness.start_link(tx.address, fn count ->
+            new_oracle_data = get_new_oracle_data(summary_date, index)
+            new_data? = !Enum.empty?(new_oracle_data)
 
-              if trigger_node?(storage_nodes, count) and new_data? do
-                Logger.info("Oracle polling transaction ...attempt #{count}",
-                  transaction_address: Base.encode16(tx.address),
-                  transaction_type: :oracle
-                )
+            if trigger_node?(storage_nodes, count) and new_data? do
+              Logger.info("Oracle polling transaction ...attempt #{count}",
+                transaction_address: Base.encode16(tx.address),
+                transaction_type: :oracle
+              )
 
-                tx = build_oracle_transaction(summary_date, index, new_oracle_data)
-                send_polling_transaction(tx)
-              end
-            end)
+              tx = build_oracle_transaction(summary_date, index, new_oracle_data)
+              send_polling_transaction(tx)
+            end
+          end)
 
-          pid
+        Process.monitor(pid)
+        {:keep_state, Map.put(data, :oracle_watcher, pid)}
 
-        {:exists, true} ->
-          Logger.warning("Transaction already exists - before sending",
-            transaction_address: Base.encode16(tx.address),
-            transaction_type: :oracle
-          )
+      {:exists, true} ->
+        Logger.warning("Transaction already exists - before sending",
+          transaction_address: Base.encode16(tx.address),
+          transaction_type: :oracle
+        )
 
-          nil
-      end
-
-    current_time = DateTime.utc_now() |> DateTime.truncate(:second)
-    next_polling_date = next_date(polling_interval, current_time)
-
-    new_data =
-      data
-      |> Map.put(:polling_date, next_polling_date)
-      |> Map.put(:polling_timer, schedule_new_polling(next_polling_date, current_time))
-      |> Map.put(:oracle_watcher_pid, watcher_pid)
-
-    {:next_state, :ready, new_data}
+        {:keep_state_and_data, [{:next_event, :internal, :schedule}]}
+    end
   end
 
   def handle_event(
         :internal,
         :aggregate,
-        :summary,
+        :triggered,
         data = %{summary_date: summary_date, summary_interval: summary_interval, indexes: indexes}
       )
       when is_map_key(indexes, summary_date) do
@@ -223,9 +272,9 @@ defmodule Archethic.OracleChain.Scheduler do
     validation_nodes = get_validation_nodes(summary_date, index + 1)
 
     # Stop previous oracle retries when the summary is triggered
-    case Map.get(data, :oracle_watcher_pid) do
+    case Map.get(data, :oracle_watcher) do
       nil ->
-        :ok
+        :ignore
 
       pid ->
         Process.exit(pid, :normal)
@@ -266,6 +315,8 @@ defmodule Archethic.OracleChain.Scheduler do
               end
             end)
 
+          Process.monitor(pid)
+
           pid
 
         {:exists, true} ->
@@ -283,9 +334,9 @@ defmodule Archethic.OracleChain.Scheduler do
 
     new_data =
       data
-      |> Map.put(:summary_watcher_pid, summary_watcher_pid)
-      |> Map.delete(:oracle_watcher_pid)
       |> Map.put(:summary_date, next_summary_date)
+      |> Map.put(:summary_watcher, summary_watcher_pid)
+      |> Map.delete(:oracle_watcher)
       |> Map.update!(:indexes, fn indexes ->
         # Clean previous indexes
         indexes
@@ -302,10 +353,15 @@ defmodule Archethic.OracleChain.Scheduler do
         end
       end)
 
-    {:next_state, :polling, new_data, {:next_event, :internal, :fetch_data}}
+    {:keep_state, new_data, {:next_event, :internal, :fetch_data}}
   end
 
-  def handle_event(:internal, :aggregate, :summary, data = %{summary_interval: summary_interval}) do
+  def handle_event(
+        :internal,
+        :aggregate,
+        :triggered,
+        data = %{summary_interval: summary_interval}
+      ) do
     # Discard the oracle summary if there is not previous indexing
 
     current_time = DateTime.utc_now() |> DateTime.truncate(:second)
@@ -316,19 +372,49 @@ defmodule Archethic.OracleChain.Scheduler do
       data
       |> Map.put(:summary_date, next_summary_date)
       |> Map.put(:indexes, %{next_summary_date => 0})
+      |> Map.put(:polling_date, next_summary_date)
 
-    {:next_state, :polling, new_data, {:next_event, :internal, :fetch_data}}
+    {:keep_state, new_data, {:next_event, :internal, :fetch_data}}
+  end
+
+  def handle_event(
+        :info,
+        {:DOWN, _ref, :process, pid, _},
+        :triggered,
+        _data = %{oracle_watcher: watcher_pid}
+      )
+      when pid == watcher_pid do
+    {:keep_state_and_data, {:next_event, :internal, :schedule}}
+  end
+
+  def handle_event(
+        :info,
+        {:DOWN, _ref, :process, pid, _},
+        :scheduled,
+        _data = %{oracle_watcher: watcher_pid}
+      )
+      when pid == watcher_pid do
+    :keep_state_and_data
+  end
+
+  def handle_event(
+        :info,
+        {:DOWN, _ref, :process, pid, _},
+        _state,
+        _data = %{summary_watcher: watcher_pid}
+      )
+      when pid == watcher_pid do
+    :keep_state_and_data
   end
 
   def handle_event(
         :info,
         {:node_update,
          %Node{authorized?: true, available?: true, first_public_key: first_public_key}},
-        _state,
-        data = %{polling_interval: polling_interval, summary_interval: summary_interval}
+        :idle,
+        data = %{summary_interval: summary_interval, polling_interval: polling_interval}
       ) do
-    with ^first_public_key <- Crypto.first_node_public_key(),
-         nil <- Map.get(data, :polling_timer) do
+    if Crypto.first_node_public_key() == first_public_key do
       current_time = DateTime.utc_now() |> DateTime.truncate(:second)
 
       next_summary_date = next_date(summary_interval, current_time)
@@ -337,50 +423,49 @@ defmodule Archethic.OracleChain.Scheduler do
         P2P.authorized_and_available_nodes()
         |> Enum.reject(&(&1.first_public_key == first_public_key))
 
-      new_data =
-        case other_authorized_nodes do
-          [] ->
-            next_polling_date = next_date(polling_interval, current_time)
-            polling_timer = schedule_new_polling(next_polling_date, current_time)
+      Logger.info("Start the Oracle scheduler")
+      PubSub.register_to_new_transaction_by_type(:oracle)
 
+      case other_authorized_nodes do
+        [] ->
+          next_polling_date = next_date(polling_interval, current_time)
+
+          new_data =
             data
-            |> Map.put(:polling_timer, polling_timer)
             |> Map.put(:polling_date, next_polling_date)
             |> Map.put(:summary_date, next_summary_date)
             |> Map.put(:indexes, %{next_summary_date => chain_size(next_summary_date)})
 
-          _ ->
-            # Start the polling after the next summary, if there are already authorized nodes
-            polling_timer = schedule_new_polling(next_summary_date, current_time)
+          {:keep_state, new_data, {:next_event, :internal, :schedule}}
 
+        _ ->
+          new_data =
             data
-            |> Map.put(:polling_timer, polling_timer)
             |> Map.put(:polling_date, next_summary_date)
             |> Map.put(:summary_date, next_summary_date)
-        end
 
-      Logger.info("Start the Oracle scheduler")
-      {:next_state, :ready, new_data}
+          {:keep_state, new_data, {:next_event, :internal, {:schedule_at, next_summary_date}}}
+      end
     else
-      _ ->
-        :keep_state_and_data
+      :keep_state_and_data
     end
   end
 
   def handle_event(
         :info,
         {:node_update, %Node{authorized?: false, first_public_key: first_public_key}},
-        _state,
+        _,
         data = %{polling_timer: polling_timer}
       ) do
     if first_public_key == Crypto.first_node_public_key() do
+      PubSub.unregister_to_new_transaction_by_type(:oracle)
       Process.cancel_timer(polling_timer)
 
       new_data =
         data
         |> Map.delete(:polling_timer)
 
-      {:keep_state, new_data}
+      {:next_state, :idle, new_data}
     else
       :keep_state_and_data
     end
@@ -394,13 +479,14 @@ defmodule Archethic.OracleChain.Scheduler do
         data = %{polling_timer: polling_timer}
       ) do
     if first_public_key == Crypto.first_node_public_key() do
+      PubSub.unregister_to_new_transaction_by_type(:oracle)
       Process.cancel_timer(polling_timer)
 
       new_data =
         data
         |> Map.delete(:polling_timer)
 
-      {:keep_state, new_data}
+      {:next_state, :idle, new_data}
     else
       :keep_state_and_data
     end
@@ -442,15 +528,6 @@ defmodule Archethic.OracleChain.Scheduler do
       |> Map.put(:summary_interval, summary_interval)
 
     {:keep_state, new_data}
-  end
-
-  def handle_event(
-        {:call, from},
-        :summary_interval,
-        _state,
-        _data = %{summary_interval: summary_interval}
-      ) do
-    {:keep_state_and_data, {:reply, from, summary_interval}}
   end
 
   def handle_event(_event_type, _event, :idle, _data), do: :keep_state_and_data

--- a/lib/archethic/oracle_chain/supervisor.ex
+++ b/lib/archethic/oracle_chain/supervisor.ex
@@ -14,7 +14,7 @@ defmodule Archethic.OracleChain.Supervisor do
   end
 
   def init(_args) do
-    scheduler_conf = Application.get_env(:archethic, Archethic.OracleChain.Scheduler)
+    scheduler_conf = Application.get_env(:archethic, Scheduler)
 
     children = [
       MemTable,

--- a/lib/archethic/pub_sub.ex
+++ b/lib/archethic/pub_sub.ex
@@ -112,11 +112,27 @@ defmodule Archethic.PubSub do
   end
 
   @doc """
+  Unregister a process to a new transaction publication by type
+  """
+  @spec unregister_to_new_transaction_by_type(Transaction.transaction_type()) :: :ok
+  def unregister_to_new_transaction_by_type(type) when is_atom(type) do
+    Registry.unregister(PubSubRegistry, {:new_transaction, type})
+  end
+
+  @doc """
   Register a process to a new transaction publication by address
   """
   @spec register_to_new_transaction_by_address(binary()) :: {:ok, pid()}
   def register_to_new_transaction_by_address(address) when is_binary(address) do
     Registry.register(PubSubRegistry, {:new_transaction, address}, [])
+  end
+
+  @doc """
+  Unregister a process to a new transaction publication by address
+  """
+  @spec unregister_to_new_transaction_by_address(binary()) :: :ok
+  def unregister_to_new_transaction_by_address(address) when is_binary(address) do
+    Registry.unregister(PubSubRegistry, {:new_transaction, address})
   end
 
   @doc """

--- a/lib/archethic/reward.ex
+++ b/lib/archethic/reward.ex
@@ -55,8 +55,9 @@ defmodule Archethic.Reward do
     ...>  }
     ...> } = Reward.new_rewards_mint(2_000_000_000)
   """
-  @spec new_rewards_mint(amount :: non_neg_integer()) :: Transaction.t()
-  def new_rewards_mint(amount) do
+  @spec new_rewards_mint(amount :: non_neg_integer(), index :: non_neg_integer()) ::
+          Transaction.t()
+  def new_rewards_mint(amount, index) do
     data = %TransactionData{
       code: """
         condition inherit: [
@@ -76,11 +77,11 @@ defmodule Archethic.Reward do
       """
     }
 
-    Transaction.new(:mint_rewards, data)
+    Transaction.new(:mint_rewards, data, index)
   end
 
-  @spec new_node_rewards() :: Transaction.t()
-  def new_node_rewards() do
+  @spec new_node_rewards(non_neg_integer()) :: Transaction.t()
+  def new_node_rewards(index) do
     data = %TransactionData{
       code: """
         condition inherit: [
@@ -97,7 +98,7 @@ defmodule Archethic.Reward do
       }
     }
 
-    Transaction.new(:node_rewards, data)
+    Transaction.new(:node_rewards, data, index)
   end
 
   @doc """
@@ -113,11 +114,11 @@ defmodule Archethic.Reward do
     initiator_key == Crypto.first_node_public_key()
   end
 
-  @spec next_address() :: binary()
-  def next_address do
-    key_index = Crypto.number_of_network_pool_keys()
-    next_public_key = Crypto.network_pool_public_key(key_index + 1)
-    Crypto.derive_address(next_public_key)
+  @spec next_address(non_neg_integer()) :: binary()
+  def next_address(index) do
+    (index + 1)
+    |> Crypto.network_pool_public_key()
+    |> Crypto.derive_address()
   end
 
   @doc """

--- a/lib/archethic/reward.ex
+++ b/lib/archethic/reward.ex
@@ -53,7 +53,7 @@ defmodule Archethic.Reward do
     ...>  data: %{
     ...>    content: "{\\n  \\"supply\\":2000000000,\\n  \\"type\\":\\"fungible\\",\\n  \\"name\\":\\"Mining UCO rewards\\",\\n  \\"symbol\\":\\"MUCO\\"\\n}\\n"
     ...>  }
-    ...> } = Reward.new_rewards_mint(2_000_000_000)
+    ...> } = Reward.new_rewards_mint(2_000_000_000, 1)
   """
   @spec new_rewards_mint(amount :: non_neg_integer(), index :: non_neg_integer()) ::
           Transaction.t()

--- a/lib/archethic/shared_secrets.ex
+++ b/lib/archethic/shared_secrets.ex
@@ -53,12 +53,14 @@ defmodule Archethic.SharedSecrets do
   @spec new_node_shared_secrets_transaction(
           authorized_node_public_keys :: list(Crypto.key()),
           daily_nonce_seed :: binary(),
-          aes_key :: binary()
+          aes_key :: binary(),
+          index :: non_neg_integer()
         ) :: Transaction.t()
   defdelegate new_node_shared_secrets_transaction(
                 authorized_node_public_keys,
                 daily_nonce_seed,
-                aes_key
+                aes_key,
+                index
               ),
               to: NodeRenewal
 

--- a/lib/archethic/shared_secrets/node_renewal.ex
+++ b/lib/archethic/shared_secrets/node_renewal.ex
@@ -77,15 +77,18 @@ defmodule Archethic.SharedSecrets.NodeRenewal do
   @spec new_node_shared_secrets_transaction(
           authorized_nodes_public_keys :: list(Crypto.key()),
           daily_nonce_seed :: binary(),
-          secret_key :: binary()
+          secret_key :: binary(),
+          index :: non_neg_integer()
         ) :: Transaction.t()
   def new_node_shared_secrets_transaction(
         authorized_node_public_keys,
         daily_nonce_seed,
-        secret_key
+        secret_key,
+        index
       )
       when is_binary(daily_nonce_seed) and is_binary(secret_key) and
-             is_list(authorized_node_public_keys) do
+             is_list(authorized_node_public_keys) and is_integer(index) and
+             index >= 0 do
     {daily_nonce_public_key, _} = Crypto.generate_deterministic_keypair(daily_nonce_seed)
 
     {encrypted_transaction_seed, encrypted_network_pool_seed} = Crypto.wrap_secrets(secret_key)
@@ -119,7 +122,8 @@ defmodule Archethic.SharedSecrets.NodeRenewal do
         ownerships: [
           Ownership.new(secret, secret_key, authorized_node_public_keys)
         ]
-      }
+      },
+      index
     )
   end
 

--- a/lib/archethic/shared_secrets/node_renewal.ex
+++ b/lib/archethic/shared_secrets/node_renewal.ex
@@ -38,7 +38,8 @@ defmodule Archethic.SharedSecrets.NodeRenewal do
     initiator_key == Crypto.first_node_public_key()
   end
 
-  defp next_address do
+  @spec next_address() :: binary()
+  def next_address do
     key_index = Crypto.number_of_node_shared_secrets_keys()
     next_public_key = Crypto.node_shared_secrets_public_key(key_index + 1)
     Crypto.derive_address(next_public_key)

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -2,17 +2,9 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
   @moduledoc """
   Schedule the renewal of node shared secrets
 
-  At each `interval - trigger offset` , a new node shared secrets transaction is created with
+  At each `interval`, a new node shared secrets transaction is created with
   the new authorized nodes and is broadcasted to the validation nodes to include
   them as new authorized nodes and update the daily nonce seed.
-
-  A trigger offset is defined to determine the seconds before the interval
-  when the transaction will be created and sent.
-  (this offset can be tuned by the prediction module to ensure the correctness depending on the latencies)
-
-  For example, for a interval every day (00:00), with 10min offset.
-  At 23:58 UTC, an elected node will build and send the transaction for the node renewal shared secrets
-  At 00.00 UTC, nodes receives will applied the node shared secrets for the transaction mining
   """
 
   alias Crontab.CronExpression.Parser, as: CronParser
@@ -34,7 +26,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
 
   require Logger
 
-  use GenServer
+  use GenStateMachine, callback_mode: :handle_event_function
 
   @doc """
   Start the node renewal scheduler process without starting the scheduler
@@ -48,7 +40,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
         ) ::
           {:ok, pid()}
   def start_link(args \\ [], opts \\ [name: __MODULE__]) do
-    GenServer.start_link(__MODULE__, args, opts)
+    GenStateMachine.start_link(__MODULE__, args, opts)
   end
 
   @doc false
@@ -60,108 +52,197 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
 
     case Crypto.first_node_public_key() |> P2P.get_node_info() |> elem(1) do
       %Node{authorized?: true, available?: true} ->
+        PubSub.register_to_new_transaction_by_type(:node_shared_secrets)
         Logger.info("Node Renewal Scheduler: Scheduled during init")
 
-        {:ok, %{interval: interval, timer: schedule_renewal_message(interval)}}
+        key_index = Crypto.number_of_node_shared_secrets_keys()
+
+        {:ok, :idle, %{interval: interval, index: key_index},
+         [{:next_event, :internal, :schedule}]}
 
       _ ->
         Logger.info("Node Renewal Scheduler: Scheduler waiting for Node Update Message")
 
-        {:ok, %{interval: interval}, :hibernate}
+        {:ok, :idle, %{interval: interval}}
     end
   end
 
-  def handle_info(
-        {:node_update, %Node{authorized?: true, available?: true}},
-        state = %{timer: _timer}
-      ) do
-    {:noreply, state, :hibernate}
-  end
+  def handle_event(:internal, :schedule, _state, data = %{interval: interval}) do
+    timer =
+      case Map.get(data, :timer) do
+        nil ->
+          schedule_renewal_message(interval)
 
-  def handle_info(
-        {:node_update,
-         %Node{first_public_key: first_public_key, authorized?: true, available?: true}},
-        state = %{interval: interval}
-      ) do
-    if first_public_key == Crypto.first_node_public_key() do
-      Logger.info("Start node shared secrets scheduling")
-      timer = schedule_renewal_message(interval)
-
-      Logger.info(
-        "Node shared secrets will be renewed in #{Utils.remaining_seconds_from_timer(timer)}"
-      )
-
-      {:noreply, Map.put(state, :timer, timer)}
-    else
-      {:noreply, state, :hibernate}
-    end
-  end
-
-  def handle_info(
-        {:node_update,
-         %Node{first_public_key: first_public_key, authorized?: true, available?: false}},
-        state
-      ) do
-    with timer when timer != nil <- Map.get(state, :timer),
-         ^first_public_key <- Crypto.first_node_public_key() do
-      Process.cancel_timer(timer)
-      {:noreply, Map.delete(state, :timer), :hibernate}
-    else
-      _ ->
-        {:noreply, state, :hibernate}
-    end
-  end
-
-  def handle_info(
-        {:node_update, %Node{first_public_key: first_public_key, authorized?: false}},
-        state
-      ) do
-    with ^first_public_key <- Crypto.first_node_public_key(),
-         timer when timer != nil <- Map.get(state, :timer) do
-      Process.cancel_timer(timer)
-      {:noreply, Map.delete(state, :timer), :hibernate}
-    else
-      _ ->
-        {:noreply, state, :hibernate}
-    end
-  end
-
-  def handle_info(:make_renewal, state = %{interval: interval}) do
-    timer = schedule_renewal_message(interval)
+        timer ->
+          Process.cancel_timer(timer)
+          schedule_renewal_message(interval)
+      end
 
     Logger.info(
-      "Node shared secrets will be renewed in #{Utils.remaining_seconds_from_timer(timer)}"
+      "Node shared secrets will be renewed in #{Utils.remaining_seconds_from_timer(timer)} seconds"
     )
 
+    {:next_state, :scheduled, Map.put(data, :timer, timer)}
+  end
+
+  def handle_event(
+        :info,
+        {:node_update,
+         %Node{first_public_key: first_public_key, authorized?: true, available?: true}},
+        :idle,
+        data
+      ) do
+    if first_public_key == Crypto.first_node_public_key() do
+      key_index = Crypto.number_of_node_shared_secrets_keys()
+      PubSub.register_to_new_transaction_by_type(:node_shared_secrets)
+      Logger.info("Start node shared secrets scheduling")
+      {:keep_state, Map.put(data, :index, key_index), {:next_event, :internal, :schedule}}
+    else
+      :keep_state_and_data
+    end
+  end
+
+  def handle_event(
+        :info,
+        {:node_update,
+         %Node{first_public_key: first_public_key, authorized?: true, available?: false}},
+        state,
+        data
+      )
+      when state != nil do
+    if first_public_key == Crypto.first_node_public_key() do
+      PubSub.unregister_to_new_transaction_by_type(:node_shared_secrets)
+
+      case Map.pop(data, :timer) do
+        {nil, _} ->
+          {:next_state, :idle, data}
+
+        {timer, new_data} ->
+          Process.cancel_timer(timer)
+          {:next_state, :idle, new_data}
+      end
+    else
+      :keep_state_and_data
+    end
+  end
+
+  def handle_event(
+        :info,
+        {:node_update, %Node{first_public_key: first_public_key, authorized?: false}},
+        state,
+        data
+      )
+      when state != :idle do
+    if first_public_key == Crypto.first_node_public_key() do
+      PubSub.unregister_to_new_transaction_by_type(:node_shared_secrets)
+
+      case Map.pop(data, :timer) do
+        {nil, _} ->
+          {:next_state, :idle, data}
+
+        {timer, new_data} ->
+          Process.cancel_timer(timer)
+          {:next_state, :idle, new_data}
+      end
+    else
+      :keep_state_and_data
+    end
+  end
+
+  def handle_event(:info, {:node_update, _}, _, _), do: :keep_state_and_data
+
+  def handle_event(:info, :make_renewal, :scheduled, data) do
+    {:next_state, :triggered, data, {:next_event, :internal, :make_renewal}}
+  end
+
+  def handle_event(:internal, :make_renewal, :triggered, data = %{index: index}) do
     tx =
       NodeRenewal.next_authorized_node_public_keys()
       |> NodeRenewal.new_node_shared_secrets_transaction(
         :crypto.strong_rand_bytes(32),
-        :crypto.strong_rand_bytes(32)
+        :crypto.strong_rand_bytes(32),
+        index
       )
 
     if NodeRenewal.initiator?() do
       Logger.info("Node shared secrets renewal creation...")
       make_renewal(tx)
+      {:keep_state, data}
     else
-      DetectNodeResponsiveness.start_link(tx.address, fn count ->
-        if NodeRenewal.initiator?(count) do
-          Logger.info("Node shared secret renewal creation...attempt #{count}")
-          make_renewal(tx)
-        end
-      end)
-    end
+      {:ok, pid} =
+        DetectNodeResponsiveness.start_link(tx.address, fn count ->
+          if NodeRenewal.initiator?(count) do
+            Logger.info("Node shared secret renewal creation...attempt #{count}")
+            make_renewal(tx)
+          end
+        end)
 
-    {:noreply, Map.put(state, :timer, timer), :hibernate}
+      Process.monitor(pid)
+
+      {:keep_state, Map.put(data, :node_detection, pid)}
+    end
   end
 
-  def handle_cast({:new_conf, conf}, state) do
+  def handle_event(
+        :info,
+        {:DOWN, _ref, :process, pid, _reason},
+        :triggered,
+        data = %{node_detection: watcher_pid}
+      )
+      when pid == watcher_pid do
+    {:keep_state, Map.delete(data, :node_detection), {:next_event, :internal, :schedule}}
+  end
+
+  def handle_event(
+        :info,
+        {:DOWN, _ref, :process, pid, _reason},
+        :scheduled,
+        data = %{node_detection: watcher_pid}
+      )
+      when pid == watcher_pid do
+    {:keep_state, Map.delete(data, :node_detection)}
+  end
+
+  def handle_event(
+        :info,
+        {:new_transaction, _address, :node_shared_secrets, _timestamp},
+        :triggered,
+        data
+      ) do
+    case Map.get(data, :watcher) do
+      nil ->
+        :ignore
+
+      pid ->
+        Process.exit(pid, :normal)
+    end
+
+    new_data = Map.update!(data, :index, &(&1 + 1))
+    {:next_state, :confirmed, new_data, {:next_event, :internal, :schedule}}
+  end
+
+  def handle_event(
+        :info,
+        {:new_transaction, _address, :node_shared_secrets, _timestamp},
+        :scheduled,
+        data
+      ) do
+    new_data = Map.update!(data, :index, &(&1 + 1))
+
+    Logger.debug(
+      "Reschedule renewal after reception of node shared secrets transaction in scheduled state instead of triggered state"
+    )
+
+    {:keep_state, new_data, {:next_event, :internal, :schedule}}
+  end
+
+  def handle_event(:cast, {:new_conf, conf}, _state, data) do
     case Keyword.get(conf, :interval) do
       nil ->
-        {:noreply, state}
+        :keep_state_and_data
 
       new_interval ->
-        {:noreply, Map.put(state, :interval, new_interval)}
+        {:keep_state, Map.put(data, :interval, new_interval)}
     end
   end
 
@@ -180,7 +261,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
   def config_change(nil), do: :ok
 
   def config_change(changed_config) do
-    GenServer.cast(__MODULE__, {:new_conf, changed_config})
+    GenStateMachine.cast(__MODULE__, {:new_conf, changed_config})
   end
 
   @doc """

--- a/lib/archethic/utils/regression/playbook.ex
+++ b/lib/archethic/utils/regression/playbook.ex
@@ -110,7 +110,7 @@ defmodule Archethic.Utils.Regression.Playbook do
         data: transaction_data,
         previous_public_key: previous_public_key
       }
-      |> Transaction.previous_sign_transaction(previous_private_key)
+      |> Transaction.previous_sign_transaction_with_key(previous_private_key)
       |> Transaction.origin_sign_transaction(genesis_origin_private_key)
 
     true =
@@ -184,7 +184,7 @@ defmodule Archethic.Utils.Regression.Playbook do
         data: transaction_data,
         previous_public_key: previous_public_key
       }
-      |> Transaction.previous_sign_transaction(previous_private_key)
+      |> Transaction.previous_sign_transaction_with_key(previous_private_key)
       |> Transaction.origin_sign_transaction(genesis_origin_private_key)
 
     true =

--- a/test/archethic/shared_secrets/node_renewal_test.exs
+++ b/test/archethic/shared_secrets/node_renewal_test.exs
@@ -17,7 +17,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalTest do
 
   import Mox
 
-  test "new_node_shared_secrets_transaction/3 should create a new node shared secrets transaction" do
+  test "new_node_shared_secrets_transaction/4 should create a new node shared secrets transaction" do
     aes_key = :crypto.strong_rand_bytes(32)
 
     %Transaction{
@@ -30,7 +30,8 @@ defmodule Archethic.SharedSecrets.NodeRenewalTest do
       SharedSecrets.new_node_shared_secrets_transaction(
         [Crypto.last_node_public_key()],
         "daily_nonce_seed",
-        aes_key
+        aes_key,
+        0
       )
 
     assert Ownership.authorized_public_key?(ownership, Crypto.first_node_public_key())


### PR DESCRIPTION
# Description

This should prevent scheduler to trigger transactions too fastly computed before the scheduling time.
Using FSM we are ensuring to enter in the state of scheduling only when the tx is replicated or after timeouts.

Fixes #420 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
