### PR TITLE
Start Schedulers Post Bootstrap  #543

### DIFF
--- a/lib/archethic/bootstrap.ex
+++ b/lib/archethic/bootstrap.ex
@@ -116,6 +116,8 @@ defmodule Archethic.Bootstrap do
     else
       post_bootstrap(sync?: false)
     end
+
+    Logger.info("Bootstrapping finished!")
   end
 
   defp should_bootstrap?(_ip, _port, _http_port, _, nil), do: true
@@ -195,8 +197,6 @@ defmodule Archethic.Bootstrap do
         end
       end
     end
-
-    Logger.info("Bootstrapping finished!")
   end
 
   defp post_bootstrap(opts) do
@@ -213,6 +213,7 @@ defmodule Archethic.Bootstrap do
     SelfRepair.start_scheduler()
 
     :persistent_term.put(:archethic_up, :up)
+    Archethic.PubSub.notify_node_up()
     Listener.listen()
   end
 

--- a/lib/archethic/pub_sub.ex
+++ b/lib/archethic/pub_sub.ex
@@ -104,6 +104,30 @@ defmodule Archethic.PubSub do
   end
 
   @doc """
+  Notify that Node is Up
+  """
+  @spec notify_node_up() :: :ok
+  def notify_node_up() do
+    dispatch(:node_up, :node_up)
+  end
+
+  @spec register_to_node_up :: {:error, {:already_registered, pid}} | {:ok, pid}
+  @doc """
+  Register a process to notify node up
+  """
+  def register_to_node_up() do
+    Registry.register(PubSubRegistry, :node_up, [])
+  end
+
+  @doc """
+  UnRegister a process to notification node up
+  """
+  @spec unregister_to_node_up :: :ok
+  def unregister_to_node_up() do
+    Registry.unregister(PubSubRegistry, :node_up)
+  end
+
+  @doc """
   Register a process to a new transaction publication by type
   """
   @spec register_to_new_transaction_by_type(Transaction.transaction_type()) :: {:ok, pid()}

--- a/lib/archethic/reward/supervisor.ex
+++ b/lib/archethic/reward/supervisor.ex
@@ -8,6 +8,7 @@ defmodule Archethic.Reward.Supervisor do
   alias Archethic.Reward.MemTablesLoader
   alias Archethic.Reward.MemTables.RewardTokens
 
+  @spec start_link(any) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(args \\ []) do
     Supervisor.start_link(__MODULE__, args, name: Archethic.RewardSupervisor)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -114,7 +114,7 @@ defmodule Archethic.MixProject do
       # run single node
       "dev.run": ["deps.get", "cmd mix dev.clean", "cmd iex -S mix"],
       # Must be run before git push --no-verify | any(dialyzer issue)
-      "dev.checks": ["clean", "format", "compile", "credo", "cmd mix test", "dialyzer"],
+      "dev.checks": ["clean", "format", "compile", "credo", "cmd mix test --trace", "dialyzer"],
       # paralele checks
       "dev.pchecks": ["  clean &   format &    compile &   credo &   test &   dialyzer"],
       # docker test-net with 3 nodes

--- a/test/archethic/beacon_chain/slot_timer_test.exs
+++ b/test/archethic/beacon_chain/slot_timer_test.exs
@@ -19,7 +19,13 @@ defmodule Archethic.BeaconChain.SlotTimerTest do
   end
 
   test "receive create_slot message after timer elapsed" do
-    SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+    :persistent_term.put(:archethic_up, nil)
+
+    {:ok, pid} = SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+    assert %{interval: "*/1 * * * * * *"} = :sys.get_state(pid)
+    send(pid, :node_up)
+    assert %{interval: "*/1 * * * * * *", timer: _} = :sys.get_state(pid)
+
     current = DateTime.utc_now()
 
     P2P.add_and_connect_node(%Node{
@@ -37,7 +43,12 @@ defmodule Archethic.BeaconChain.SlotTimerTest do
   end
 
   test "should not send create slot event if node is unavailable" do
-    SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+    :persistent_term.put(:archethic_up, nil)
+
+    {:ok, pid} = SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+    assert %{interval: "*/1 * * * * * *"} = :sys.get_state(pid)
+    send(pid, :node_up)
+    assert %{interval: "*/1 * * * * * *", timer: _} = :sys.get_state(pid)
 
     P2P.add_and_connect_node(%Node{
       first_public_key: Crypto.first_node_public_key(),
@@ -51,7 +62,12 @@ defmodule Archethic.BeaconChain.SlotTimerTest do
   end
 
   test "handle_info/3 receive a slot creation message" do
-    {:ok, pid} = SlotTimer.start_link([interval: "0 * * * * * *"], [])
+    :persistent_term.put(:archethic_up, nil)
+
+    {:ok, pid} = SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+    assert %{interval: "*/1 * * * * * *"} = :sys.get_state(pid)
+    send(pid, :node_up)
+    assert %{interval: "*/1 * * * * * *", timer: _} = :sys.get_state(pid)
 
     P2P.add_and_connect_node(%Node{
       first_public_key: Crypto.first_node_public_key(),
@@ -76,17 +92,52 @@ defmodule Archethic.BeaconChain.SlotTimerTest do
   end
 
   test "next_slot/1 should get the slot time from a given date" do
-    {:ok, _pid} = SlotTimer.start_link([interval: "0 * * * * * *", trigger_offset: 0], [])
+    :persistent_term.put(:archethic_up, nil)
+
+    {:ok, pid} = SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+    assert %{interval: "*/1 * * * * * *"} = :sys.get_state(pid)
+    send(pid, :node_up)
+    assert %{interval: "*/1 * * * * * *", timer: _} = :sys.get_state(pid)
+
     now = DateTime.utc_now()
     next_slot_time = SlotTimer.next_slot(now)
     assert :gt == DateTime.compare(next_slot_time, now)
   end
 
   test "previous_slot/2 should retrieve the previous slot time from a date" do
-    {:ok, _pid} = SlotTimer.start_link([interval: "0 * * * * * *"], [])
+    :persistent_term.put(:archethic_up, nil)
+
+    {:ok, pid} = SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+    assert %{interval: "*/1 * * * * * *"} = :sys.get_state(pid)
+    send(pid, :node_up)
+    assert %{interval: "*/1 * * * * * *", timer: _} = :sys.get_state(pid)
 
     now = DateTime.utc_now()
     previous_slot_time = SlotTimer.previous_slot(now)
     assert :gt == DateTime.compare(now, previous_slot_time)
+  end
+
+  describe "SlotTimer Behavior During start" do
+    test "should wait for node :up message" do
+      :persistent_term.put(:archethic_up, nil)
+
+      {:ok, pid} = SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+      assert %{interval: "*/1 * * * * * *"} = :sys.get_state(pid)
+    end
+
+    test "should start timer post node :up message" do
+      :persistent_term.put(:archethic_up, nil)
+
+      {:ok, pid} = SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+      assert %{interval: "*/1 * * * * * *"} = :sys.get_state(pid)
+      send(pid, :node_up)
+      assert %{interval: "*/1 * * * * * *", timer: _} = :sys.get_state(pid)
+    end
+
+    test "should use :persistent_term archethic_up when slot timer crashes" do
+      :persistent_term.put(:archethic_up, :up)
+      {:ok, pid} = SlotTimer.start_link([interval: "*/1 * * * * * *"], [])
+      assert %{interval: "*/1 * * * * * *", timer: _} = :sys.get_state(pid)
+    end
   end
 end

--- a/test/archethic/beacon_chain/subset_test.exs
+++ b/test/archethic/beacon_chain/subset_test.exs
@@ -42,6 +42,12 @@ defmodule Archethic.BeaconChain.SubsetTest do
 
     :ok = Subset.add_end_of_node_sync(subset, %EndOfNodeSync{public_key: public_key})
 
+    MockClient
+    |> stub(:send_message, fn
+      _, %NewBeaconTransaction{}, _ ->
+        {:ok, %Ok{}}
+    end)
+
     assert %{
              current_slot: %Slot{
                end_of_node_synchronizations: [%EndOfNodeSync{public_key: ^public_key}]
@@ -53,8 +59,12 @@ defmodule Archethic.BeaconChain.SubsetTest do
     test "new transaction summary is added to the slot and include the storage node confirmation",
          %{subset: subset} do
       MockClient
-      |> stub(:send_message, fn _, _txn = %TransactionSummary{}, _ ->
-        :ok
+      |> stub(:send_message, fn
+        _, _txn = %TransactionSummary{}, _ ->
+          {:ok, %Ok{}}
+
+        _, %NewBeaconTransaction{}, _ ->
+          {:ok, %Ok{}}
       end)
 
       start_supervised!({SummaryTimer, interval: "0 0 * * *"})
@@ -100,8 +110,8 @@ defmodule Archethic.BeaconChain.SubsetTest do
       pid = start_supervised!({Subset, subset: subset})
 
       MockClient
-      |> stub(:send_message, fn _, _txn = %NewBeaconTransaction{}, _ ->
-        :ok
+      |> stub(:send_message, fn _, %NewBeaconTransaction{}, _ ->
+        {:ok, %Ok{}}
       end)
 
       tx_time = DateTime.utc_now()

--- a/test/archethic/reward/scheduler_test.exs
+++ b/test/archethic/reward/scheduler_test.exs
@@ -17,7 +17,11 @@ defmodule Archethic.Reward.SchedulerTest do
     MockDB
     |> stub(:get_latest_burned_fees, fn -> 0 end)
 
-    assert {:ok, pid} = Scheduler.start_link(interval: "*/1 * * * * *")
+    {:ok, pid} = Scheduler.start_link(interval: "*/1 * * * * *")
+
+    assert {:idle, %{interval: "*/1 * * * * *"}} = :sys.get_state(pid)
+
+    send(pid, :node_up)
 
     assert {:idle, %{interval: "*/1 * * * * *"}} = :sys.get_state(pid)
 
@@ -58,6 +62,7 @@ defmodule Archethic.Reward.SchedulerTest do
       me = self()
 
       assert {:ok, pid} = Scheduler.start_link(interval: "*/1 * * * * *")
+      send(pid, :node_up)
 
       MockClient
       |> stub(:send_message, fn
@@ -84,10 +89,97 @@ defmodule Archethic.Reward.SchedulerTest do
         send(me, type)
       end)
 
-      assert {:ok, _} = Scheduler.start_link(interval: "*/1 * * * * *")
+      assert {:ok, pid} = Scheduler.start_link(interval: "*/1 * * * * *")
+      send(pid, :node_up)
 
       refute_receive :mint_rewards, 1_200
       assert_receive :node_rewards, 1_500
+    end
+  end
+
+  describe "Scheduler Behavior During Start" do
+    test "should be idle(state with args) when node has not done Bootstrapping" do
+      :persistent_term.put(:archethic_up, nil)
+
+      {:ok, pid} = Scheduler.start_link(interval: "*/1 * * * * *")
+
+      assert {:idle, %{interval: "*/1 * * * * *"}} = :sys.get_state(pid)
+    end
+
+    test "should wait for node :up message to start the scheduler, when node is not authorized and available" do
+      :persistent_term.put(:archethic_up, nil)
+
+      {:ok, pid} = Scheduler.start_link(interval: "*/2 * * * * *")
+
+      assert {:idle, %{interval: "*/2 * * * * *"}} = :sys.get_state(pid)
+
+      send(pid, :node_up)
+
+      assert {:idle, %{interval: "*/2 * * * * *"}} = :sys.get_state(pid)
+    end
+
+    test "should wait for node :up message to start the scheduler, when node is authorized and available" do
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3002,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
+        authorized?: true,
+        authorization_date: DateTime.utc_now(),
+        geo_patch: "AAA",
+        available?: true
+      })
+
+      {:ok, pid} = Scheduler.start_link(interval: "*/3 * * * * *")
+
+      assert {:idle, %{interval: "*/3 * * * * *"}} = :sys.get_state(pid)
+      send(pid, :node_up)
+
+      assert {:scheduled,
+              %{
+                interval: "*/3 * * * * *",
+                index: _,
+                next_address: _
+              }} = :sys.get_state(pid)
+    end
+
+    test "Should use persistent_term :archethic_up when a Scheduler crashes, when a node is not authorized and available" do
+      :persistent_term.put(:archethic_up, :up)
+
+      {:ok, pid} = Scheduler.start_link(interval: "*/4 * * * * *")
+
+      assert {:idle,
+              %{
+                interval: "*/4 * * * * *"
+              }} = :sys.get_state(pid)
+
+      :persistent_term.put(:archethic_up, nil)
+    end
+
+    test "Should use persistent_term :archethic_up when a Scheduler crashes, when a node is authorized and available" do
+      :persistent_term.put(:archethic_up, :up)
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3002,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
+        authorized?: true,
+        authorization_date: DateTime.utc_now(),
+        geo_patch: "AAA",
+        available?: true
+      })
+
+      {:ok, pid} = Scheduler.start_link(interval: "*/5 * * * * *")
+
+      assert {:scheduled,
+              %{
+                interval: "*/5 * * * * *",
+                index: _,
+                next_address: _
+              }} = :sys.get_state(pid)
+
+      :persistent_term.put(:archethic_up, nil)
     end
   end
 end

--- a/test/archethic/shared_secrets/node_renewal_scheduler_test.exs
+++ b/test/archethic/shared_secrets/node_renewal_scheduler_test.exs
@@ -28,6 +28,8 @@ defmodule Archethic.SharedSecrets.NodeRenewalSchedulerTest do
   end
 
   test "should initiate the node renewal scheduler and trigger node renewal every each seconds" do
+    :persistent_term.put(:archethic_up, :up)
+
     P2P.add_and_connect_node(%Node{
       first_public_key: Crypto.last_node_public_key(),
       last_public_key: Crypto.last_node_public_key(),
@@ -64,9 +66,12 @@ defmodule Archethic.SharedSecrets.NodeRenewalSchedulerTest do
     )
 
     assert_receive :renewal_processed, 3_000
+    :persistent_term.put(:archethic_up, nil)
   end
 
   test "should retrigger the scheduling after tx replication" do
+    :persistent_term.put(:archethic_up, :up)
+
     P2P.add_and_connect_node(%Node{
       first_public_key: Crypto.last_node_public_key(),
       last_public_key: Crypto.last_node_public_key(),
@@ -101,5 +106,94 @@ defmodule Archethic.SharedSecrets.NodeRenewalSchedulerTest do
     assert {:scheduled, %{timer: timer2}} = :sys.get_state(pid)
 
     assert timer2 != timer1
+    :persistent_term.put(:archethic_up, nil)
+  end
+
+  describe "Scheduler Behavior During start" do
+    test "should be idle when node has not done Bootstrapping" do
+      :persistent_term.put(:archethic_up, nil)
+
+      assert {:ok, pid} = Scheduler.start_link([interval: "*/2 * * * * *"], [])
+
+      assert {:idle, %{interval: "*/2 * * * * *"}} = :sys.get_state(pid)
+    end
+
+    test "should wait for node up message to start the scheduler, node: not authorized and available" do
+      :persistent_term.put(:archethic_up, nil)
+
+      assert {:ok, pid} = Scheduler.start_link([interval: "*/3 * * * * *"], [])
+
+      assert {:idle, %{interval: "*/3 * * * * *"}} = :sys.get_state(pid)
+
+      send(pid, :node_up)
+
+      assert {:idle,
+              %{
+                interval: "*/3 * * * * *"
+              }} = :sys.get_state(pid)
+    end
+
+    test "should wait for node up message to start the scheduler, node: authorized and available" do
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3002,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
+        authorized?: true,
+        authorization_date: DateTime.utc_now(),
+        geo_patch: "AAA",
+        available?: true
+      })
+
+      assert {:ok, pid} = Scheduler.start_link([interval: "*/4 * * * * *"], [])
+
+      assert {:idle, %{interval: "*/4 * * * * *"}} = :sys.get_state(pid)
+
+      send(pid, :node_up)
+
+      assert {:scheduled,
+              %{
+                interval: "*/4 * * * * *",
+                index: _
+              }} = :sys.get_state(pid)
+    end
+
+    test "Should use persistent_term :archethic_up when a Scheduler crashes,current node: Not authorized and available" do
+      :persistent_term.put(:archethic_up, :up)
+
+      assert {:ok, pid} = Scheduler.start_link([interval: "*/5 * * * * *"], [])
+
+      assert {:idle,
+              %{
+                interval: "*/5 * * * * *"
+              }} = :sys.get_state(pid)
+
+      :persistent_term.put(:archethic_up, nil)
+    end
+
+    test "Should use persistent_term :archethic_up when a Scheduler crashes, current node: authorized and available" do
+      :persistent_term.put(:archethic_up, :up)
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3002,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
+        authorized?: true,
+        authorization_date: DateTime.utc_now(),
+        geo_patch: "AAA",
+        available?: true
+      })
+
+      assert {:ok, pid} = Scheduler.start_link([interval: "*/6 * * * * *"], [])
+
+      assert {:scheduled,
+              %{
+                interval: "*/6 * * * * *",
+                index: _
+              }} = :sys.get_state(pid)
+
+      :persistent_term.put(:archethic_up, nil)
+    end
   end
 end

--- a/test/archethic/utils/detect_node_responsiveness_test.exs
+++ b/test/archethic/utils/detect_node_responsiveness_test.exs
@@ -1,5 +1,5 @@
 defmodule Archethic.Utils.DetectNodeResponsivenessTest do
-  use ArchethicCase
+  use ArchethicCase, async: false
   @timeout 200
   @sleep_timeout 350
 


### PR DESCRIPTION
# Description

Scheduler must start only after post Bootstrap, So that no new next txn are sent during bootstrap .  
During crash scheduler must read arch-ethic_up  before starting.

Affected Schedulers
- Reward
- Oracle
- Node Renewal
- Slot timer

Fixes # (#543)

## Type of change

# How Has This Been Tested?

- [x] Unit Test cases. 
- [x] Distributed Testing.

Logs were checked to ensure the scheduler started post Bootstrap Finished message.

![Screenshot_20220906_161508](https://user-images.githubusercontent.com/90304197/188615910-f7380b9d-cfc0-4d0e-81e1-e1128fd7dcac.png)

explicitly killing a scheduler
![Screenshot_20220906_162836](https://user-images.githubusercontent.com/90304197/188618469-d602bf84-90cf-4661-8023-5ff44bd29d9c.png)

## How to test?

Use Logs to confirm that schedulers started post bootstrap finished message.





# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
