### PR TITLE
Remove used messages tracking in the PortHandler

### DIFF
--- a/lib/archethic/utils/port_handler.ex
+++ b/lib/archethic/utils/port_handler.ex
@@ -49,11 +49,11 @@ defmodule Archethic.Utils.PortHandler do
         {_port, {:data, <<request_id::32, response::binary>>}},
         state = %{awaiting: awaiting}
       ) do
-    case Map.get(awaiting, request_id) do
-      nil ->
-        {:noreply, state}
+    case Map.pop(awaiting, request_id) do
+      {nil, awaiting} ->
+        {:noreply, %{state | awaiting: awaiting}}
 
-      client ->
+      {client, awaiting} ->
         case response do
           <<0::8, error_message::binary>> ->
             GenServer.reply(client, {:error, error_message})
@@ -65,7 +65,7 @@ defmodule Archethic.Utils.PortHandler do
             GenServer.reply(client, {:ok, data})
         end
 
-        {:noreply, state}
+        {:noreply, %{state | awaiting: awaiting}}
     end
   end
 


### PR DESCRIPTION
# Description

This fix reduce the memory footprint by pruning used messages when communicating with a port (external program)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
