### PR TITLE
Fix unspent outputs amount

### DIFF
--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -384,9 +384,14 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       tokens_received
       |> Enum.reject(&Map.has_key?(tokens_to_spend, elem(&1, 0)))
       |> Enum.map(fn {{token_address, token_id}, amount} ->
-        Enum.find(inputs, fn input ->
-          input.type == {:token, token_address, token_id} and input.amount == amount
-        end)
+        input =
+          Enum.find(inputs, fn input ->
+            input.type == {:token, token_address, token_id}
+          end)
+
+        if input.amount == amount,
+          do: input,
+          else: %{input | amount: amount, from: change_address}
       end)
 
     Enum.reduce(tokens_to_spend, tokens_not_used, fn {{token_address, token_id}, amount_to_spend},


### PR DESCRIPTION
# Description

Fix a bug where the amount of token unspent outuput was not updated causing crash

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create 2 addresses and do a faucet on them

With address 1 : 
- Create a fungible token
- Send small amount of this token to address 2
- Send again small amount of this token to address 2

With address 2 : 
- Send UCO to any address, it should not crash anymore

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
