### PR TITLE
Fix invalid movement when transactoin send funds to itself

### DIFF
--- a/lib/archethic/account/mem_tables/token_ledger.ex
+++ b/lib/archethic/account/mem_tables/token_ledger.ex
@@ -72,10 +72,19 @@ defmodule Archethic.Account.MemTables.TokenLedger do
       )
       when is_binary(to_address) and is_binary(from_address) and is_integer(amount) and amount > 0 and
              is_binary(token_address) and is_integer(token_id) and token_id >= 0 do
+    spent? =
+      case :ets.lookup(@unspent_output_index_table, to_address) do
+        [] ->
+          false
+
+        [ledger_key | _] ->
+          :ets.lookup_element(@ledger_table, ledger_key, 3)
+      end
+
     true =
       :ets.insert(
         @ledger_table,
-        {{to_address, from_address, token_address, token_id}, amount, false, timestamp}
+        {{to_address, from_address, token_address, token_id}, amount, spent?, timestamp}
       )
 
     true =

--- a/lib/archethic/account/mem_tables/uco_ledger.ex
+++ b/lib/archethic/account/mem_tables/uco_ledger.ex
@@ -68,7 +68,16 @@ defmodule Archethic.Account.MemTables.UCOLedger do
         timestamp = %DateTime{}
       )
       when is_binary(to) and is_integer(amount) and amount > 0 do
-    true = :ets.insert(@ledger_table, {{to, from}, amount, false, timestamp, reward?})
+    spent? =
+      case :ets.lookup(@unspent_output_index_table, to) do
+        [] ->
+          false
+
+        [ledger_key | _] ->
+          :ets.lookup_element(@ledger_table, ledger_key, 3)
+      end
+
+    true = :ets.insert(@ledger_table, {{to, from}, amount, spent?, timestamp, reward?})
     true = :ets.insert(@unspent_output_index_table, {to, from})
 
     Logger.info("#{amount} unspent UCO added for #{Base.encode16(to)}",

--- a/lib/archethic/db/embedded_impl/chain_index.ex
+++ b/lib/archethic/db/embedded_impl/chain_index.ex
@@ -461,17 +461,11 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
          {:ok, hash} <- :file.read(fd, hash_size) do
       address = <<curve_id::8, hash_id::8, hash::binary>>
 
-      cond do
-        timestamp < until ->
-          do_search_last_address_until(fd, until, {address, timestamp})
-
-        timestamp == until ->
-          :file.close(fd)
-          {address, timestamp}
-
-        true ->
-          :file.close(fd)
-          acc
+      if timestamp < until do
+        do_search_last_address_until(fd, until, {address, timestamp})
+      else
+        :file.close(fd)
+        acc
       end
     else
       :eof ->

--- a/lib/archethic_web/graphql_schema/transaction_type.ex
+++ b/lib/archethic_web/graphql_schema/transaction_type.ex
@@ -231,9 +231,10 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
   It includes:
   - genesis: Genesis address to the token
   - name: Name of the token
-  - symbol: Symbol for the token
+  - symbol: Symbol of the token
   - supply: Supply of the token
   - type: Type of the token
+  - decimals: Number of decimals of the token
   - properties: Properties of the token (if any)
   - collection: List of properties for a collection (if any)
   - id: Unique identification of the token on the chain

--- a/test/archethic/db/embedded_impl_test.exs
+++ b/test/archethic/db/embedded_impl_test.exs
@@ -441,43 +441,6 @@ defmodule Archethic.DB.EmbeddedTest do
              ) == :eq
     end
 
-    test "should get the last address of chain for the exact time of last address timestamp" do
-      tx1 =
-        TransactionFactory.create_valid_transaction([],
-          index: 0,
-          timestamp: ~U[2020-03-30 10:13:00Z]
-        )
-
-      tx2 =
-        TransactionFactory.create_valid_transaction([],
-          index: 1,
-          timestamp: ~U[2020-04-02 10:13:00Z]
-        )
-
-      tx3 =
-        TransactionFactory.create_valid_transaction([],
-          index: 2,
-          timestamp: ~U[2020-04-10 10:13:00Z]
-        )
-
-      EmbeddedImpl.write_transaction_chain([tx1, tx2, tx3])
-
-      assert {tx3.address, ~U[2020-04-10 10:13:00.000Z]} ==
-               EmbeddedImpl.get_last_chain_address(tx3.address, tx3.validation_stamp.timestamp)
-
-      assert {tx2.address, ~U[2020-04-02 10:13:00.000Z]} ==
-               EmbeddedImpl.get_last_chain_address(tx2.address, tx2.validation_stamp.timestamp)
-
-      assert {tx1.address, ~U[2020-03-30 10:13:00.000Z]} ==
-               EmbeddedImpl.get_last_chain_address(tx1.address, tx1.validation_stamp.timestamp)
-
-      assert {tx1.address, ~U[2020-03-30 10:13:00.000Z]} ==
-               EmbeddedImpl.get_last_chain_address(
-                 Transaction.previous_address(tx1),
-                 tx1.validation_stamp.timestamp
-               )
-    end
-
     test "should get the last address of a chain before given date" do
       tx1 =
         TransactionFactory.create_valid_transaction([],
@@ -499,10 +462,10 @@ defmodule Archethic.DB.EmbeddedTest do
 
       EmbeddedImpl.write_transaction_chain([tx1, tx2, tx3])
 
-      assert {tx3.address, ~U[2020-04-10 10:13:00.000Z]} ==
+      assert {tx2.address, ~U[2020-04-02 10:13:00.000Z]} ==
                EmbeddedImpl.get_last_chain_address(tx2.address, tx3.validation_stamp.timestamp)
 
-      assert {tx3.address, ~U[2020-04-10 10:13:00.000Z]} ==
+      assert {tx2.address, ~U[2020-04-02 10:13:00.000Z]} ==
                EmbeddedImpl.get_last_chain_address(tx1.address, tx3.validation_stamp.timestamp)
 
       assert {tx2.address, ~U[2020-04-02 10:13:00.000Z]} ==
@@ -510,9 +473,6 @@ defmodule Archethic.DB.EmbeddedTest do
                  tx1.address,
                  DateTime.add(tx2.validation_stamp.timestamp, 100)
                )
-
-      assert {tx2.address, ~U[2020-04-02 10:13:00.000Z]} ==
-               EmbeddedImpl.get_last_chain_address(tx1.address, tx2.validation_stamp.timestamp)
 
       assert {tx1.address, ~U[2020-03-30 10:13:00.000Z]} ==
                EmbeddedImpl.get_last_chain_address(
@@ -828,7 +788,7 @@ defmodule Archethic.DB.EmbeddedTest do
       genesis_address = Transaction.previous_address(tx1)
 
       EmbeddedImpl.write_transaction(tx1)
-      now = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+      now = DateTime.utc_now() |> DateTime.add(-1) |> DateTime.truncate(:millisecond)
       EmbeddedImpl.add_last_transaction_address(genesis_address, tx2.address, now)
 
       assert {tx2.address, now} == EmbeddedImpl.get_last_chain_address(tx1.address)


### PR DESCRIPTION
# Description

Fixes an issue when a transaction send funds to itself. If a node try to do a self repair including this transaction, an invalid_transaction_movement appear.
Error is raised because the last transaction address at a specific date return the address if the timestamp is < or = and so the transaction is validated in first as the last address at this time is thre previous transaction of the chain, but during the self repair, the last transaction at this time is the transaction itself.

So to fix this, the last transaction address at specific date returns do not return timestamp == date

Also fix the spent? flag on UTXO when the transaction is already spent

Fixes #594 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Start a node -> faucet to an address
Send a transaction to itself
The unspent output of the previous address should be spent
Start a second node and the self repair should pass normaly

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
