### PR TITLE
Archethic Node cron scheduler wrongly configured #540

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -196,7 +196,7 @@ defmodule Archethic.Contracts do
   end
 
   defp valid_from_trigger?(
-         %Trigger{type: :interval, opts: [at: interval, extended_mode: _]},
+         %Trigger{type: :interval, opts: [at: interval]},
          %Transaction{},
          validation_date = %DateTime{}
        ) do

--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -196,7 +196,7 @@ defmodule Archethic.Contracts do
   end
 
   defp valid_from_trigger?(
-         %Trigger{type: :interval, opts: [at: interval]},
+         %Trigger{type: :interval, opts: [at: interval, extended_mode: _]},
          %Transaction{},
          validation_date = %DateTime{}
        ) do

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -68,7 +68,7 @@ defmodule Archethic.Contracts.Contract do
   def add_trigger(
         contract = %__MODULE__{},
         :interval,
-        opts = [at: interval, extended_mode: _],
+        opts = [at: interval],
         actions
       )
       when is_binary(interval) do

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -65,7 +65,12 @@ defmodule Archethic.Contracts.Contract do
     do_add_trigger(contract, %Trigger{type: :datetime, opts: opts, actions: actions})
   end
 
-  def add_trigger(contract = %__MODULE__{}, :interval, opts = [at: interval], actions)
+  def add_trigger(
+        contract = %__MODULE__{},
+        :interval,
+        opts = [at: interval, extended_mode: _],
+        actions
+      )
       when is_binary(interval) do
     do_add_trigger(contract, %Trigger{type: :interval, opts: opts, actions: actions})
   end

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -822,10 +822,22 @@ defmodule Archethic.Contracts.Interpreter do
         "interval" ->
           [{{:atom, "at"}, interval}] = opts
 
+          # Extended Mode Signifies whether use CRON Extended Mode or Not while running SC Intervals
+          extended_mode =
+            case length(String.split(interval, " ", trim: true)) do
+              5 -> false
+              _ -> true
+            end
+
           Map.update!(
             acc,
             :contract,
-            &Contract.add_trigger(&1, :interval, [at: interval], actions)
+            &Contract.add_trigger(
+              &1,
+              :interval,
+              [at: interval, extended_mode: extended_mode],
+              actions
+            )
           )
 
         "transaction" ->

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -822,20 +822,13 @@ defmodule Archethic.Contracts.Interpreter do
         "interval" ->
           [{{:atom, "at"}, interval}] = opts
 
-          # Extended Mode Signifies whether use CRON Extended Mode or Not while running SC Intervals
-          extended_mode =
-            case length(String.split(interval, " ", trim: true)) do
-              5 -> false
-              _ -> true
-            end
-
           Map.update!(
             acc,
             :contract,
             &Contract.add_trigger(
               &1,
               :interval,
-              [at: interval, extended_mode: extended_mode],
+              [at: interval],
               actions
             )
           )

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -241,12 +241,12 @@ defmodule Archethic.Contracts.Worker do
   end
 
   defp schedule_trigger(
-         trigger = %Trigger{type: :interval, opts: [at: interval, extended_mode: extended_mode]}
+         trigger = %Trigger{type: :interval, opts: [at: interval]}
        ) do
     Process.send_after(
       self(),
       trigger,
-      Utils.time_offset(interval, DateTime.utc_now(), extended_mode) * 1000
+      Utils.time_offset(interval, DateTime.utc_now(), false) * 1000
     )
   end
 

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -240,9 +240,7 @@ defmodule Archethic.Contracts.Worker do
     {:via, Registry, {ContractRegistry, address}}
   end
 
-  defp schedule_trigger(
-         trigger = %Trigger{type: :interval, opts: [at: interval]}
-       ) do
+  defp schedule_trigger(trigger = %Trigger{type: :interval, opts: [at: interval]}) do
     Process.send_after(
       self(),
       trigger,

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -240,8 +240,14 @@ defmodule Archethic.Contracts.Worker do
     {:via, Registry, {ContractRegistry, address}}
   end
 
-  defp schedule_trigger(trigger = %Trigger{type: :interval, opts: [at: interval]}) do
-    Process.send_after(self(), trigger, Utils.time_offset(interval) * 1000)
+  defp schedule_trigger(
+         trigger = %Trigger{type: :interval, opts: [at: interval, extended_mode: extended_mode]}
+       ) do
+    Process.send_after(
+      self(),
+      trigger,
+      Utils.time_offset(interval, DateTime.utc_now(), extended_mode) * 1000
+    )
   end
 
   defp schedule_trigger(trigger = %Trigger{type: :datetime, opts: [at: datetime = %DateTime{}]}) do

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -38,10 +38,10 @@ defmodule Archethic.Utils do
       # 1 second + offset = 86400 (1 day)
   """
   @spec time_offset(cron_interval :: binary()) :: seconds :: non_neg_integer()
-  def time_offset(interval, ref_time \\ DateTime.utc_now()) do
+  def time_offset(interval, ref_time \\ DateTime.utc_now(), extended_mode \\ true) do
     next_slot =
       interval
-      |> CronParser.parse!(true)
+      |> CronParser.parse!(extended_mode)
       |> CronScheduler.get_next_run_date!(DateTime.to_naive(ref_time))
       |> DateTime.from_naive!("Etc/UTC")
 

--- a/test/archethic/contracts/worker_test.exs
+++ b/test/archethic/contracts/worker_test.exs
@@ -194,11 +194,11 @@ defmodule Archethic.Contracts.WorkerTest do
               assert tx.address == expected_tx.address
               assert tx.data.code == code
           after
-            3_000 ->
+            100_000 ->
               raise "Timeout"
           end
       after
-        3_000 ->
+        100_000 ->
           raise "Timeout"
       end
     end


### PR DESCRIPTION
# Description
Before when supplied with old Cron Specification, the extended mode was triggering SC with per seconds which is not the intended effect which is to send per minute

Fixes #540 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Manually Tested


# Checklist:
![Screenshot from 2022-09-01 20-05-59](https://user-images.githubusercontent.com/89784724/187941606-65feccd2-d92d-464a-b90c-27919d58323e.png)


- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
