### PR TITLE
Fix availability error, local summaries download, scheduler handle event

### DIFF
--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -398,30 +398,54 @@ defmodule Archethic.OracleChain.Scheduler do
         :info,
         {:DOWN, _ref, :process, pid, _},
         :triggered,
-        _data = %{oracle_watcher: watcher_pid}
+        data = %{oracle_watcher: watcher_pid}
       )
       when pid == watcher_pid do
-    {:keep_state_and_data, {:next_event, :internal, :schedule}}
+    {:keep_state, Map.delete(data, :oracle_watcher), {:next_event, :internal, :schedule}}
+  end
+
+  def handle_event(
+        :info,
+        {:DOWN, _ref, :process, pid, _},
+        :triggered,
+        data = %{summary_watcher: watcher_pid}
+      )
+      when pid == watcher_pid do
+    {:keep_state, Map.delete(data, :summary_watcher)}
   end
 
   def handle_event(
         :info,
         {:DOWN, _ref, :process, pid, _},
         :scheduled,
-        _data = %{oracle_watcher: watcher_pid}
+        data = %{oracle_watcher: watcher_pid}
       )
       when pid == watcher_pid do
-    :keep_state_and_data
+    {:keep_state, Map.delete(data, :oracle_watcher)}
   end
 
   def handle_event(
         :info,
         {:DOWN, _ref, :process, pid, _},
         _state,
-        _data = %{summary_watcher: watcher_pid}
+        data = %{summary_watcher: watcher_pid}
       )
       when pid == watcher_pid do
-    :keep_state_and_data
+    {:keep_state, Map.delete(data, :summary_watcher)}
+  end
+
+  def handle_event(
+        :info,
+        {:DOWN, _ref, :process, _pid, _},
+        _state,
+        data
+      ) do
+    new_data =
+      data
+      |> Map.delete(:oracle_watcher)
+      |> Map.delete(:summary_watcher)
+
+    {:keep_state, new_data}
   end
 
   def handle_event(

--- a/lib/archethic/p2p/mem_table.ex
+++ b/lib/archethic/p2p/mem_table.ex
@@ -829,10 +829,13 @@ defmodule Archethic.P2P.MemTable do
     avg_availability_pos = Keyword.fetch!(@discovery_index_position, :average_availability)
     availability_history_pos = Keyword.fetch!(@discovery_index_position, :availability_history)
 
+    <<last_history::1, _rest::bitstring>> =
+      :ets.lookup_element(@discovery_table, first_public_key, availability_history_pos)
+
     true =
       :ets.update_element(@discovery_table, first_public_key, [
         {avg_availability_pos, avg_availability},
-        {availability_history_pos, <<1::1>>}
+        {availability_history_pos, <<last_history::1>>}
       ])
 
     Logger.info("New average availability: #{avg_availability}}",

--- a/lib/archethic/reward/scheduler.ex
+++ b/lib/archethic/reward/scheduler.ex
@@ -250,11 +250,10 @@ defmodule Archethic.Reward.Scheduler do
 
   def handle_event(
         :info,
-        {:DOWN, _ref, :process, pid, _},
+        {:DOWN, _ref, :process, _pid, _},
         :scheduled,
-        data = %{watcher: watcher_pid}
-      )
-      when pid == watcher_pid do
+        data
+      ) do
     {:keep_state, Map.delete(data, :watcher)}
   end
 

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -207,13 +207,14 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
 
   def handle_event(
         :info,
-        {:DOWN, _ref, :process, pid, _reason},
+        {:DOWN, _ref, :process, _pid, _reason},
         :scheduled,
-        data = %{node_detection: watcher_pid}
-      )
-      when pid == watcher_pid do
+        data
+      ) do
     {:keep_state, Map.delete(data, :node_detection)}
   end
+
+  #
 
   def handle_event(
         :info,

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -60,6 +60,7 @@ defmodule ArchethicWeb.API.TransactionController do
 
           {:error, e} ->
             Logger.error("Cannot get transaction summary - #{inspect(e)}")
+            conn |> put_status(504) |> json(%{status: "error - networking error"})
         end
 
       changeset ->


### PR DESCRIPTION
# Description

Fixes some errors: 
- availability_history bit was reseted to 1 when updating avarage availability during self repair. Updated to reset the bt with it's last value
- during self repair, summaries were not downloaded if they already exists in DB, but in some case nodes don't have the same summaries and so some desynchronisation may happen. So downloading summary from all the node and doing an aggregate is a better way so all nodes have the same aggregate.
- some event sent to the scheduler were not handled causing scheduler crash.
- In transaction API, when quorum fail, no response were sent back to the user

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
