### PR TITLE
Clean Node movements references

### DIFF
--- a/lib/archethic/transaction_chain/transaction/cross_validation_stamp.ex
+++ b/lib/archethic/transaction_chain/transaction/cross_validation_stamp.ex
@@ -18,7 +18,6 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStamp do
           | :transaction_fee
           | :transaction_movements
           | :unspent_outputs
-          | :node_movements
           | :error
 
   @typedoc """
@@ -128,7 +127,6 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStamp do
   defp serialize_inconsistency(:transaction_fee), do: 5
   defp serialize_inconsistency(:transaction_movements), do: 6
   defp serialize_inconsistency(:unspent_outputs), do: 7
-  defp serialize_inconsistency(:node_movements), do: 8
   defp serialize_inconsistency(:error), do: 9
 
   @doc """
@@ -193,7 +191,6 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStamp do
   defp do_reduce_inconsistencies(<<5::8, rest::bitstring>>), do: {:transaction_fee, rest}
   defp do_reduce_inconsistencies(<<6::8, rest::bitstring>>), do: {:transaction_movements, rest}
   defp do_reduce_inconsistencies(<<7::8, rest::bitstring>>), do: {:unspent_outputs, rest}
-  defp do_reduce_inconsistencies(<<8::8, rest::bitstring>>), do: {:node_movements, rest}
   defp do_reduce_inconsistencies(<<9::8, rest::bitstring>>), do: {:error, rest}
 
   @spec cast(map()) :: t()

--- a/lib/archethic/transaction_chain/transaction/cross_validation_stamp.ex
+++ b/lib/archethic/transaction_chain/transaction/cross_validation_stamp.ex
@@ -127,7 +127,7 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStamp do
   defp serialize_inconsistency(:transaction_fee), do: 5
   defp serialize_inconsistency(:transaction_movements), do: 6
   defp serialize_inconsistency(:unspent_outputs), do: 7
-  defp serialize_inconsistency(:error), do: 9
+  defp serialize_inconsistency(:error), do: 8
 
   @doc """
   Deserialize an encoded cross validation stamp
@@ -191,7 +191,7 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStamp do
   defp do_reduce_inconsistencies(<<5::8, rest::bitstring>>), do: {:transaction_fee, rest}
   defp do_reduce_inconsistencies(<<6::8, rest::bitstring>>), do: {:transaction_movements, rest}
   defp do_reduce_inconsistencies(<<7::8, rest::bitstring>>), do: {:unspent_outputs, rest}
-  defp do_reduce_inconsistencies(<<9::8, rest::bitstring>>), do: {:error, rest}
+  defp do_reduce_inconsistencies(<<8::8, rest::bitstring>>), do: {:error, rest}
 
   @spec cast(map()) :: t()
   def cast(stamp = %{}) do

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -27,7 +27,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
   @typedoc """
   - Transaction movements: represents the pending transaction ledger movements
   - Unspent outputs: represents the new unspent outputs
-  - fee: represents the transaction fee distributed across the node movements
+  - fee: represents the transaction fee
   """
   @type t() :: %__MODULE__{
           transaction_movements: list(TransactionMovement.t()),

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -144,7 +144,7 @@ defmodule ArchethicWeb.API.TransactionController do
         conn
         |> put_status(:ok)
         |> json(%{
-          "fee" => fee / 100_000_000,
+          "fee" => fee,
           "rates" => %{
             "usd" => uco_usd,
             "eur" => uco_eur

--- a/lib/archethic_web/graphql_schema/transaction_type.ex
+++ b/lib/archethic_web/graphql_schema/transaction_type.ex
@@ -135,9 +135,8 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
   [LedgerOperations] represents the ledger operations performed by the transaction
   It includes:
   - Transaction movements: assets transfers
-  - Node movements: node rewards
   - Unspent outputs: remaining unspent outputs
-  - Fee: transaction fee (distributed over the node rewards)
+  - Fee: transaction fee
   """
   object :ledger_operations do
     field(:transaction_movements, list_of(:transaction_movement))

--- a/test/archethic/transaction_chain/transaction/cross_validation_stamp_test.exs
+++ b/test/archethic/transaction_chain/transaction/cross_validation_stamp_test.exs
@@ -45,8 +45,7 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStampTest do
       :proof_of_integrity,
       :transaction_fee,
       :transaction_movements,
-      :unspent_outputs,
-      :node_movements
+      :unspent_outputs
     ]
     |> StreamData.one_of()
     |> StreamData.uniq_list_of(max_length: 4, max_tries: 100)

--- a/test/archethic_web/controllers/api/transaction_controller_test.exs
+++ b/test/archethic_web/controllers/api/transaction_controller_test.exs
@@ -36,7 +36,7 @@ defmodule ArchethicWeb.API.TransactionControllerTest do
               "uco" => %{
                 "transfers" => [
                   %{
-                    "amount" => trunc(100_000_000),
+                    "amount" => 100_000_000,
                     "to" => "000098fe10e8633bce19c59a40a089731c1f72b097c5a8f7dc71a37eb26913aa4f80"
                   }
                 ]
@@ -54,7 +54,7 @@ defmodule ArchethicWeb.API.TransactionControllerTest do
         })
 
       assert %{
-               "fee" => trunc(0.05001344 * 100_000_000),
+               "fee" => 5_001_344,
                "rates" => %{
                  "eur" => 0.2,
                  "usd" => 0.2

--- a/test/archethic_web/controllers/api/transaction_controller_test.exs
+++ b/test/archethic_web/controllers/api/transaction_controller_test.exs
@@ -54,7 +54,7 @@ defmodule ArchethicWeb.API.TransactionControllerTest do
         })
 
       assert %{
-               "fee" => 0.05001344,
+               "fee" => trunc(0.05001344 * 100_000_000),
                "rates" => %{
                  "eur" => 0.2,
                  "usd" => 0.2


### PR DESCRIPTION
# Description
I remove Node movements object references

Commands ok:
```
mix test --trace
mix archethic.regression --playbook localhost
```
