### PR TITLE
Remove decrease availability history when node goes unavailable

### DIFF
--- a/lib/archethic/p2p/mem_table.ex
+++ b/lib/archethic/p2p/mem_table.ex
@@ -716,8 +716,6 @@ defmodule Archethic.P2P.MemTable do
   def set_node_unavailable(first_public_key) when is_binary(first_public_key) do
     :ets.delete(@availability_lookup_table, first_public_key)
     Logger.info("Node globally unavailable", node: Base.encode16(first_public_key))
-    tuple_pos = Keyword.fetch!(@discovery_index_position, :availability_history)
-    true = :ets.update_element(@discovery_table, first_public_key, {tuple_pos, <<0::1>>})
     notify_node_update(first_public_key)
     :ok
   end


### PR DESCRIPTION
# Description

When a node goes globally unavailable, it's availability history goes to 0. But, for a node, there is no way to self increase it's availabilty hostory, so from the node itself it's local availability may be to 0.
As we changed previously the way we handle the availability history, decreasing availability when node goeas globally unavailable is not required anymore

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Start 2 nodes
Wait them to be authorized
Stop 1 node and wait it to be globally unavailable
Restart it just before a beacon summary time
On the next self repair the node should be globally unavailable and locally available for itself

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
