### PR TITLE
Fix paging address with selected fields

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -120,6 +120,9 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
   end
 
   defp do_process_get_chain(fd, address, fields) do
+    # Always return transaction address
+    fields = if Enum.empty?(fields), do: fields, else: Enum.uniq([:address | fields])
+
     column_names = fields_to_column_names(fields)
 
     # Read the transactions until the nb of transactions to fullfil the page (ie. 10 transactions)
@@ -174,6 +177,9 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
           {list(Transaction.t()), boolean(), binary() | nil}
   def scan_chain(genesis_address, limit_address, fields, paging_address, db_path) do
     filepath = ChainWriter.chain_path(db_path, genesis_address)
+    # Always return transaction address
+    fields = if Enum.empty?(fields), do: fields, else: Enum.uniq([:address | fields])
+
     column_names = fields_to_column_names(fields)
 
     case File.open(filepath, [:binary, :read]) do


### PR DESCRIPTION
# Description

Fix a bug when requesting a chain to the DB with selected fields.
DB return transaction chain paginated by size of 10, if the chain has more than 10 transactions, DB return the paging address which is the transaction address of the last transaction read.
The problem is if we request specific fields without address, the transaction read have a nil address and so the paging address returned is nil. This beahavior leads to an infinite loop in some case.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a transaction chain with more than 10 transactions, request the chain with some specific fields without address (`TransactionChain.get(address, [data: [:content], validation_stamp: [:timestamp]])`) the return is `{chain, true, paging_address}`
with pagin address != nil

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
