### PR TITLE
Use NV indexes to store node's seed in TPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC = /usr/bin/gcc
 OS := $(shell uname)
 TPM_INSTALLED := $(shell ldconfig -p | grep libtss2-esys.so > /dev/null; echo $$?)
+TPMFLAGS = -ltss2-esys -ltss2-rc -ltss2-mu -lcrypto
 
 all: compile_c_programs
 
@@ -15,8 +16,8 @@ compile_c_programs:
 	
 
 ifeq ($(TPM_INSTALLED),0)
-	$(CC) src/c/crypto/stdio_helpers.c src/c/crypto/tpm/lib.c src/c/crypto/tpm/port.c -o priv/c_dist/tpm_port -I src/c/crypto/stdio_helpers.h -I src/c/crypto/tpm/lib.h -ltss2-esys
-	$(CC) src/c/crypto/tpm/keygen.c src/c/crypto/tpm/lib.c -o priv/c_dist/tpm_keygen -I src/c/crypto/tpm/lib.h -ltss2-esys -lcrypto
+	$(CC) src/c/crypto/stdio_helpers.c src/c/crypto/tpm/lib.c src/c/crypto/tpm/port.c -o priv/c_dist/tpm_port -I src/c/crypto/stdio_helpers.h -I src/c/crypto/tpm/lib.h $(TPMFLAGS)
+	$(CC) src/c/crypto/tpm/keygen.c src/c/crypto/tpm/lib.c -o priv/c_dist/tpm_keygen -I src/c/crypto/tpm/lib.h $(TPMFLAGS)
 endif
 
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -64,8 +64,8 @@ config :archethic, Archethic.P2P.BootstrappingSeeds,
       "127.0.0.1:3002:00011D967D71B2E135C84206DDD108B5925A2CD99C8EBC5AB5D8FD2EC9400CE3C98A:tcp"
     )
 
-config :archethic, Archethic.Crypto.NodeKeystore.SoftwareImpl,
-  seed: System.get_env("ARCHETHIC_CRYPTO_SEED", "node1")
+config :archethic, Archethic.Crypto.NodeKeystore.Origin.SoftwareImpl,
+  node_seed: System.get_env("ARCHETHIC_CRYPTO_SEED", "node1")
 
 config :archethic,
        Archethic.Crypto.NodeKeystore.Origin,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -102,8 +102,8 @@ config :archethic, Archethic.Crypto,
   key_certificates_dir: System.get_env("ARCHETHIC_CRYPTO_CERT_DIR", "~/aebot/key_certificates")
 
 config :archethic,
-       Archethic.Crypto.NodeKeystore.SoftwareImpl,
-       seed: System.get_env("ARCHETHIC_CRYPTO_SEED")
+       Archethic.Crypto.NodeKeystore.Origin.SoftwareImpl,
+       node_seed: System.get_env("ARCHETHIC_CRYPTO_SEED")
 
 config :archethic,
        Archethic.Crypto.NodeKeystore.Origin,

--- a/lib/archethic/crypto/keystore/node/origin.ex
+++ b/lib/archethic/crypto/keystore/node/origin.ex
@@ -8,4 +8,5 @@ defmodule Archethic.Crypto.NodeKeystore.Origin do
   @callback child_spec(any) :: Supervisor.child_spec()
   @callback sign_with_origin_key(data :: iodata()) :: binary()
   @callback origin_public_key() :: Crypto.key()
+  @callback retrieve_node_seed() :: binary()
 end

--- a/lib/archethic/crypto/keystore/node/origin/tpm_impl.ex
+++ b/lib/archethic/crypto/keystore/node/origin/tpm_impl.ex
@@ -114,6 +114,7 @@ defmodule Archethic.Crypto.NodeKeystore.Origin.TPMImpl do
   end
 
   defp retrieve_node_seed(port_handler) do
-    PortHandler.request(port_handler, 4, <<>>)
+    {:ok, seed} = PortHandler.request(port_handler, 4, <<>>)
+    seed
   end
 end

--- a/lib/archethic/crypto/keystore/node_supervisor.ex
+++ b/lib/archethic/crypto/keystore/node_supervisor.ex
@@ -13,12 +13,9 @@ defmodule Archethic.Crypto.NodeKeystore.Supervisor do
   end
 
   def init(_) do
-    node_keystore_impl = Application.get_env(:archethic, NodeKeystore, NodeKeystore.SoftwareImpl)
-    node_keystore_conf = Application.get_env(:archethic, node_keystore_impl)
-
     children = [
-      {NodeKeystore, node_keystore_conf},
-      Origin
+      Origin,
+      NodeKeystore
     ]
 
     Supervisor.init(Utils.configurable_children(children), strategy: :one_for_one)

--- a/src/c/crypto/tpm/keygen.c
+++ b/src/c/crypto/tpm/keygen.c
@@ -1,22 +1,18 @@
-#include <stdio.h>
-#include <openssl/sha.h>
 #include "lib.h"
+#include <openssl/sha.h>
+#include <stdio.h>
 
-void main()
-{
-    initializeTPM(1);
+void main() {
+  initializeTPM(1);
 
-    INT publicKeySize = 0;
-    BYTE *asnkey;
+  INT publicKeySize = 0;
+  BYTE *asnkey;
 
-    for (int z = 0; z < 500; z++)
-    {
-        asnkey = getPublicKey(z, &publicKeySize);
-        for (int v = 26; v < publicKeySize; v++)
-        {
-            printf("%02x", asnkey[v]);
-        }
-        printf("\n");
+  for (int z = 0; z < 500; z++) {
+    asnkey = getPublicKey(z, &publicKeySize);
+    for (int v = 26; v < publicKeySize; v++) {
+      printf("%02x", asnkey[v]);
     }
+    printf("\n");
+  }
 }
-

--- a/src/c/crypto/tpm/lib.c
+++ b/src/c/crypto/tpm/lib.c
@@ -15,7 +15,7 @@
 #define PRIME_LEN 32
 #define ANS1_MAX_KEY_SIZE 4 + 9 + 10 + 4 + PRIME_LEN + PRIME_LEN
 
-#define NV_INDEX 0x1880001
+#define NV_INDEX 0x1880650
 
 static ESYS_CONTEXT *esysContext;
 int rc;

--- a/src/c/crypto/tpm/lib.c
+++ b/src/c/crypto/tpm/lib.c
@@ -1,7 +1,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include <tss2/tss2_esys.h>
+#include <tss2/tss2_mu.h>
+#include <tss2/tss2_rc.h>
+
 #include "lib.h"
 
 #define ASN1_SEQ 0x30
@@ -11,7 +15,9 @@
 #define PRIME_LEN 32
 #define ANS1_MAX_KEY_SIZE 4 + 9 + 10 + 4 + PRIME_LEN + PRIME_LEN
 
-static ESYS_CONTEXT *esys_context;
+#define NV_INDEX 0x1880001
+
+static ESYS_CONTEXT *esysContext;
 int rc;
 
 static ESYS_TR rootKeyHandle;
@@ -38,385 +44,450 @@ static BYTE tempKey[ANS1_MAX_KEY_SIZE];
 static BYTE sigEccASN[2 + 2 + PRIME_LEN + 2 + PRIME_LEN + 2];
 static BYTE zPoint[2 * PRIME_LEN + 1];
 
-void keyToASN()
-{
-    BYTE asnHeader[] = {ASN1_SEQ, 0x59, ASN1_SEQ, 0x13};
-    BYTE keyType[] = {ASN1_OID, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01};
-    BYTE curveType[] = {ASN1_OID, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07};
-    BYTE pubKeyHeader[] = {ASN1_BitString, 0x42, 0x00, 0x04};
+void keyToASN() {
+  BYTE asnHeader[] = {ASN1_SEQ, 0x59, ASN1_SEQ, 0x13};
+  BYTE keyType[] = {ASN1_OID, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01};
+  BYTE curveType[] = {ASN1_OID, 0x08, 0x2a, 0x86, 0x48,
+                      0xce,     0x3d, 0x03, 0x01, 0x07};
+  BYTE pubKeyHeader[] = {ASN1_BitString, 0x42, 0x00, 0x04};
 
-    int index = 0, size_x_y = 0;
-    memcpy(currentKeyASN + index, asnHeader, sizeof(asnHeader));
-    index += sizeof(asnHeader);
+  int index = 0, size_x_y = 0;
+  memcpy(currentKeyASN + index, asnHeader, sizeof(asnHeader));
+  index += sizeof(asnHeader);
 
-    memcpy(currentKeyASN + index, keyType, sizeof(keyType));
-    index += sizeof(keyType);
+  memcpy(currentKeyASN + index, keyType, sizeof(keyType));
+  index += sizeof(keyType);
 
-    memcpy(currentKeyASN + index, curveType, sizeof(curveType));
-    index += sizeof(curveType);
+  memcpy(currentKeyASN + index, curveType, sizeof(curveType));
+  index += sizeof(curveType);
 
-    memcpy(currentKeyASN + index, pubKeyHeader, sizeof(pubKeyHeader));
-    index += sizeof(pubKeyHeader);
+  memcpy(currentKeyASN + index, pubKeyHeader, sizeof(pubKeyHeader));
+  index += sizeof(pubKeyHeader);
 
-    size_x_y = currentKeyTPM->publicArea.unique.ecc.x.size;
-    memcpy(currentKeyASN + index, currentKeyTPM->publicArea.unique.ecc.x.buffer, size_x_y);
-    index += size_x_y;
+  size_x_y = currentKeyTPM->publicArea.unique.ecc.x.size;
+  memcpy(currentKeyASN + index, currentKeyTPM->publicArea.unique.ecc.x.buffer,
+         size_x_y);
+  index += size_x_y;
 
-    size_x_y = currentKeyTPM->publicArea.unique.ecc.y.size;
-    memcpy(currentKeyASN + index, currentKeyTPM->publicArea.unique.ecc.y.buffer, size_x_y);
-    index += size_x_y;
+  size_x_y = currentKeyTPM->publicArea.unique.ecc.y.size;
+  memcpy(currentKeyASN + index, currentKeyTPM->publicArea.unique.ecc.y.buffer,
+         size_x_y);
+  index += size_x_y;
 
-    currentKeySizeASN = index;
-    //Esys_Free(currentKeyTPM);
+  currentKeySizeASN = index;
+  // Esys_Free(currentKeyTPM);
 }
 
-void signToASN(BYTE *r, INT sizeR, BYTE *s, INT sizeS, INT *asnSignSize)
-{
+void signToASN(BYTE *r, INT sizeR, BYTE *s, INT sizeS, INT *asnSignSize) {
 
-    int index = 0;
-    sigEccASN[index++] = ASN1_SEQ;
+  int index = 0;
+  sigEccASN[index++] = ASN1_SEQ;
 
-    int asnLen = (PRIME_LEN * 2) + 4;
-    if (r[0] > 127) // check MSB, R needs padding to remain positive
-        asnLen++;
-    if (s[0] > 127) // check MSB, S needs padding to remain positive
-        asnLen++;
-    /*
-	if(asnLen > 127)
-		sigEccASN[index++] = 0x81;
-    */
-    sigEccASN[index++] = asnLen;
+  int asnLen = (PRIME_LEN * 2) + 4;
+  if (r[0] > 127) { // check MSB, R needs padding to remain positive
+    asnLen++;
+  }
+  if (s[0] > 127) { // check MSB, S needs padding to remain positive
+    asnLen++;
+  }
+  /*
+      if(asnLen > 127)
+              sigEccASN[index++] = 0x81;
+  */
+  sigEccASN[index++] = asnLen;
 
-    // R value
-    sigEccASN[index++] = ASN1_INT;
-    if (r[0] > 127)
-    {
-        sigEccASN[index++] = PRIME_LEN + 1;
-        sigEccASN[index++] = 0x00; // Extra byte to ensure R remains positive
-    }
-    else
-        sigEccASN[index++] = PRIME_LEN;
-    memcpy(sigEccASN + index, r, PRIME_LEN);
-    index += PRIME_LEN;
+  // R value
+  sigEccASN[index++] = ASN1_INT;
+  if (r[0] > 127) {
+    sigEccASN[index++] = PRIME_LEN + 1;
+    sigEccASN[index++] = 0x00; // Extra byte to ensure R remains positive
+  } else {
+    sigEccASN[index++] = PRIME_LEN;
+  }
+  memcpy(sigEccASN + index, r, PRIME_LEN);
+  index += PRIME_LEN;
 
-    // S value
-    sigEccASN[index++] = ASN1_INT;
-    if (s[0] > 127)
-    {
-        sigEccASN[index++] = PRIME_LEN + 1;
-        sigEccASN[index++] = 0x00; // Extra byte to ensure S remains positive
-    }
-    else
-        sigEccASN[index++] = PRIME_LEN;
-    memcpy(sigEccASN + index, s, PRIME_LEN);
-    index += PRIME_LEN;
+  // S value
+  sigEccASN[index++] = ASN1_INT;
+  if (s[0] > 127) {
+    sigEccASN[index++] = PRIME_LEN + 1;
+    sigEccASN[index++] = 0x00; // Extra byte to ensure S remains positive
+  } else {
+    sigEccASN[index++] = PRIME_LEN;
+  }
+  memcpy(sigEccASN + index, s, PRIME_LEN);
+  index += PRIME_LEN;
 
-    *asnSignSize = index;
+  *asnSignSize = index;
 
-    //return sigEccASN;
+  // return sigEccASN;
 }
 
-void generatePublicKey(INT keyIndex)
-{
+void generatePublicKey(INT keyIndex) {
+  TPM2B_SENSITIVE_CREATE inSensitive = {
+      .size = 0,
+      .sensitive = {.userAuth =
+                        {
+                            .size = 0,
+                            .buffer = {0},
+                        },
+                    .data = {.size = 0, .buffer = {0}}}};
 
-    TPM2B_SENSITIVE_CREATE inSensitive = {
-        .size = 0,
-        .sensitive = {
-            .userAuth = {
-                .size = 0,
-                .buffer = {0},
-            },
-            .data = {.size = 0, .buffer = {0}}}};
+  TPM2B_PUBLIC inPublicECC = {
+      .size = 0,
+      .publicArea = {
+          .type = TPM2_ALG_ECC,
+          .nameAlg = TPM2_ALG_SHA256,
 
-    TPM2B_PUBLIC inPublicECC = {
-        .size = 0,
-        .publicArea = {
-            .type = TPM2_ALG_ECC,
-            .nameAlg = TPM2_ALG_SHA256,
+          .objectAttributes =
+              (TPMA_OBJECT_USERWITHAUTH | TPMA_OBJECT_ADMINWITHPOLICY |
+               TPMA_OBJECT_SIGN_ENCRYPT | TPMA_OBJECT_DECRYPT |
+               TPMA_OBJECT_FIXEDTPM | TPMA_OBJECT_FIXEDPARENT |
+               TPMA_OBJECT_SENSITIVEDATAORIGIN),
 
-            .objectAttributes = (TPMA_OBJECT_USERWITHAUTH |
-                                 TPMA_OBJECT_ADMINWITHPOLICY |
-                                 TPMA_OBJECT_SIGN_ENCRYPT |
-                                 TPMA_OBJECT_DECRYPT |
-                                 TPMA_OBJECT_FIXEDTPM |
-                                 TPMA_OBJECT_FIXEDPARENT |
-                                 TPMA_OBJECT_SENSITIVEDATAORIGIN),
+          .authPolicy = {.size = 32,
+                         .buffer = {0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3,
+                                    0xF8, 0x1A, 0x90, 0xCC, 0x8D, 0x46, 0xA5,
+                                    0xD7, 0x24, 0xFD, 0x52, 0xD7, 0x6E, 0x06,
+                                    0x52, 0x0B, 0x64, 0xF2, 0xA1, 0xDA, 0x1B,
+                                    0x33, 0x14, 0x69, 0xAA}},
+          .parameters.eccDetail =
+              {.symmetric =
+                   {
+                       .algorithm = TPM2_ALG_NULL,
+                       .keyBits.aes = 256,
+                       .mode.sym = TPM2_ALG_CFB,
+                   },
+               .scheme = {.scheme = TPM2_ALG_NULL,
+                          .details = {.ecdsa = {.hashAlg = TPM2_ALG_SHA256}}},
+               .curveID = TPM2_ECC_NIST_P256,
+               .kdf = {.scheme = TPM2_ALG_NULL, .details = {}}},
+          .unique.ecc = {.x = {.size = 32, .buffer = {0}},
+                         .y = {.size = 32, .buffer = {0}}},
 
-            .authPolicy = {
-                .size = 32,
-                .buffer = {0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3, 0xF8, 0x1A, 0x90, 0xCC,
-                           0x8D, 0x46, 0xA5, 0xD7, 0x24, 0xFD, 0x52, 0xD7, 0x6E, 0x06, 0x52,
-                           0x0B, 0x64, 0xF2, 0xA1, 0xDA, 0x1B, 0x33, 0x14, 0x69, 0xAA}},
-            .parameters.eccDetail = {.symmetric = {
-                                         .algorithm = TPM2_ALG_NULL,
-                                         .keyBits.aes = 256,
-                                         .mode.sym = TPM2_ALG_CFB,
-                                     },
-                                     .scheme = {.scheme = TPM2_ALG_NULL, .details = {.ecdsa = {.hashAlg = TPM2_ALG_SHA256}}},
-                                     .curveID = TPM2_ECC_NIST_P256,
-                                     .kdf = {.scheme = TPM2_ALG_NULL, .details = {}}},
-            .unique.ecc = {.x = {.size = 32, .buffer = {0}}, .y = {.size = 32, .buffer = {0}}},
+      }};
 
-        }};
+  memcpy(inPublicECC.publicArea.unique.ecc.x.buffer, rootKeyHash, 32);
+  memcpy(inPublicECC.publicArea.unique.ecc.y.buffer, &keyIndex,
+         sizeof(keyIndex));
 
-    memcpy(inPublicECC.publicArea.unique.ecc.x.buffer, rootKeyHash, 32);
-    memcpy(inPublicECC.publicArea.unique.ecc.y.buffer, &keyIndex, sizeof(keyIndex));
+  TPM2B_DATA outsideInfo = {
+      .size = 0,
+      .buffer = {},
+  };
 
-    TPM2B_DATA outsideInfo = {
-        .size = 0,
-        .buffer = {},
-    };
+  TPML_PCR_SELECTION creationPCR = {
+      .count = 0,
+  };
 
-    TPML_PCR_SELECTION creationPCR = {
-        .count = 0,
-    };
+  TPM2B_CREATION_DATA *creationData = NULL;
+  TPM2B_DIGEST *creationHash = NULL;
+  TPMT_TK_CREATION *creationTicket = NULL;
 
-    TPM2B_CREATION_DATA *creationData = NULL;
-    TPM2B_DIGEST *creationHash = NULL;
-    TPMT_TK_CREATION *creationTicket = NULL;
+  rc = Esys_CreatePrimary(esysContext, ESYS_TR_RH_ENDORSEMENT, ESYS_TR_PASSWORD,
+                          ESYS_TR_NONE, ESYS_TR_NONE, &inSensitive,
+                          &inPublicECC, &outsideInfo, &creationPCR,
+                          &currentKeyHandle, &currentKeyTPM, &creationData,
+                          &creationHash, &creationTicket);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Primary Key Creation Failed -> %s\n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
 
-    rc = Esys_CreatePrimary(esys_context, ESYS_TR_RH_ENDORSEMENT, ESYS_TR_PASSWORD,
-                            ESYS_TR_NONE, ESYS_TR_NONE, &inSensitive, &inPublicECC,
-                            &outsideInfo, &creationPCR, &currentKeyHandle,
-                            &currentKeyTPM, &creationData, &creationHash,
-                            &creationTicket);
-    if (rc != TSS2_RC_SUCCESS)
-    {
-        printf("\nError: Primary Key Creation Failed\n");
-        exit(1);
-    }
+  Esys_Free(creationData);
+  Esys_Free(creationHash);
+  Esys_Free(creationTicket);
 
-    Esys_Free(creationData);
-    Esys_Free(creationHash);
-    Esys_Free(creationTicket);
-
-    keyToASN();
-    if (keyIndex)
-        Esys_Free(currentKeyTPM);
-}
-
-void setRootKey()
-{
-    memset(rootKeyASN, 0, ANS1_MAX_KEY_SIZE);
-    memset(rootKeyHash, 0, PRIME_LEN);
-    generatePublicKey(0);
-
-    rootKeySizeASN = currentKeySizeASN;
-    memcpy(rootKeyASN, currentKeyASN, currentKeySizeASN);
-    rootKeyHandle = currentKeyHandle;
-
-    TPM2B_MAX_BUFFER data = {.size = 64, .buffer = {}};
-    memcpy(data.buffer, (*currentKeyTPM).publicArea.unique.ecc.x.buffer, 32);
-    memcpy(data.buffer + 32, (*currentKeyTPM).publicArea.unique.ecc.y.buffer, 32);
-
-    TPMT_TK_HASHCHECK *hashTicket = NULL;
-    TPM2B_DIGEST *creationHash = NULL;
-
-    Esys_Hash(esys_context, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &data, TPM2_ALG_SHA256, ESYS_TR_RH_OWNER, &creationHash, &hashTicket);
-    memcpy(rootKeyHash, creationHash, 32);
-
-    Esys_Free(hashTicket);
-    Esys_Free(creationHash);
+  keyToASN();
+  if (keyIndex) {
     Esys_Free(currentKeyTPM);
+  }
 }
 
-void updateHandlesIndexes()
-{
-    Esys_FlushContext(esys_context, previousKeyHandle);
-    previousKeyHandle = nextKeyHandle;
-    previousKeyIndex = nextKeyIndex;
-    memset(previousKeyASN, 0, ANS1_MAX_KEY_SIZE);
-    memcpy(previousKeyASN, nextKeyASN, nextKeySizeASN);
-    previousKeySizeASN = nextKeySizeASN;
+void setRootKey() {
+  memset(rootKeyASN, 0, ANS1_MAX_KEY_SIZE);
+  memset(rootKeyHash, 0, PRIME_LEN);
+  generatePublicKey(0);
 
-    nextKeyIndex = previousKeyIndex + 1;
-    generatePublicKey(nextKeyIndex);
-    nextKeyHandle = currentKeyHandle;
-    memset(nextKeyASN, 0, ANS1_MAX_KEY_SIZE);
-    memcpy(nextKeyASN, currentKeyASN, currentKeySizeASN);
-    nextKeySizeASN = currentKeySizeASN;
+  rootKeySizeASN = currentKeySizeASN;
+  memcpy(rootKeyASN, currentKeyASN, currentKeySizeASN);
+  rootKeyHandle = currentKeyHandle;
+
+  TPM2B_MAX_BUFFER data = {.size = 64, .buffer = {}};
+  memcpy(data.buffer, (*currentKeyTPM).publicArea.unique.ecc.x.buffer, 32);
+  memcpy(data.buffer + 32, (*currentKeyTPM).publicArea.unique.ecc.y.buffer, 32);
+
+  TPMT_TK_HASHCHECK *hashTicket = NULL;
+  TPM2B_DIGEST *creationHash = NULL;
+
+  Esys_Hash(esysContext, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &data,
+            TPM2_ALG_SHA256, ESYS_TR_RH_OWNER, &creationHash, &hashTicket);
+  memcpy(rootKeyHash, creationHash, 32);
+
+  Esys_Free(hashTicket);
+  Esys_Free(creationHash);
+  Esys_Free(currentKeyTPM);
 }
 
-void initializeTPM(INT keyIndex)
-{
-    rc = Esys_Initialize(&esys_context, NULL, NULL);
-    if (rc != TSS2_RC_SUCCESS)
-    {
-        printf("\nError: Esys Initialization Failed\n");
-        exit(1);
-    }
+void updateHandlesIndexes() {
+  Esys_FlushContext(esysContext, previousKeyHandle);
+  previousKeyHandle = nextKeyHandle;
+  previousKeyIndex = nextKeyIndex;
+  memset(previousKeyASN, 0, ANS1_MAX_KEY_SIZE);
+  memcpy(previousKeyASN, nextKeyASN, nextKeySizeASN);
+  previousKeySizeASN = nextKeySizeASN;
 
-    previousKeyHandle = ESYS_TR_NONE;
-    nextKeyHandle = ESYS_TR_NONE;
+  nextKeyIndex = previousKeyIndex + 1;
+  generatePublicKey(nextKeyIndex);
+  nextKeyHandle = currentKeyHandle;
+  memset(nextKeyASN, 0, ANS1_MAX_KEY_SIZE);
+  memcpy(nextKeyASN, currentKeyASN, currentKeySizeASN);
+  nextKeySizeASN = currentKeySizeASN;
+}
+
+void setKeyIndex(INT keyIndex) {
+  if (keyIndex < 1) {
+    keyIndex = 1;
+  }
+  previousKeyIndex = keyIndex;
+  if (previousKeyHandle != ESYS_TR_NONE) {
+    Esys_FlushContext(esysContext, previousKeyHandle);
+  }
+  generatePublicKey(previousKeyIndex);
+  previousKeyHandle = currentKeyHandle;
+  previousKeySizeASN = currentKeySizeASN;
+
+  memset(previousKeyASN, 0, ANS1_MAX_KEY_SIZE);
+  memcpy(previousKeyASN, currentKeyASN, currentKeySizeASN);
+
+  nextKeyIndex = previousKeyIndex + 1;
+  if (nextKeyHandle != ESYS_TR_NONE) {
+    Esys_FlushContext(esysContext, nextKeyHandle);
+  }
+  generatePublicKey(nextKeyIndex);
+  nextKeyHandle = currentKeyHandle;
+  nextKeySizeASN = currentKeySizeASN;
+
+  memset(nextKeyASN, 0, ANS1_MAX_KEY_SIZE);
+  memcpy(nextKeyASN, currentKeyASN, currentKeySizeASN);
+
+  currentKeyHandle = ESYS_TR_NONE;
+}
+
+void provisionNodeSeed() {
+  ESYS_TR session = ESYS_TR_NONE;
+  TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
+                            .keyBits = {.aes = 128},
+                            .mode = {.aes = TPM2_ALG_CFB}};
+
+  rc = Esys_StartAuthSession(
+      esysContext, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+      ESYS_TR_NONE, NULL, TPM2_SE_HMAC, &symmetric, TPM2_ALG_SHA256, &session);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Start session -> %s \n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
+
+  rc = Esys_TRSess_SetAttributes(esysContext, session,
+                                 TPMA_SESSION_DECRYPT | TPMA_SESSION_ENCRYPT |
+                                     TPMA_SESSION_CONTINUESESSION,
+                                 0xff);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Set session attributes -> %s\n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
+
+  // Search the NV index
+  TPMS_CAPABILITY_DATA *capability_data = NULL;
+  rc =
+      Esys_GetCapability(esysContext, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                         TPM2_CAP_HANDLES, NV_INDEX, 1, NULL, &capability_data);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Get capability -> %s \n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
+
+  int exists = (capability_data->data.handles.count > 0 &&
+                capability_data->data.handles.handle[0] == NV_INDEX);
+  if (exists == 1) {
+    return;
+  }
+
+  ESYS_TR nvHandle = ESYS_TR_NONE;
+
+  TPM2B_NV_PUBLIC publicInfo = {
+      .size = sizeof(publicInfo.nvPublic),
+      .nvPublic = {.attributes = TPM2_NT_ORDINARY | TPMA_NV_WRITEALL |
+                                 TPMA_NV_AUTHWRITE | TPMA_NV_POLICYREAD |
+                                 TPMA_NV_AUTHREAD | TPMA_NV_OWNERREAD,
+                   .dataSize = 32,
+                   .nameAlg = TPM2_ALG_SHA256,
+                   .nvIndex = NV_INDEX,
+                   .authPolicy = {.size = 0, .buffer = {}}}};
+
+  TPM2B_AUTH nullAuth = {.size = 0};
+
+  // Create the NV index
+  rc = Esys_NV_DefineSpace(esysContext, ESYS_TR_RH_OWNER, session, ESYS_TR_NONE,
+                           ESYS_TR_NONE, &nullAuth, &publicInfo, &nvHandle);
+
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: NV Define -> %s \n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
+
+  // Generate random bytes
+  TPM2B_DIGEST *seed;
+  rc = Esys_GetRandom(esysContext, session, ESYS_TR_NONE, ESYS_TR_NONE, 32,
+                      &seed);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Get random after session -> %s \n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
+
+  // Write the bytes to the NV index
+  rc = Esys_NV_Write(esysContext, nvHandle, nvHandle, session, ESYS_TR_NONE,
+                     ESYS_TR_NONE, (TPM2B_MAX_NV_BUFFER *)seed, 0);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: NV Write -> %s \n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
+
+  Esys_Free(seed);
+
+  rc = Esys_FlushContext(esysContext, session);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Context flushing -> %s \n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
+}
+
+void initializeTPM(INT keyIndex) {
+  rc = Esys_Initialize(&esysContext, NULL, NULL);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Esys Initialization Failed -> %s\n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
+
+  previousKeyHandle = ESYS_TR_NONE;
+  nextKeyHandle = ESYS_TR_NONE;
+  setRootKey();
+  setKeyIndex(keyIndex);
+  provisionNodeSeed();
+}
+
+BYTE *getPublicKey(INT keyIndex, INT *publicKeySize) {
+  if (keyIndex == nextKeyIndex) {
+    memcpy(publicKeySize, &nextKeySizeASN, sizeof(nextKeySizeASN));
+    return nextKeyASN;
+  } else if (keyIndex == previousKeyIndex) {
+    memcpy(publicKeySize, &previousKeySizeASN, sizeof(previousKeySizeASN));
+    return previousKeyASN;
+  } else if (keyIndex == 0) {
+    memcpy(publicKeySize, &rootKeySizeASN, sizeof(rootKeySizeASN));
+    return rootKeyASN;
+  } else {
+    Esys_FlushContext(esysContext, rootKeyHandle);
+    generatePublicKey(keyIndex);
+    Esys_FlushContext(esysContext, currentKeyHandle);
+
+    memcpy(tempKey, currentKeyASN, currentKeySizeASN);
+    memcpy(publicKeySize, &currentKeySizeASN, sizeof(currentKeySizeASN));
+
     setRootKey();
+    return tempKey;
+  }
+}
+
+BYTE *signECDSA(INT keyIndex, BYTE *hashToSign, INT *eccSignSize,
+                bool increment) {
+
+  TPM2B_DIGEST hashTPM = {.size = 32};
+  memcpy(hashTPM.buffer, hashToSign, 32);
+
+  TPMT_SIG_SCHEME inScheme = {
+      .scheme = TPM2_ALG_ECDSA,
+      .details = {.ecdsa = {.hashAlg = TPM2_ALG_SHA256}}};
+
+  TPMT_TK_HASHCHECK hash_validation = {.tag = TPM2_ST_HASHCHECK,
+                                       .hierarchy = TPM2_RH_ENDORSEMENT,
+                                       .digest = {0}};
+
+  TPMT_SIGNATURE *signature = NULL;
+
+  ESYS_TR signingKeyHandle = ESYS_TR_NONE;
+
+  if (keyIndex == 0) {
+    signingKeyHandle = rootKeyHandle;
+  } else if (keyIndex != previousKeyIndex) {
     setKeyIndex(keyIndex);
+    signingKeyHandle = previousKeyHandle;
+  } else {
+    signingKeyHandle = previousKeyHandle;
+  }
+
+  rc = Esys_Sign(esysContext, signingKeyHandle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
+                 ESYS_TR_NONE, &hashTPM, &inScheme, &hash_validation,
+                 &signature);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Signing failed -> %s\n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
+  if (keyIndex && increment) {
+    updateHandlesIndexes();
+  }
+
+  INT asnSignSize = 0;
+  signToASN(signature->signature.ecdsa.signatureR.buffer,
+            signature->signature.ecdsa.signatureR.size,
+            signature->signature.ecdsa.signatureS.buffer,
+            signature->signature.ecdsa.signatureS.size, &asnSignSize);
+  memcpy(eccSignSize, &asnSignSize, sizeof(asnSignSize));
+  Esys_Free(signature);
+  return sigEccASN;
 }
 
-INT getKeyIndex()
-{
-    return previousKeyIndex;
-}
+BYTE *retrieveNodeSeed() {
+  ESYS_TR session = ESYS_TR_NONE;
+  TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
+                            .keyBits = {.aes = 128},
+                            .mode = {.aes = TPM2_ALG_CFB}};
 
-void setKeyIndex(INT keyIndex)
-{
-    if (keyIndex < 1)
-        keyIndex = 1;
-    previousKeyIndex = keyIndex;
-    if (previousKeyHandle != ESYS_TR_NONE)
-        Esys_FlushContext(esys_context, previousKeyHandle);
-    generatePublicKey(previousKeyIndex);
-    previousKeyHandle = currentKeyHandle;
-    previousKeySizeASN = currentKeySizeASN;
+  rc = Esys_StartAuthSession(
+      esysContext, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+      ESYS_TR_NONE, NULL, TPM2_SE_HMAC, &symmetric, TPM2_ALG_SHA256, &session);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Start session failed -> %s \n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
 
-    memset(previousKeyASN, 0, ANS1_MAX_KEY_SIZE);
-    memcpy(previousKeyASN, currentKeyASN, currentKeySizeASN);
+  rc = Esys_TRSess_SetAttributes(esysContext, session,
+                                 TPMA_SESSION_DECRYPT | TPMA_SESSION_ENCRYPT |
+                                     TPMA_SESSION_CONTINUESESSION,
+                                 0xff);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Set session attributes -> %s\n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
 
-    nextKeyIndex = previousKeyIndex + 1;
-    if (nextKeyHandle != ESYS_TR_NONE)
-        Esys_FlushContext(esys_context, nextKeyHandle);
-    generatePublicKey(nextKeyIndex);
-    nextKeyHandle = currentKeyHandle;
-    nextKeySizeASN = currentKeySizeASN;
+  // Get the NV Index handle
+  ESYS_TR nvHandle = ESYS_TR_NONE;
+  rc = Esys_TR_FromTPMPublic(esysContext, NV_INDEX, ESYS_TR_NONE, ESYS_TR_NONE,
+                             ESYS_TR_NONE, &nvHandle);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: Read TPM Public -> %s\n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
 
-    memset(nextKeyASN, 0, ANS1_MAX_KEY_SIZE);
-    memcpy(nextKeyASN, currentKeyASN, currentKeySizeASN);
+  TPM2B_MAX_NV_BUFFER *seed = NULL;
+  rc = Esys_NV_Read(esysContext, nvHandle, nvHandle, session, ESYS_TR_NONE,
+                    ESYS_TR_NONE, 32, 0, &seed);
+  if (rc != TSS2_RC_SUCCESS) {
+    printf("\nError: NV Read -> %s\n", Tss2_RC_Decode(rc));
+    exit(1);
+  }
 
-    currentKeyHandle = ESYS_TR_NONE;
-}
+  Esys_FlushContext(esysContext, session);
 
-BYTE *getPublicKey(INT keyIndex, INT *publicKeySize)
-{
-    if (keyIndex == nextKeyIndex)
-    {
-        memcpy(publicKeySize, &nextKeySizeASN, sizeof(nextKeySizeASN));
-        return nextKeyASN;
-    }
-
-    else if (keyIndex == previousKeyIndex)
-    {
-        memcpy(publicKeySize, &previousKeySizeASN, sizeof(previousKeySizeASN));
-        return previousKeyASN;
-    }
-
-    else if (keyIndex == 0)
-    {
-        memcpy(publicKeySize, &rootKeySizeASN, sizeof(rootKeySizeASN));
-        return rootKeyASN;
-    }
-
-    else
-    {
-        Esys_FlushContext(esys_context, rootKeyHandle);
-        generatePublicKey(keyIndex);
-        Esys_FlushContext(esys_context, currentKeyHandle);
-
-        memcpy(tempKey, currentKeyASN, currentKeySizeASN);
-        memcpy(publicKeySize, &currentKeySizeASN, sizeof(currentKeySizeASN));
-
-        setRootKey();
-        return tempKey;
-    }
-}
-
-BYTE *signECDSA(INT keyIndex, BYTE *hashToSign, INT *eccSignSize, bool increment)
-{
-
-    TPM2B_DIGEST hashTPM = {.size = 32};
-    memcpy(hashTPM.buffer, hashToSign, 32);
-
-    TPMT_SIG_SCHEME inScheme = {.scheme = TPM2_ALG_ECDSA, .details = {.ecdsa = {.hashAlg = TPM2_ALG_SHA256}}};
-
-    TPMT_TK_HASHCHECK hash_validation = {
-        .tag = TPM2_ST_HASHCHECK,
-        .hierarchy = TPM2_RH_ENDORSEMENT,
-        .digest = {0}};
-
-    TPMT_SIGNATURE *signature = NULL;
-
-    ESYS_TR signingKeyHandle = ESYS_TR_NONE;
-
-    if (keyIndex == 0)
-    {
-        signingKeyHandle = rootKeyHandle;
-    }
-
-    else if (keyIndex != previousKeyIndex)
-    {
-        setKeyIndex(keyIndex);
-        signingKeyHandle = previousKeyHandle;
-    }
-
-    else
-        signingKeyHandle = previousKeyHandle;
-
-    rc = Esys_Sign(esys_context, signingKeyHandle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
-                   &hashTPM, &inScheme, &hash_validation, &signature);
-    if (keyIndex && increment)
-        updateHandlesIndexes();
-
-    INT asnSignSize = 0;
-    signToASN(signature->signature.ecdsa.signatureR.buffer,
-              signature->signature.ecdsa.signatureR.size,
-              signature->signature.ecdsa.signatureS.buffer,
-              signature->signature.ecdsa.signatureS.size,
-              &asnSignSize);
-    memcpy(eccSignSize, &asnSignSize, sizeof(asnSignSize));
-    Esys_Free(signature);
-    return sigEccASN;
-}
-
-BYTE *getECDHPoint(INT keyIndex, BYTE *euphemeralKey)
-{
-    TPM2B_ECC_POINT *zPointTPM = NULL;
-    ESYS_TR ECDHKeyHandle = ESYS_TR_NONE;
-    TPM2B_ECC_POINT inPoint = {
-        .size = 0,
-        .point = {
-            .x = {
-                .size = 32,
-            },
-            .y = {
-                .size = 32,
-            }}};
-
-    if (keyIndex == previousKeyIndex)
-    {
-        ECDHKeyHandle = previousKeyHandle;
-    }
-
-    else if (keyIndex == nextKeyIndex)
-    {
-        ECDHKeyHandle = nextKeyHandle;
-    }
-
-    else if (keyIndex == 0)
-    {
-        ECDHKeyHandle = rootKeyHandle;
-    }
-
-    else
-    {
-        Esys_FlushContext(esys_context, rootKeyHandle);
-        generatePublicKey(keyIndex);
-        ECDHKeyHandle = currentKeyHandle;
-    }
-
-    memcpy(inPoint.point.x.buffer, euphemeralKey + 1, PRIME_LEN);
-    memcpy(inPoint.point.y.buffer, euphemeralKey + 1 + PRIME_LEN, PRIME_LEN);
-
-    Esys_ECDH_ZGen(esys_context, ECDHKeyHandle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
-                   ESYS_TR_NONE, &inPoint, &zPointTPM);
-
-    zPoint[0] = 0x04;
-    memcpy(zPoint + 1, zPointTPM->point.x.buffer, PRIME_LEN);
-    memcpy(zPoint + 1 + PRIME_LEN, zPointTPM->point.y.buffer, PRIME_LEN);
-
-    if (currentKeyHandle != ESYS_TR_NONE)
-    {
-        Esys_FlushContext(esys_context, currentKeyHandle);
-        setRootKey();
-    }
-
-    Esys_Free(zPointTPM);
-    return zPoint;
+  return seed->buffer;
 }

--- a/src/c/crypto/tpm/lib.h
+++ b/src/c/crypto/tpm/lib.h
@@ -5,9 +5,7 @@ typedef unsigned short INT;
 void initializeTPM(INT keyIndex);
 
 BYTE *getPublicKey(INT keyIndex, INT *publicKeySize);
-BYTE *signECDSA(INT keyIndex, BYTE *hashToSign, INT *eccSignSize, bool increment);
+BYTE *signECDSA(INT keyIndex, BYTE *hashToSign, INT *eccSignSize,
+                bool increment);
 
-INT getKeyIndex();
-void setKeyIndex(INT keyIndex);
-
-BYTE *getECDHPoint(INT keyIndex, BYTE *euphemeralKey);
+BYTE *retrieveNodeSeed();

--- a/src/c/crypto/tpm/port.c
+++ b/src/c/crypto/tpm/port.c
@@ -1,316 +1,205 @@
-#include <err.h>
-#include <stdlib.h>
-#include "lib.h"
 #include "../stdio_helpers.h"
+#include "lib.h"
+#include <err.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-void write_error(unsigned char *buf, char *error_message, int error_message_len);
+void write_error(unsigned char *buf, char *error_message,
+                 int error_message_len);
 
-enum
-{
-    INITIALIZE = 1,
-    GET_PUBLIC_KEY = 2,
-    SIGN_ECDSA = 3,
-    GET_KEY_INDEX = 4,
-    SET_KEY_INDEX = 5,
-    GET_ECDH_POINT = 6
+enum {
+  INITIALIZE = 1,
+  GET_PUBLIC_KEY = 2,
+  SIGN_ECDSA = 3,
+  RETRIEVE_NODE_SEED = 4
 };
 
-void initialize_tpm(unsigned char *buf, int pos, int len)
-{
-    if (len < pos + 2)
-    {
-        write_error(buf, "missing index", 13);
+void initialize_tpm(unsigned char *buf, int pos, int len) {
+  if (len < pos + 2) {
+    write_error(buf, "missing index", 13);
+  } else {
+    BYTE index[2];
+    for (int i = 0; i < 2; i++) {
+      index[i] = buf[pos + i];
     }
-    else
-    {
-        BYTE index[2];
-        for (int i = 0; i < 2; i++)
-        {
-            index[i] = buf[pos + i];
-        }
 
-        INT index_int = index[1] | index[0] << 8;
-        initializeTPM(index_int);
+    INT index_int = index[1] | index[0] << 8;
+    initializeTPM(index_int);
 
-        int response_len = 5;
-        unsigned char response[response_len];
-
-        //Encoding of the request id
-        for (int i = 0; i < 4; i++)
-        {
-            response[i] = buf[i];
-        }
-
-        // Encoding of success
-        response[4] = 1;
-        write_response(response, response_len);
-    }
-}
-
-void get_public_key(unsigned char *buf, int pos, int len)
-{
-    if (len < pos + 2)
-    {
-        write_error(buf, "missing index", 13);
-    }
-    else
-    {
-        BYTE index[2];
-        for (int i = 0; i < 2; i++)
-        {
-            index[i] = buf[pos + i];
-        }
-
-        INT index_int = index[1] | index[0] << 8;
-
-        BYTE *asnkey;
-        INT publicKeySize = 0;
-        asnkey = getPublicKey(index_int, &publicKeySize);
-        int response_len = 5 + publicKeySize;
-       
-	unsigned char response[response_len];
-        for (int i = 0; i < 4; i++)
-        {
-            response[i] = buf[i];
-        }
-
-        // Encoding of success
-        response[4] = 1;
-
-        for (int i = 0; i < publicKeySize; i++)
-        {
-            response[5 + i] = asnkey[i];
-        }
-
-        write_response(response, response_len);
-    }
-}
-
-void sign_ecdsa(unsigned char *buf, int pos, int len)
-{
-    BYTE hash256[32];
-
-    if (len < pos + 2)
-    {
-        write_error(buf, "missing index", 13);
-    }
-    else
-    {
-        BYTE index[2];
-        for (int i = 0; i < 2; i++)
-        {
-            index[i] = buf[pos + i];
-        }
-
-        pos += 2;
-
-        for (int i = 0; i < 32; i++)
-        {
-            hash256[i] = buf[pos + i];
-        }
-
-        INT index_int = index[1] | index[0] << 8;
-
-        BYTE *eccSign;
-        INT signLen = 0;
-
-        eccSign = signECDSA(index_int, hash256, &signLen, false);
-
-        int response_len = 5 + signLen;
-        unsigned char response[response_len];
-        for (int i = 0; i < 4; i++)
-        {
-            response[i] = buf[i];
-        }
-
-        // Encoding of success
-        response[4] = 1;
-
-        for (int i = 0; i < signLen; i++)
-        {
-            response[5 + i] = eccSign[i];
-        }
-
-        write_response(response, response_len);
-    }
-}
-
-void get_key_index(unsigned char *buf, int pos, int len)
-{
-    INT keyIndex = 0;
-    keyIndex = getKeyIndex();
-    int response_len = 5 + 2;
+    int response_len = 5;
     unsigned char response[response_len];
-    for (int i = 0; i < 4; i++)
-    {
-        response[i] = buf[i];
+
+    // Encoding of the request id
+    for (int i = 0; i < 4; i++) {
+      response[i] = buf[i];
     }
+
     // Encoding of success
     response[4] = 1;
-    response[5] = keyIndex >> 8;
-    response[6] = keyIndex;
     write_response(response, response_len);
+  }
 }
 
-void set_key_index(unsigned char *buf, int pos, int len)
-{
-    if (len < pos + 2)
-    {
-        write_error(buf, "missing index", 13);
+void get_public_key(unsigned char *buf, int pos, int len) {
+  if (len < pos + 2) {
+    write_error(buf, "missing index", 13);
+  } else {
+    BYTE index[2];
+    for (int i = 0; i < 2; i++) {
+      index[i] = buf[pos + i];
     }
-    else
-    {
-        BYTE index[2];
-        for (int i = 0; i < 2; i++)
-        {
-            index[i] = buf[pos + i];
-        }
 
-        INT index_int = index[1] | index[0] << 8;
-        setKeyIndex(index_int);
+    INT index_int = index[1] | index[0] << 8;
 
-        int response_len = 5;
-        unsigned char response[response_len];
+    BYTE *asnkey;
+    INT publicKeySize = 0;
+    asnkey = getPublicKey(index_int, &publicKeySize);
+    int response_len = 5 + publicKeySize;
 
-        //Encoding of the request id
-        for (int i = 0; i < 4; i++)
-        {
-            response[i] = buf[i];
-        }
-
-        // Encoding of success
-        response[4] = 1;
-        write_response(response, response_len);
+    unsigned char response[response_len];
+    // Encode request's ID
+    for (int i = 0; i < 4; i++) {
+      response[i] = buf[i];
     }
+
+    // Encoding of success
+    response[4] = 1;
+
+    for (int i = 0; i < publicKeySize; i++) {
+      response[5 + i] = asnkey[i];
+    }
+
+    write_response(response, response_len);
+  }
 }
 
-void get_ecdh_point(unsigned char *buf, int pos, int len)
-{
-    BYTE ephemeral_key[65];
+void sign_ecdsa(unsigned char *buf, int pos, int len) {
+  BYTE hash256[32];
 
-    if (len < pos + 2)
-    {
-        write_error(buf, "missing index", 13);
+  if (len < pos + 2) {
+    write_error(buf, "missing index", 13);
+  } else {
+    BYTE index[2];
+    for (int i = 0; i < 2; i++) {
+      index[i] = buf[pos + i];
     }
-    else
-    {
-        BYTE index[2];
-        for (int i = 0; i < 2; i++)
-        {
-            index[i] = buf[pos + i];
-        }
 
-        pos += 2;
+    pos += 2;
 
-        for (int i = 0; i < 65; i++)
-        {
-            ephemeral_key[i] = buf[pos + i];
-        }
-
-        INT index_int = index[1] | index[0] << 8;
-
-        BYTE *zPoint;
-
-        zPoint = getECDHPoint(index_int, ephemeral_key);
-
-        int response_len = 5 + 65;
-        unsigned char response[response_len]; 
-        for (int i = 0; i < 4; i++)
-        {
-            response[i] = buf[i];
-        }
-
-        // Encoding of success
-        response[4] = 1;
-
-        for (int i = 0; i < 65; i++)
-        {
-            response[5 + i] = zPoint[i];
-        }
-
-        write_response(response, response_len);
+    for (int i = 0; i < 32; i++) {
+      hash256[i] = buf[pos + i];
     }
+
+    INT index_int = index[1] | index[0] << 8;
+
+    BYTE *eccSign;
+    INT signLen = 0;
+
+    eccSign = signECDSA(index_int, hash256, &signLen, false);
+
+    int response_len = 5 + signLen;
+    unsigned char response[response_len];
+    for (int i = 0; i < 4; i++) {
+      response[i] = buf[i];
+    }
+
+    // Encoding of success
+    response[4] = 1;
+
+    for (int i = 0; i < signLen; i++) {
+      response[5 + i] = eccSign[i];
+    }
+
+    write_response(response, response_len);
+  }
 }
 
-int main()
-{
-    int len = get_length();
+void getNodeSeed(unsigned char *buf, int pos, int len) {
+  BYTE *seed;
+  seed = retrieveNodeSeed();
 
-    while (len > 0)
-    {
+  int response_len = 5 + 32; // seed => 32 bytes;
 
-        unsigned char *buf = (unsigned char *)malloc(len);
-        int read_bytes = read_message(buf, len);
+  unsigned char response[response_len];
+  // Encode request's ID
+  for (int i = 0; i < 4; i++) {
+    response[i] = buf[i];
+  }
 
-        if (read_bytes != len)
-        {
-            free(buf);
-            err(EXIT_FAILURE, "missing message");
-        }
+  // Encoding of success
+  response[4] = 1;
 
-        if (len < 4)
-        {
-            free(buf);
-            err(EXIT_FAILURE, "missing request id");
-        }
-        int pos = 4; //After the 32 bytes of the request id
+  for (int i = 0; i < 32; i++) {
+    response[5 + i] = seed[i];
+  }
 
-        if (len < 5)
-        {
-            free(buf);
-            err(EXIT_FAILURE, "missing fun id");
-        }
-
-        unsigned char fun_id = buf[pos];
-        pos++;
-
-        switch (fun_id)
-        {
-
-        case INITIALIZE:
-            initialize_tpm(buf, pos, len);
-            break;
-        case GET_PUBLIC_KEY:
-            get_public_key(buf, pos, len);
-            break;
-        case SIGN_ECDSA:
-            sign_ecdsa(buf, pos, len);
-            break;
-        case GET_KEY_INDEX:
-            get_key_index(buf, pos, len);
-            break;
-        case SET_KEY_INDEX:
-            set_key_index(buf, pos, len);
-            break;
-        case GET_ECDH_POINT:
-            get_ecdh_point(buf, pos, len);
-            break;
-        }
-
-        free(buf);
-        len = get_length();
-    }
+  write_response(response, response_len);
 }
 
-void write_error(unsigned char *buf, char *error_message, int error_message_len)
-{
-    int response_size = 5 + error_message_len;
-    unsigned char response[response_size];
+int main() {
+  int len = get_length();
 
-    //Encode the request id
-    for (int i = 0; i < 4; i++)
-    {
-        response[i] = buf[i];
+  while (len > 0) {
+
+    unsigned char *buf = (unsigned char *)malloc(len);
+    int read_bytes = read_message(buf, len);
+
+    if (read_bytes != len) {
+      free(buf);
+      err(EXIT_FAILURE, "missing message");
     }
 
-    // Error response type
-    response[4] = 0;
-
-    //Encode the error message
-    for (int i = 0; i < error_message_len; i++)
-    {
-        response[5 + i] = error_message[i];
+    if (len < 4) {
+      free(buf);
+      err(EXIT_FAILURE, "missing request id");
     }
-    write_response(response, response_size);
+    int pos = 4; // After the 32 bytes of the request id
+
+    if (len < 5) {
+      free(buf);
+      err(EXIT_FAILURE, "missing fun id");
+    }
+
+    unsigned char fun_id = buf[pos];
+    pos++;
+
+    switch (fun_id) {
+
+    case INITIALIZE:
+      initialize_tpm(buf, pos, len);
+      break;
+    case GET_PUBLIC_KEY:
+      get_public_key(buf, pos, len);
+      break;
+    case SIGN_ECDSA:
+      sign_ecdsa(buf, pos, len);
+      break;
+    case RETRIEVE_NODE_SEED:
+      getNodeSeed(buf, pos, len);
+      break;
+    }
+
+    free(buf);
+    len = get_length();
+  }
+}
+
+void write_error(unsigned char *buf, char *error_message,
+                 int error_message_len) {
+  int response_size = 5 + error_message_len;
+  unsigned char response[response_size];
+
+  // Encode the request id
+  for (int i = 0; i < 4; i++) {
+    response[i] = buf[i];
+  }
+
+  // Error response type
+  response[4] = 0;
+
+  // Encode the error message
+  for (int i = 0; i < error_message_len; i++) {
+    response[5 + i] = error_message[i];
+  }
+  write_response(response, response_size);
 }

--- a/test/archethic/crypto/keystore/node/origin/tpm_impl_test.exs
+++ b/test/archethic/crypto/keystore/node/origin/tpm_impl_test.exs
@@ -6,7 +6,7 @@ defmodule Archethic.Crypto.NodeKeystore.Origin.TPMImplTest do
   @tag :infrastructure
   test "origin_public_key/0" do
     {:ok, _} = TPMImpl.start_link()
-    assert <<1::8, 1::8, 4::8, _::binary>> = TPMImpl.origin_public_key()
+    assert <<1::8, 2::8, 4::8, _::binary>> = TPMImpl.origin_public_key()
   end
 
   @tag :infrastructure
@@ -15,5 +15,15 @@ defmodule Archethic.Crypto.NodeKeystore.Origin.TPMImplTest do
     <<_::8, _::8, public_key::binary>> = TPMImpl.origin_public_key()
     sig = TPMImpl.sign_with_origin_key("hello")
     assert :crypto.verify(:ecdsa, :sha256, "hello", sig, [public_key, :secp256r1])
+  end
+
+  @tag :infrastructure
+  test "retrieve_node_seed/0" do
+    {:ok, pid} = TPMImpl.start_link()
+    seed = TPMImpl.retrieve_node_seed()
+    ^seed = TPMImpl.retrieve_node_seed()
+    GenServer.stop(pid)
+    {:ok, _} = TPMImpl.start_link()
+    ^seed = TPMImpl.retrieve_node_seed()
   end
 end

--- a/test/archethic/crypto/keystore/node/software_impl_test.exs
+++ b/test/archethic/crypto/keystore/node/software_impl_test.exs
@@ -14,14 +14,19 @@ defmodule Archethic.Crypto.NodeKeystore.SoftwareImplTest do
       File.rm_rf!(Archethic.Utils.mut_dir())
     end)
 
-    :ok
+    impl = Application.get_env(:archethic, Archethic.Crypto.NodeKeystore.Origin)
+    seed = impl.retrieve_node_seed()
+
+    {:ok, %{seed: seed}}
   end
 
   describe "start_link/1" do
-    test "should set the last keypair to the first keypair if no previous transaction found" do
-      {:ok, _} = Keystore.start_link(seed: "fake seed")
-      first_keypair = Crypto.derive_keypair("fake seed", 0)
-      next_keypair = Crypto.derive_keypair("fake seed", 1)
+    test "should set the last keypair to the first keypair if no previous transaction found", %{
+      seed: seed
+    } do
+      {:ok, _} = Keystore.start_link()
+      first_keypair = Crypto.derive_keypair(seed, 0)
+      next_keypair = Crypto.derive_keypair(seed, 1)
 
       assert elem(first_keypair, 0) == Keystore.first_public_key()
       assert elem(next_keypair, 0) == Keystore.next_public_key()
@@ -29,16 +34,16 @@ defmodule Archethic.Crypto.NodeKeystore.SoftwareImplTest do
       assert "0" == File.read!(Archethic.Utils.mut_dir("crypto/index"))
     end
 
-    test "should set the last keypair based on the previous transaction found" do
+    test "should set the last keypair based on the previous transaction found", %{seed: seed} do
       File.mkdir_p!(Archethic.Utils.mut_dir("crypto"))
       File.write!(Archethic.Utils.mut_dir("crypto/index"), "3")
 
-      {:ok, _} = Keystore.start_link(seed: "fake seed")
+      {:ok, _} = Keystore.start_link()
 
-      first_keypair = Crypto.derive_keypair("fake seed", 0)
-      last_keypair = Crypto.derive_keypair("fake seed", 2)
-      previous_keypair = Crypto.derive_keypair("fake seed", 3)
-      next_keypair = Crypto.derive_keypair("fake seed", 4)
+      first_keypair = Crypto.derive_keypair(seed, 0)
+      last_keypair = Crypto.derive_keypair(seed, 2)
+      previous_keypair = Crypto.derive_keypair(seed, 3)
+      next_keypair = Crypto.derive_keypair(seed, 4)
 
       assert elem(first_keypair, 0) == Keystore.first_public_key()
       assert elem(next_keypair, 0) == Keystore.next_public_key()
@@ -47,41 +52,43 @@ defmodule Archethic.Crypto.NodeKeystore.SoftwareImplTest do
     end
   end
 
-  test "first_public_key/0 should return the first node public key" do
-    {:ok, _} = Keystore.start_link(seed: "fake seed")
-    {pub, _} = Crypto.derive_keypair("fake seed", 0)
+  test "first_public_key/0 should return the first node public key", %{seed: seed} do
+    {:ok, _} = Keystore.start_link()
+    {pub, _} = Crypto.derive_keypair(seed, 0)
     assert pub == Keystore.first_public_key()
   end
 
-  test "last_public_key/0 should return the first node public key" do
-    {:ok, _} = Keystore.start_link(seed: "fake seed")
-    {pub, _} = Crypto.derive_keypair("fake seed", 0)
+  test "last_public_key/0 should return the first node public key", %{seed: seed} do
+    {:ok, _} = Keystore.start_link()
+    {pub, _} = Crypto.derive_keypair(seed, 0)
     assert pub == Keystore.last_public_key()
   end
 
-  test "next_public_key/0 should return the next node public key" do
-    {:ok, _} = Keystore.start_link(seed: "fake seed")
-    {pub, _} = Crypto.derive_keypair("fake seed", 1)
+  test "next_public_key/0 should return the next node public key", %{seed: seed} do
+    {:ok, _} = Keystore.start_link()
+    {pub, _} = Crypto.derive_keypair(seed, 1)
     assert pub == Keystore.next_public_key()
   end
 
-  test "sign_with_first_key/1 should sign the data with the first node private key" do
-    {:ok, _} = Keystore.start_link(seed: "fake seed")
-    {_, pv} = Crypto.derive_keypair("fake seed", 0)
+  test "sign_with_first_key/1 should sign the data with the first node private key", %{seed: seed} do
+    {:ok, _} = Keystore.start_link()
+    {_, pv} = Crypto.derive_keypair(seed, 0)
     expected_sign = Crypto.sign("hello", pv)
     assert expected_sign == Keystore.sign_with_first_key("hello")
   end
 
-  test "sign_with_last_key/1 should sign the data with the last node private key" do
-    {:ok, _} = Keystore.start_link(seed: "fake seed")
-    {_, pv} = Crypto.derive_keypair("fake seed", 0)
+  test "sign_with_last_key/1 should sign the data with the last node private key", %{seed: seed} do
+    {:ok, _} = Keystore.start_link()
+    {_, pv} = Crypto.derive_keypair(seed, 0)
     expected_sign = Crypto.sign("hello", pv)
     assert expected_sign == Keystore.sign_with_last_key("hello")
   end
 
-  test "diffie_helman_with_last_key/1 should perform a ecdh with the last node private key" do
-    {:ok, _} = Keystore.start_link(seed: "fake seed")
-    {_, <<_::8, _::8, pv::binary>>} = Crypto.derive_keypair("fake seed", 0)
+  test "diffie_helman_with_last_key/1 should perform a ecdh with the last node private key", %{
+    seed: seed
+  } do
+    {:ok, _} = Keystore.start_link()
+    {_, <<_::8, _::8, pv::binary>>} = Crypto.derive_keypair(seed, 0)
     {<<_::8, _::8, pub::binary>>, _} = Crypto.generate_random_keypair()
 
     x25519_sk = Ed25519.convert_to_x25519_private_key(pv)

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -141,6 +141,9 @@ defmodule ArchethicCase do
       {pub, _} = Crypto.derive_keypair("seed", 0, :secp256r1)
       pub
     end)
+    |> stub(:retrieve_node_seed, fn ->
+      "seed"
+    end)
     |> stub(:node_shared_secrets_public_key, fn index ->
       {pub, _} = Crypto.derive_keypair("shared_secret_seed", index, :secp256r1)
       pub


### PR DESCRIPTION
# Description

Leverage TPM NV indexes to store the node seed generated by secure random generator from the TPM.
This allows to provide a secure backup for the node seed.

Fixes #589 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Start a node with TPM activated.
Then reboot and restart the app, the seed should remain the same.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
