### PR TITLE
Fix some display / API issue

### DIFF
--- a/lib/archethic/metrics/poller.ex
+++ b/lib/archethic/metrics/poller.ex
@@ -70,7 +70,9 @@ defmodule Archethic.Metrics.Poller do
            http_port: port,
            first_public_key: first_public_key
          } ->
-        {first_public_key, Collector.fetch_metrics(ip, port)}
+        if first_public_key == Archethic.Crypto.first_node_public_key(),
+          do: {first_public_key, Collector.fetch_metrics({127, 0, 0, 1}, port)},
+          else: {first_public_key, Collector.fetch_metrics(ip, port)}
       end,
       on_timeout: :kill_task
     )

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -539,14 +539,14 @@ defmodule Archethic.P2P.Message do
     token_balances_binary =
       token_balances
       |> Enum.reduce([], fn {{token_address, token_id}, amount}, acc ->
-        [<<token_address::binary, amount::float, VarInt.from_value(token_id)::binary>> | acc]
+        [<<token_address::binary, amount::64, VarInt.from_value(token_id)::binary>> | acc]
       end)
       |> Enum.reverse()
       |> :erlang.list_to_binary()
 
     encoded_token_balances_length = map_size(token_balances) |> VarInt.from_value()
 
-    <<248::8, uco_balance::float, encoded_token_balances_length::binary,
+    <<248::8, uco_balance::64, encoded_token_balances_length::binary,
       token_balances_binary::binary>>
   end
 
@@ -1084,7 +1084,7 @@ defmodule Archethic.P2P.Message do
      }, rest}
   end
 
-  def decode(<<248::8, uco_balance::float, rest::bitstring>>) do
+  def decode(<<248::8, uco_balance::64, rest::bitstring>>) do
     {nb_token_balances, rest} = rest |> VarInt.get_value()
     {token_balances, rest} = deserialize_token_balances(rest, nb_token_balances, %{})
 
@@ -1200,7 +1200,7 @@ defmodule Archethic.P2P.Message do
   end
 
   defp deserialize_token_balances(rest, nb_token_balances, acc) do
-    {token_address, <<amount::float, rest::bitstring>>} = Utils.deserialize_address(rest)
+    {token_address, <<amount::64, rest::bitstring>>} = Utils.deserialize_address(rest)
     {token_id, rest} = VarInt.get_value(rest)
 
     deserialize_token_balances(

--- a/lib/archethic_web/live/chains/oracle_live.ex
+++ b/lib/archethic_web/live/chains/oracle_live.ex
@@ -180,7 +180,7 @@ defmodule ArchethicWeb.OracleChainLive do
                      } ->
       %{address: address, type: type, timestamp: timestamp}
     end)
-    |> Enum.to_list()
+    |> Enum.reverse()
   end
 
   defp list_transactions_by_date(nil), do: []


### PR DESCRIPTION
# Description

Fix some issue affecting explorer and API
- `%GetBalance` message: amount serialized in float instead of integer, it was returning number in scientific notation (3e8) but this notation is not handled in Absinthe serialization.
- Metric poller : when using upnp, some router do not open port for local request on public ip (public_ip:port does not work but local_ip:port does work). If not request metrics to iteself, changed ip to 127.0.0.1
- Oracle chain on explorer is firstly loaded in chronologic order, but when a new transaction comes, the transaction is prepended causing an inconsistencie in the transaction order

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

%GetBalance message return integer value correctly
Metric poller can fetch metric from local ip correclty

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
