### PR TITLE
Fix datetime interval sc

### DIFF
--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -269,7 +269,10 @@ defmodule Archethic.Contracts.Worker do
 
   defp schedule_trigger(trigger = %Trigger{type: :datetime, opts: [at: datetime = %DateTime{}]}) do
     seconds = DateTime.diff(datetime, DateTime.utc_now())
-    Process.send_after(self(), trigger, seconds * 1000)
+
+    if seconds > 0 do
+      Process.send_after(self(), trigger, seconds * 1000)
+    end
   end
 
   defp schedule_trigger(%Trigger{type: :oracle}) do


### PR DESCRIPTION
# Description

Using SC datetime's trigger with UNIX timestamp from a pastime, causes the worker to crash.
Hence, this fix ensures the worker will only trigger date time UNIX timestamp in the future.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
