### PR TITLE
Add timestamp in the unspent outputs#564

### DIFF
--- a/lib/archethic/account/mem_tables/uco_ledger.ex
+++ b/lib/archethic/account/mem_tables/uco_ledger.ex
@@ -16,8 +16,7 @@ defmodule Archethic.Account.MemTables.UCOLedger do
   - Main UCO ledger as ETS set ({{to, from}, amount, spent?, timestamp, reward?})
   - UCO Unspent Output Index as ETS bag (to, from)
   """
-  @spec start_link(args :: list()) ::
-          {:ok, pid()} | {:error, reason :: any()} | {:stop, reason :: any()} | :ignore
+  @spec start_link(args :: list()) :: GenServer.on_start()
   def start_link(args \\ []) do
     GenServer.start_link(__MODULE__, args)
   end
@@ -66,9 +65,14 @@ defmodule Archethic.Account.MemTables.UCOLedger do
   @spec add_unspent_output(binary(), UnspentOutput.t()) :: :ok
   def add_unspent_output(
         to,
-        %UnspentOutput{from: from, amount: amount, reward?: reward?, timestamp: timestamp}
+        %UnspentOutput{
+          from: from,
+          amount: amount,
+          reward?: reward?,
+          timestamp: %DateTime{} = timestamp
+        }
       )
-      when is_binary(to) and is_integer(amount) and amount > 0 and not is_nil(timestamp) do
+      when is_binary(to) and is_integer(amount) and amount > 0 do
     spent? =
       case :ets.lookup(@unspent_output_index_table, to) do
         [] ->

--- a/lib/archethic/account/mem_tables_loader.ex
+++ b/lib/archethic/account/mem_tables_loader.ex
@@ -46,8 +46,7 @@ defmodule Archethic.Account.MemTablesLoader do
     :on_chain_wallet
   ]
 
-  @spec start_link(args :: list()) ::
-          {:ok, pid()} | {:error, reason :: any()} | {:stop, reason :: any()} | :ignore
+  @spec start_link(args :: list()) :: GenServer.on_start()
   def start_link(args \\ []) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1136,12 +1136,8 @@ defmodule Archethic.Mining.ValidationContext do
         fee: fee,
         transaction_movements: Transaction.get_movements(tx)
       }
-      |> LedgerOperations.from_transaction(tx, timestamp |> DateTime.truncate(:millisecond))
-      |> LedgerOperations.consume_inputs(
-        tx.address,
-        previous_unspent_outputs,
-        timestamp |> DateTime.truncate(:millisecond)
-      )
+      |> LedgerOperations.from_transaction(tx, timestamp)
+      |> LedgerOperations.consume_inputs(tx.address, previous_unspent_outputs, timestamp)
 
     expected_unspent_outputs == next_unspent_outputs
   end

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -781,10 +781,11 @@ defmodule Archethic.Mining.ValidationContext do
             fee: fee,
             transaction_movements: resolved_movements
           }
-          |> LedgerOperations.from_transaction(tx)
+          |> LedgerOperations.from_transaction(tx, validation_time)
           |> LedgerOperations.consume_inputs(
             tx.address,
-            unspent_outputs
+            unspent_outputs,
+            validation_time |> DateTime.truncate(:millisecond)
           ),
         recipients: resolved_recipients,
         error: error
@@ -1122,7 +1123,8 @@ defmodule Archethic.Mining.ValidationContext do
 
   defp valid_stamp_unspent_outputs?(
          %ValidationStamp{
-           ledger_operations: %LedgerOperations{fee: fee, unspent_outputs: next_unspent_outputs}
+           ledger_operations: %LedgerOperations{fee: fee, unspent_outputs: next_unspent_outputs},
+           timestamp: timestamp
          },
          %__MODULE__{
            transaction: tx,
@@ -1134,10 +1136,11 @@ defmodule Archethic.Mining.ValidationContext do
         fee: fee,
         transaction_movements: Transaction.get_movements(tx)
       }
-      |> LedgerOperations.from_transaction(tx)
+      |> LedgerOperations.from_transaction(tx, timestamp |> DateTime.truncate(:millisecond))
       |> LedgerOperations.consume_inputs(
         tx.address,
-        previous_unspent_outputs
+        previous_unspent_outputs,
+        timestamp |> DateTime.truncate(:millisecond)
       )
 
     expected_unspent_outputs == next_unspent_outputs

--- a/lib/archethic/replication/transaction_validator.ex
+++ b/lib/archethic/replication/transaction_validator.ex
@@ -360,15 +360,8 @@ defmodule Archethic.Replication.TransactionValidator do
         fee: fee,
         transaction_movements: transaction_movements
       }
-      |> LedgerOperations.from_transaction(
-        tx,
-        tx.validation_stamp.timestamp |> DateTime.truncate(:millisecond)
-      )
-      |> LedgerOperations.consume_inputs(
-        tx.address,
-        inputs,
-        tx.validation_stamp.timestamp |> DateTime.truncate(:millisecond)
-      )
+      |> LedgerOperations.from_transaction(tx, tx.validation_stamp.timestamp)
+      |> LedgerOperations.consume_inputs(tx.address, inputs, tx.validation_stamp.timestamp)
 
     same? =
       Enum.all?(next_unspent_outputs, fn %{amount: amount, from: from} ->

--- a/lib/archethic/replication/transaction_validator.ex
+++ b/lib/archethic/replication/transaction_validator.ex
@@ -360,8 +360,15 @@ defmodule Archethic.Replication.TransactionValidator do
         fee: fee,
         transaction_movements: transaction_movements
       }
-      |> LedgerOperations.from_transaction(tx)
-      |> LedgerOperations.consume_inputs(tx.address, inputs)
+      |> LedgerOperations.from_transaction(
+        tx,
+        tx.validation_stamp.timestamp |> DateTime.truncate(:millisecond)
+      )
+      |> LedgerOperations.consume_inputs(
+        tx.address,
+        inputs,
+        tx.validation_stamp.timestamp |> DateTime.truncate(:millisecond)
+      )
 
     same? =
       Enum.all?(next_unspent_outputs, fn %{amount: amount, from: from} ->

--- a/lib/archethic/reward/scheduler.ex
+++ b/lib/archethic/reward/scheduler.ex
@@ -20,9 +20,9 @@ defmodule Archethic.Reward.Scheduler do
 
   require Logger
 
-  @spec start_link(any) :: :ignore | {:error, any} | {:ok, pid}
-  def start_link(args \\ []) do
-    GenStateMachine.start_link(__MODULE__, args, name: __MODULE__)
+  @spec start_link(list(), any) :: GenStateMachine.on_start()
+  def start_link(args \\ [], opts \\ [name: __MODULE__]) do
+    GenStateMachine.start_link(__MODULE__, args, opts)
   end
 
   @doc """

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -51,10 +51,10 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>     address: "@Token2",
       ...>     type: :token,
       ...>     data: %TransactionData{content: "{\"supply\": 1000000000, \"type\": \"fungible\" }"}
-      ...>   }
+      ...>   },~U[2022-10-10 08:07:31.784Z]
       ...> )
       %LedgerOperations{
-          unspent_outputs: [%UnspentOutput{from: "@Token2", amount: 1000000000, type: {:token, "@Token2", 0}}]
+          unspent_outputs: [%UnspentOutput{from: "@Token2", amount: 1000000000, type: {:token, "@Token2", 0},timestamp: ~U[2022-10-10 08:07:31.784Z]}]
       }
 
       iex> LedgerOperations.from_transaction(%LedgerOperations{},
@@ -62,20 +62,20 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>     address: "@Token2",
       ...>     type: :token,
       ...>     data: %TransactionData{content: "{\"supply\": 1000000000, \"type\": \"non-fungible\", \"collection\": [{},{},{},{},{},{},{},{},{},{}]}"}
-      ...>   }
+      ...>   },~U[2022-10-10 08:07:31.784Z]
       ...>  )
       %LedgerOperations{
         unspent_outputs: [
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 1}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 2}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 3}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 4}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 5}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 6}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 7}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 8}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 9}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 10}}
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 1}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 2}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 3}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 4}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 5}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 6}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 7}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 8}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 9}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 10},timestamp: ~U[2022-10-10 08:07:31.784Z]}
         ]
       }
 
@@ -84,11 +84,11 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>     address: "@Token2",
       ...>     type: :token,
       ...>     data: %TransactionData{content: "{\"supply\": 100000000, \"type\": \"non-fungible\"}"}
-      ...>   }
+      ...>   },~U[2022-10-10 08:07:31.784Z]
       ...>  )
       %LedgerOperations{
         unspent_outputs: [
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 1}},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 1}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
         ]
       }
 
@@ -97,12 +97,12 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>     address: "@Token2",
       ...>     type: :token,
       ...>     data: %TransactionData{content: "{\"supply\": 200000000, \"type\": \"non-fungible\", \"collection\": [{\"id\": 42}, {\"id\": 38}]}"}
-      ...>   }
+      ...>   },~U[2022-10-10 08:07:31.784Z]
       ...>  )
       %LedgerOperations{
         unspent_outputs: [
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 42}},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 38}}
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 42}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 38}, timestamp: ~U[2022-10-10 08:07:31.784Z]}
         ]
       }
 
@@ -111,22 +111,26 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>     address: "@Token2",
       ...>     type: :token,
       ...>     data: %TransactionData{content: "{\"supply\": 1000000000, \"type\": \"non-fungible\", \"collection\": [{}]}"}
-      ...>   }
+      ...>   }, ~U[2022-10-10 08:07:31.784Z]
       ...>  )
       %LedgerOperations{
         unspent_outputs: []
       }
   """
-  @spec from_transaction(t(), Transaction.t()) :: t()
-  def from_transaction(ops = %__MODULE__{}, %Transaction{
-        address: address,
-        type: type,
-        data: %TransactionData{content: content}
-      })
-      when type in [:token, :mint_rewards] do
+  @spec from_transaction(t(), Transaction.t(), DateTime.t()) :: t()
+  def from_transaction(
+        ops = %__MODULE__{},
+        %Transaction{
+          address: address,
+          type: type,
+          data: %TransactionData{content: content}
+        },
+        timestamp
+      )
+      when type in [:token, :mint_rewards] and not is_nil(timestamp) do
     case Jason.decode(content) do
       {:ok, json} ->
-        utxos = get_token_utxos(json, address)
+        utxos = get_token_utxos(json, address, timestamp)
         Map.update(ops, :unspent_outputs, utxos, &(utxos ++ &1))
 
       _ ->
@@ -134,28 +138,36 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
     end
   end
 
-  def from_transaction(ops = %__MODULE__{}, %Transaction{}), do: ops
+  def from_transaction(ops = %__MODULE__{}, %Transaction{}, _timestamp), do: ops
 
-  defp get_token_utxos(%{"type" => "fungible", "supply" => supply}, address) do
+  defp get_token_utxos(%{"type" => "fungible", "supply" => supply}, address, timestamp) do
     [
       %UnspentOutput{
         from: address,
         amount: supply,
-        type: {:token, address, 0}
+        type: {:token, address, 0},
+        timestamp: timestamp
       }
     ]
   end
 
   defp get_token_utxos(
          %{"type" => "non-fungible", "supply" => supply, "collection" => collection},
-         address
+         address,
+         timestamp
        ) do
     if length(collection) == supply / @unit_uco do
       collection
       |> Enum.with_index()
       |> Enum.map(fn {item_properties, index} ->
         token_id = Map.get(item_properties, "id", index + 1)
-        %UnspentOutput{from: address, amount: 1 * @unit_uco, type: {:token, address, token_id}}
+
+        %UnspentOutput{
+          from: address,
+          amount: 1 * @unit_uco,
+          type: {:token, address, token_id},
+          timestamp: timestamp
+        }
       end)
     else
       []
@@ -164,12 +176,20 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
 
   defp get_token_utxos(
          %{"type" => "non-fungible", "supply" => @unit_uco},
-         address
+         address,
+         timestamp
        ) do
-    [%UnspentOutput{from: address, amount: 1 * @unit_uco, type: {:token, address, 1}}]
+    [
+      %UnspentOutput{
+        from: address,
+        amount: 1 * @unit_uco,
+        type: {:token, address, 1},
+        timestamp: timestamp
+      }
+    ]
   end
 
-  defp get_token_utxos(_, _), do: []
+  defp get_token_utxos(_, _, _), do: []
 
   @doc """
   Returns the amount to spend from the transaction movements and the fee
@@ -292,8 +312,8 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>    fee: 40_000_000
       ...> }
       ...> |> LedgerOperations.consume_inputs("@Alice2", [
-      ...>    %UnspentOutput{from: "@Bob3", amount: 2_000_000_000, type: :UCO}
-      ...> ])
+      ...>    %UnspentOutput{from: "@Bob3", amount: 2_000_000_000, type: :UCO,timestamp: ~U[2022-10-09 08:39:10.463Z]}
+      ...> ], ~U[2022-10-10 10:44:38.983Z])
       %LedgerOperations{
           transaction_movements: [
             %TransactionMovement{to: "@Bob4", amount: 1_040_000_000, type: :UCO},
@@ -301,7 +321,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
           ],
           fee: 40_000_000,
           unspent_outputs: [
-            %UnspentOutput{from: "@Alice2", amount: 703_000_000, type: :UCO}
+            %UnspentOutput{from: "@Alice2", amount: 703_000_000, type: :UCO, timestamp:  ~U[2022-10-10 10:44:38.983Z]}
           ]
       }
 
@@ -319,7 +339,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>    %UnspentOutput{from: "@Tom4", amount: 700_000_000, type: :UCO},
       ...>    %UnspentOutput{from: "@Christina", amount: 400_000_000, type: :UCO},
       ...>    %UnspentOutput{from: "@Hugo", amount: 800_000_000, type: :UCO}
-      ...> ])
+      ...> ],~U[2022-10-10 10:44:38.983Z])
       %LedgerOperations{
           transaction_movements: [
             %TransactionMovement{to: "@Bob4", amount: 1_040_000_000, type: :UCO},
@@ -327,7 +347,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
           ],
           fee: 40_000_000,
           unspent_outputs: [
-            %UnspentOutput{from: "@Alice2", amount: 1_103_000_000, type: :UCO},
+            %UnspentOutput{from: "@Alice2", amount: 1_103_000_000, type: :UCO, timestamp: ~U[2022-10-10 10:44:38.983Z]},
           ]
       }
 
@@ -340,17 +360,17 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
        ...>    fee: 40_000_000
        ...> }
        ...> |> LedgerOperations.consume_inputs("@Alice2", [
-       ...>    %UnspentOutput{from: "@Charlie1", amount: 200_000_000, type: :UCO},
-       ...>    %UnspentOutput{from: "@Bob3", amount: 1_200_000_000, type: {:token, "@CharlieToken", 0}}
-       ...> ])
+       ...>    %UnspentOutput{from: "@Charlie1", amount: 200_000_000, type: :UCO, timestamp: ~U[2022-10-09 08:39:10.463Z]},
+       ...>    %UnspentOutput{from: "@Bob3", amount: 1_200_000_000, type: {:token, "@CharlieToken", 0}, timestamp: ~U[2022-10-09 08:39:10.463Z]}
+       ...> ],~U[2022-10-10 10:44:38.983Z])
        %LedgerOperations{
            transaction_movements: [
              %TransactionMovement{to: "@Bob4", amount: 1_000_000_000, type: {:token, "@CharlieToken", 0}}
            ],
            fee: 40_000_000,
            unspent_outputs: [
-             %UnspentOutput{from: "@Alice2", amount: 160_000_000, type: :UCO},
-             %UnspentOutput{from: "@Alice2", amount: 200_000_000, type: {:token, "@CharlieToken", 0}}
+             %UnspentOutput{from: "@Alice2", amount: 160_000_000, type: :UCO, timestamp: ~U[2022-10-10 10:44:38.983Z]},
+             %UnspentOutput{from: "@Alice2", amount: 200_000_000, type: {:token, "@CharlieToken", 0}, timestamp: ~U[2022-10-10 10:44:38.983Z]}
            ]
        }
 
@@ -367,15 +387,15 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>    %UnspentOutput{from: "@Bob3", amount: 500_000_000, type: {:token, "@CharlieToken", 0}},
       ...>    %UnspentOutput{from: "@Hugo5", amount: 700_000_000, type: {:token, "@CharlieToken", 0}},
       ...>    %UnspentOutput{from: "@Tom1", amount: 700_000_000, type: {:token, "@CharlieToken", 0}}
-      ...> ])
+      ...> ], ~U[2022-10-10 10:44:38.983Z])
       %LedgerOperations{
           transaction_movements: [
             %TransactionMovement{to: "@Bob4", amount: 1_000_000_000, type: {:token, "@CharlieToken", 0}}
           ],
           fee: 40_000_000,
           unspent_outputs: [
-            %UnspentOutput{from: "@Alice2", amount: 160_000_000, type: :UCO},
-            %UnspentOutput{from: "@Alice2", amount: 900_000_000, type: {:token, "@CharlieToken", 0}}
+            %UnspentOutput{from: "@Alice2", amount: 160_000_000, type: :UCO, timestamp: ~U[2022-10-10 10:44:38.983Z]},
+            %UnspentOutput{from: "@Alice2", amount: 900_000_000, type: {:token, "@CharlieToken", 0}, timestamp: ~U[2022-10-10 10:44:38.983Z]}
           ]
       }
 
@@ -387,38 +407,50 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...> ],
       ...>   fee: 40_000_000
       ...> } |> LedgerOperations.consume_inputs("@Alice2", [
-      ...>     %UnspentOutput{from: "@Charlie1", amount: 200_000_000, type: :UCO},
-      ...>      %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 1}},
-      ...>      %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 2}},
-      ...>      %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 3}}
-      ...> ])
+      ...>     %UnspentOutput{from: "@Charlie1", amount: 200_000_000, type: :UCO, timestamp: ~U[2022-10-09 08:39:10.463Z]},
+      ...>      %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 1}, timestamp: ~U[2022-10-09 08:39:10.463Z]},
+      ...>      %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 2}, timestamp: ~U[2022-10-09 08:39:10.463Z]},
+      ...>      %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 3}, timestamp: ~U[2022-10-09 08:39:10.463Z]}
+      ...> ],~U[2022-10-10 10:44:38.983Z])
       %LedgerOperations{
         fee: 40_000_000,
         transaction_movements: [
           %TransactionMovement{to: "@Bob4", amount: 100_000_000, type: {:token, "@CharlieToken", 2}}
         ],
         unspent_outputs: [
-          %UnspentOutput{from: "@Alice2", amount: 160_000_000, type: :UCO},
-          %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 1}},
-          %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 3}}
+          %UnspentOutput{from: "@Alice2", amount: 160_000_000, type: :UCO, timestamp: ~U[2022-10-10 10:44:38.983Z]},
+          %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 1}, timestamp: ~U[2022-10-09 08:39:10.463Z]},
+          %UnspentOutput{from: "@CharlieToken", amount: 100_000_000, type: {:token, "@CharlieToken", 3}, timestamp: ~U[2022-10-09 08:39:10.463Z]}
         ]
       }
   """
   @spec consume_inputs(
           ledger_operations :: t(),
           change_address :: binary(),
-          inputs :: list(UnspentOutput.t() | TransactionInput.t())
+          inputs :: list(UnspentOutput.t() | TransactionInput.t()),
+          timestamp :: DateTime.t()
         ) ::
           t()
-  def consume_inputs(ops = %__MODULE__{}, change_address, inputs)
-      when is_binary(change_address) and is_list(inputs) do
+  def consume_inputs(ops = %__MODULE__{}, change_address, inputs, timestamp)
+      when is_binary(change_address) and is_list(inputs) and not is_nil(timestamp) do
     if sufficient_funds?(ops, inputs) do
       %{uco: uco_balance, token: tokens_received} = ledger_balances(inputs)
       %{uco: uco_to_spend, token: tokens_to_spend} = total_to_spend(ops)
 
       new_unspent_outputs = [
-        %UnspentOutput{from: change_address, amount: uco_balance - uco_to_spend, type: :UCO}
-        | new_token_unspent_outputs(tokens_received, tokens_to_spend, change_address, inputs)
+        %UnspentOutput{
+          from: change_address,
+          amount: uco_balance - uco_to_spend,
+          type: :UCO,
+          timestamp: timestamp
+        }
+        | new_token_unspent_outputs(
+            tokens_received,
+            tokens_to_spend,
+            change_address,
+            inputs,
+            timestamp
+          )
       ]
 
       Map.update!(ops, :unspent_outputs, &(new_unspent_outputs ++ &1))
@@ -427,7 +459,13 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
     end
   end
 
-  defp new_token_unspent_outputs(tokens_received, tokens_to_spend, change_address, inputs) do
+  defp new_token_unspent_outputs(
+         tokens_received,
+         tokens_to_spend,
+         change_address,
+         inputs,
+         timestamp
+       ) do
     # Reject Token not used to inject back in the new unspent outputs
     tokens_not_used =
       tokens_received
@@ -454,7 +492,8 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
             %UnspentOutput{
               from: change_address,
               amount: recv_amount - trunc_token_amount(token_id, amount_to_spend),
-              type: {:token, token_address, token_id}
+              type: {:token, token_address, token_id},
+              timestamp: timestamp
             }
             | acc
           ]
@@ -499,7 +538,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>       from: <<0, 0, 34, 118, 242, 194, 93, 131, 130, 195, 9, 97, 237, 220, 195, 112, 1, 54, 221,
       ...>           86, 154, 234, 96, 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207>>,
       ...>       amount: 200_000_000,
-      ...>       type: :UCO
+      ...>       type: :UCO,timestamp: ~U[2022-10-11 07:27:22.815Z]
       ...>     }
       ...>   ]
       ...> }
@@ -523,6 +562,8 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       86, 154, 234, 96, 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207,
       # Unspent output amount (2 UCO)
       0, 0, 0, 0, 11, 235, 194, 0,
+      # Timestamp
+      0, 0, 1, 131, 197, 240, 230, 191,
       # Unspent output type (UCO)
       0
       >>
@@ -553,12 +594,12 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
 
   ## Examples
 
-      iex> <<0, 0, 0, 0, 0, 152, 150, 128, 1, 1,
-      ...> 0, 0, 34, 118, 242, 194, 93, 131, 130, 195, 9, 97, 237, 220, 195, 112, 1, 54, 221, 86, 154, 234, 96, 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207,
-      ...> 0, 0, 0, 0, 60, 203, 247, 0, 0,
-      ...> 1, 1, 0, 0, 34, 118, 242, 194, 93, 131, 130, 195, 9, 97, 237,
-      ...> 220, 195, 112, 1, 54, 221, 86, 154, 234, 96, 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207,
-      ...> 0, 0, 0, 0, 11, 235, 194, 0, 0>>
+      iex> <<0, 0, 0, 0, 0, 152, 150, 128,     1, 1,
+      ...> 0, 0, 34, 118, 242, 194, 93, 131, 130, 195, 9, 97, 237, 220, 195, 112, 1, 54, 221, 86, 154, 234, 96,
+      ...> 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207,    0, 0, 0, 0, 60, 203, 247, 0,     0,
+      ...> 1, 1,     0, 0, 34, 118, 242, 194, 93, 131, 130, 195, 9, 97, 237, 220, 195, 112, 1,
+      ...> 54, 221, 86, 154, 234, 96, 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207,
+      ...> 0, 0, 0, 0, 11, 235, 194, 0,     0, 0, 1, 131, 197, 240, 230, 191,     0>>
       ...> |> LedgerOperations.deserialize()
       {
         %LedgerOperations{
@@ -576,7 +617,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
               from: <<0, 0, 34, 118, 242, 194, 93, 131, 130, 195, 9, 97, 237, 220, 195, 112, 1, 54, 221,
                 86, 154, 234, 96, 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207>>,
               amount: 200_000_000,
-              type: :UCO
+              type: :UCO,timestamp: ~U[2022-10-11 07:27:22.815Z]
             }
           ]
         },

--- a/lib/archethic_web/graphql_schema/transaction_type.ex
+++ b/lib/archethic_web/graphql_schema/transaction_type.ex
@@ -157,6 +157,7 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
   - Type: UCO/token
   - token address: address of the token if the type is token
   - token id: It is the id for a token which is allocated when the token is minted.
+  - Timestamp: Date time when the UTXO created/manipulated.
   """
   object :unspent_output do
     field(:from, :address)
@@ -164,6 +165,7 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
     field(:type, :string)
     field(:token_address, :address)
     field(:token_id, :integer)
+    field(:timestamp, :timestamp)
   end
 
   @desc """

--- a/test/archethic/account_test.exs
+++ b/test/archethic/account_test.exs
@@ -59,14 +59,16 @@ defmodule Archethic.AccountTest do
     end
 
     test "should return the sum of unspent outputs amounts" do
+      timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+
       UCOLedger.add_unspent_output(
         "@Alice2",
         %UnspentOutput{
           from: "@Bob3",
           amount: 300_000_000,
-          type: :UCO
-        },
-        ~U[2021-03-05 13:41:34Z]
+          type: :UCO,
+          timestamp: timestamp
+        }
       )
 
       UCOLedger.add_unspent_output(
@@ -74,9 +76,9 @@ defmodule Archethic.AccountTest do
         %UnspentOutput{
           from: "@Tom10",
           amount: 100_000_000,
-          type: :UCO
-        },
-        ~U[2021-03-05 13:41:34Z]
+          type: :UCO,
+          timestamp: timestamp
+        }
       )
 
       TokenLedger.add_unspent_output(
@@ -84,9 +86,9 @@ defmodule Archethic.AccountTest do
         %UnspentOutput{
           from: "@Charlie2",
           amount: 10_000_000_000,
-          type: {:token, "@CharlieToken", 0}
-        },
-        ~U[2021-03-05 13:41:34Z]
+          type: {:token, "@CharlieToken", 0},
+          timestamp: timestamp
+        }
       )
 
       assert %{uco: 400_000_000, token: %{{"@CharlieToken", 0} => 10_000_000_000}} ==
@@ -98,16 +100,16 @@ defmodule Archethic.AccountTest do
     end
 
     test "should return 0 when all the unspent outputs have been spent" do
+      timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+
       UCOLedger.add_unspent_output(
         "@Alice2",
-        %UnspentOutput{from: "@Bob3", amount: 300_000_000},
-        ~U[2021-03-05 13:41:34Z]
+        %UnspentOutput{from: "@Bob3", amount: 300_000_000, timestamp: timestamp}
       )
 
       UCOLedger.add_unspent_output(
         "@Alice2",
-        %UnspentOutput{from: "@Tom10", amount: 100_000_000},
-        ~U[2021-03-05 13:41:34Z]
+        %UnspentOutput{from: "@Tom10", amount: 100_000_000, timestamp: timestamp}
       )
 
       TokenLedger.add_unspent_output(
@@ -115,9 +117,9 @@ defmodule Archethic.AccountTest do
         %UnspentOutput{
           from: "@Charlie2",
           amount: 10_000_000_000,
-          type: {:token, "@CharlieToken", 0}
-        },
-        ~U[2021-03-05 13:41:34Z]
+          type: {:token, "@CharlieToken", 0},
+          timestamp: timestamp
+        }
       )
 
       UCOLedger.spend_all_unspent_outputs("@Alice2")

--- a/test/archethic/bootstrap/network_init_test.exs
+++ b/test/archethic/bootstrap/network_init_test.exs
@@ -146,7 +146,15 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
         0
       )
 
-    unspent_outputs = [%UnspentOutput{amount: 1_000_000_000_000, from: tx.address, type: :UCO}]
+    unspent_outputs = [
+      %UnspentOutput{
+        amount: 1_000_000_000_000,
+        from: tx.address,
+        type: :UCO,
+        timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+      }
+    ]
+
     tx = NetworkInit.self_validation(tx, unspent_outputs)
 
     tx_fee = tx.validation_stamp.ledger_operations.fee
@@ -163,7 +171,8 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
                    %UnspentOutput{
                      amount: ^unspent_output,
                      from: _,
-                     type: :UCO
+                     type: :UCO,
+                     timestamp: _
                    }
                  ]
                }

--- a/test/archethic/contracts/worker_test.exs
+++ b/test/archethic/contracts/worker_test.exs
@@ -84,14 +84,16 @@ defmodule Archethic.Contracts.WorkerTest do
       }
       |> Constants.from_transaction()
 
+    timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+
     Account.MemTables.UCOLedger.add_unspent_output(
       "@SC1",
       %UnspentOutput{
         from: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
         amount: 100_000_000_000,
-        type: :UCO
-      },
-      DateTime.utc_now()
+        type: :UCO,
+        timestamp: timestamp
+      }
     )
 
     expected_tx = %Transaction{

--- a/test/archethic/mining/standalone_workflow_test.exs
+++ b/test/archethic/mining/standalone_workflow_test.exs
@@ -40,7 +40,14 @@ defmodule Archethic.Mining.StandaloneWorkflowTest do
       reward_address: :crypto.strong_rand_bytes(32)
     })
 
-    unspent_outputs = [%UnspentOutput{from: "@Alice2", amount: 1_000_000_000, type: :UCO}]
+    unspent_outputs = [
+      %UnspentOutput{
+        from: "@Alice2",
+        amount: 1_000_000_000,
+        type: :UCO,
+        timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+      }
+    ]
 
     me = self()
 

--- a/test/archethic/mining/transaction_context_test.exs
+++ b/test/archethic/mining/transaction_context_test.exs
@@ -47,7 +47,8 @@ defmodule Archethic.Mining.TransactionContextTest do
                %UnspentOutput{
                  from: "@Bob3",
                  amount: 1_000_000_000,
-                 type: :UCO
+                 type: :UCO,
+                 timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                }
              ]
            }}

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -553,7 +553,8 @@ defmodule Archethic.P2P.MessageTest do
               <<0, 0, 214, 107, 17, 107, 227, 11, 17, 43, 204, 48, 78, 129, 145, 126, 45, 68, 194,
                 159, 19, 92, 240, 29, 37, 105, 183, 232, 56, 42, 163, 236, 251, 186>>,
             amount: 1_050_000_000,
-            type: :UCO
+            type: :UCO,
+            timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
           }
         ]
       }

--- a/test/archethic/replication/transaction_context_test.exs
+++ b/test/archethic/replication/transaction_context_test.exs
@@ -82,9 +82,9 @@ defmodule Archethic.Replication.TransactionContextTest do
       %UnspentOutput{
         from: "@Bob3",
         amount: 19_300_000,
-        type: :UCO
-      },
-      ~U[2021-03-05 13:41:34Z]
+        type: :UCO,
+        timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+      }
     )
 
     MockClient

--- a/test/archethic/replication/transaction_validator_test.exs
+++ b/test/archethic/replication/transaction_validator_test.exs
@@ -67,7 +67,14 @@ defmodule Archethic.Replication.TransactionValidatorTest do
 
   describe "validate/2" do
     test "should return {:error, :invalid_atomic_commitment} when the atomic commitment is not reached" do
-      unspent_outputs = [%UnspentOutput{from: "@Alice2", amount: 1_000_000_000, type: :UCO}]
+      unspent_outputs = [
+        %UnspentOutput{
+          from: "@Alice2",
+          amount: 1_000_000_000,
+          type: :UCO,
+          timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+        }
+      ]
 
       assert {:error, :invalid_atomic_commitment} =
                TransactionFactory.create_transaction_with_not_atomic_commitment(unspent_outputs)
@@ -99,7 +106,14 @@ defmodule Archethic.Replication.TransactionValidatorTest do
     end
 
     test "should return {:error, :invalid_transaction_with_inconsistencies} when there is an atomic commitment but with inconsistencies" do
-      unspent_outputs = [%UnspentOutput{from: "@Alice2", amount: 1_000_000_000, type: :UCO}]
+      unspent_outputs = [
+        %UnspentOutput{
+          from: "@Alice2",
+          amount: 1_000_000_000,
+          type: :UCO,
+          timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+        }
+      ]
 
       assert {:error, :invalid_transaction_with_inconsistencies} =
                TransactionFactory.create_valid_transaction_with_inconsistencies(unspent_outputs)
@@ -107,7 +121,14 @@ defmodule Archethic.Replication.TransactionValidatorTest do
     end
 
     test "should return :ok when the transaction is valid" do
-      unspent_outputs = [%UnspentOutput{from: "@Alice2", amount: 1_000_000_000, type: :UCO}]
+      unspent_outputs = [
+        %UnspentOutput{
+          from: "@Alice2",
+          amount: 1_000_000_000,
+          type: :UCO,
+          timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+        }
+      ]
 
       assert :ok =
                TransactionFactory.create_valid_transaction(unspent_outputs)
@@ -117,7 +138,14 @@ defmodule Archethic.Replication.TransactionValidatorTest do
 
   describe "validate/3" do
     test "should return :ok when the transaction is valid" do
-      unspent_outputs = [%UnspentOutput{from: "@Alice2", amount: 1_000_000_000, type: :UCO}]
+      unspent_outputs = [
+        %UnspentOutput{
+          from: "@Alice2",
+          amount: 1_000_000_000,
+          type: :UCO,
+          timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+        }
+      ]
 
       assert :ok =
                TransactionFactory.create_valid_transaction(unspent_outputs)

--- a/test/archethic/replication_test.exs
+++ b/test/archethic/replication_test.exs
@@ -65,7 +65,15 @@ defmodule Archethic.ReplicationTest do
 
     me = self()
 
-    unspent_outputs = [%UnspentOutput{from: "@Alice2", amount: 1_000_000_000, type: :UCO}]
+    unspent_outputs = [
+      %UnspentOutput{
+        from: "@Alice2",
+        amount: 1_000_000_000,
+        type: :UCO,
+        timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+      }
+    ]
+
     p2p_context()
     tx = create_valid_transaction(unspent_outputs)
 
@@ -120,7 +128,15 @@ defmodule Archethic.ReplicationTest do
   test "validate_and_store_transaction/1" do
     me = self()
 
-    unspent_outputs = [%UnspentOutput{from: "@Alice2", amount: 1_000_000_000, type: :UCO}]
+    unspent_outputs = [
+      %UnspentOutput{
+        from: "@Alice2",
+        amount: 1_000_000_000,
+        type: :UCO,
+        timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+      }
+    ]
+
     p2p_context()
     tx = create_valid_transaction(unspent_outputs)
 
@@ -190,16 +206,17 @@ defmodule Archethic.ReplicationTest do
 
   defp create_valid_transaction(unspent_outputs) do
     tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
+    timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
 
     ledger_operations =
       %LedgerOperations{
         fee: Fee.calculate(tx, 0.07)
       }
-      |> LedgerOperations.consume_inputs(tx.address, unspent_outputs)
+      |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
 
     validation_stamp =
       %ValidationStamp{
-        timestamp: DateTime.utc_now(),
+        timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_election:
           Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),

--- a/test/archethic/reward/mem_tables_loader_test.exs
+++ b/test/archethic/reward/mem_tables_loader_test.exs
@@ -2,21 +2,41 @@ defmodule Archethic.Reward.MemTablesLoaderTest do
   @moduledoc false
   use ArchethicCase
 
-  alias Archethic.Reward
-  alias Archethic.Reward.MemTables.RewardTokens
-  alias Archethic.Reward.MemTablesLoader, as: RewardTableLoader
   import Mox
 
   @tx_type :mint_rewards
   @fields [:address, :type]
 
-  alias Archethic.TransactionChain
-  alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.Transaction.ValidationStamp
-  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
+  alias Archethic.{
+    Crypto,
+    Reward,
+    Reward.MemTables.RewardTokens,
+    TransactionChain,
+    P2P,
+    P2P.Node
+  }
+
+  alias Archethic.TransactionChain.{
+    Transaction,
+    Transaction.ValidationStamp,
+    Transaction.ValidationStamp.LedgerOperations
+  }
+
+  alias Archethic.Reward.MemTablesLoader, as: RewardTableLoader
 
   describe "RewardTokens MEMTable: " do
     setup do
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3002,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
+        authorized?: true,
+        authorization_date: DateTime.utc_now(),
+        geo_patch: "AAA",
+        available?: true
+      })
+
       MockDB
       |> stub(:list_transactions_by_type, fn :mint_rewards, [:address, :type] ->
         [

--- a/test/archethic/reward/scheduler_test.exs
+++ b/test/archethic/reward/scheduler_test.exs
@@ -1,8 +1,6 @@
 defmodule Archethic.Reward.SchedulerTest do
   use ArchethicCase, async: false
 
-  alias Archethic.Crypto
-
   alias Archethic.{
     Crypto,
     P2P,

--- a/test/archethic/reward/scheduler_test.exs
+++ b/test/archethic/reward/scheduler_test.exs
@@ -18,7 +18,7 @@ defmodule Archethic.Reward.SchedulerTest do
       MockDB
       |> stub(:get_latest_burned_fees, fn -> 0 end)
 
-      {:ok, pid} = GenStateMachine.start_link(Scheduler, interval: "*/1 * * * * *")
+      {:ok, pid} = Scheduler.start_link([interval: "*/1 * * * * *"], [])
 
       assert {:idle, %{interval: "*/1 * * * * *"}} = :sys.get_state(pid)
 
@@ -44,7 +44,7 @@ defmodule Archethic.Reward.SchedulerTest do
     end
   end
 
-  describe "scheduler" do
+  describe "Scheduler" do
     setup do
       P2P.add_and_connect_node(%Node{
         first_public_key: Crypto.last_node_public_key(),
@@ -76,7 +76,8 @@ defmodule Archethic.Reward.SchedulerTest do
 
       me = self()
 
-      assert {:ok, pid} = GenStateMachine.start_link(Scheduler, interval: "*/1 * * * * *")
+      assert {:ok, pid} = Scheduler.start_link([interval: "*/1 * * * * *"], [])
+
       send(pid, :node_up)
 
       MockClient
@@ -104,7 +105,8 @@ defmodule Archethic.Reward.SchedulerTest do
         send(me, type)
       end)
 
-      assert {:ok, pid} = GenStateMachine.start_link(Scheduler, interval: "*/1 * * * * *")
+      assert {:ok, pid} = Scheduler.start_link([interval: "*/1 * * * * *"], [])
+
       send(pid, :node_up)
 
       refute_receive :mint_rewards, 1_200
@@ -112,11 +114,11 @@ defmodule Archethic.Reward.SchedulerTest do
     end
   end
 
-  describe "Scheduler Behavior During Start" do
+  describe "Scheduler_Behavior During Start" do
     test "should be idle(state with args) when node has not done Bootstrapping" do
       :persistent_term.put(:archethic_up, nil)
 
-      {:ok, pid} = GenStateMachine.start_link(Scheduler, interval: "*/1 * * * * *")
+      {:ok, pid} = Scheduler.start_link([interval: "*/1 * * * * *"], [])
 
       assert {:idle, %{interval: "*/1 * * * * *"}} = :sys.get_state(pid)
     end
@@ -124,7 +126,7 @@ defmodule Archethic.Reward.SchedulerTest do
     test "should wait for node :up message to start the scheduler, when node is not authorized and available" do
       :persistent_term.put(:archethic_up, nil)
 
-      {:ok, pid} = GenStateMachine.start_link(Scheduler, interval: "*/2 * * * * *")
+      {:ok, pid} = Scheduler.start_link([interval: "*/2 * * * * *"], [])
 
       assert {:idle, %{interval: "*/2 * * * * *"}} = :sys.get_state(pid)
 
@@ -145,7 +147,7 @@ defmodule Archethic.Reward.SchedulerTest do
         available?: true
       })
 
-      {:ok, pid} = GenStateMachine.start_link(Scheduler, interval: "*/3 * * * * *")
+      {:ok, pid} = Scheduler.start_link([interval: "*/3 * * * * *"], [])
 
       assert {:idle, %{interval: "*/3 * * * * *"}} = :sys.get_state(pid)
       send(pid, :node_up)
@@ -161,7 +163,7 @@ defmodule Archethic.Reward.SchedulerTest do
     test "Should use persistent_term :archethic_up when a Scheduler crashes, when a node is not authorized and available" do
       :persistent_term.put(:archethic_up, :up)
 
-      {:ok, pid} = GenStateMachine.start_link(Scheduler, interval: "*/4 * * * * *")
+      {:ok, pid} = Scheduler.start_link([interval: "*/4 * * * * *"], [])
 
       assert {:idle,
               %{
@@ -185,7 +187,7 @@ defmodule Archethic.Reward.SchedulerTest do
         available?: true
       })
 
-      {:ok, pid} = GenStateMachine.start_link(Scheduler, interval: "*/5 * * * * *")
+      {:ok, pid} = Scheduler.start_link([interval: "*/5 * * * * *"], [])
 
       assert {:scheduled,
               %{

--- a/test/archethic/reward_test.exs
+++ b/test/archethic/reward_test.exs
@@ -70,20 +70,24 @@ defmodule Archethic.RewardTest do
 
     reward_amount2 = reward_amount - 10
 
+    timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+
     unspent_outputs1 = %UnspentOutput{
       from: :crypto.strong_rand_bytes(32),
       amount: reward_amount * 2,
-      type: {:token, token_address1, 0}
+      type: {:token, token_address1, 0},
+      timestamp: timestamp
     }
 
     unspent_outputs2 = %UnspentOutput{
       from: :crypto.strong_rand_bytes(32),
       amount: reward_amount2,
-      type: {:token, token_address2, 0}
+      type: {:token, token_address2, 0},
+      timestamp: timestamp
     }
 
-    TokenLedger.add_unspent_output(address, unspent_outputs1, DateTime.utc_now())
-    TokenLedger.add_unspent_output(address, unspent_outputs2, DateTime.utc_now())
+    TokenLedger.add_unspent_output(address, unspent_outputs1)
+    TokenLedger.add_unspent_output(address, unspent_outputs2)
 
     assert [
              %Transfer{
@@ -106,7 +110,6 @@ defmodule Archethic.RewardTest do
 
   describe "Reward Ops:" do
     setup do
-      #  start supervised  ...
       MockDB
       |> stub(:list_transactions_by_type, fn :mint_rewards, [:address, :type] ->
         [
@@ -204,20 +207,28 @@ defmodule Archethic.RewardTest do
                 %UnspentOutput{
                   from: "@Alen2",
                   amount: 200_000_000,
-                  type: :UCO
+                  type: :UCO,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 },
-                %UnspentOutput{from: "@Dan2", amount: 1_900_000_000, type: :UCO},
+                %UnspentOutput{
+                  from: "@Dan2",
+                  amount: 1_900_000_000,
+                  type: :UCO,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+                },
                 %UnspentOutput{
                   from: "@RewardToken1",
                   amount: 5_000_000_000,
                   type: {:token, "@RewardToken1", 0},
-                  reward?: true
+                  reward?: true,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 },
                 %UnspentOutput{
                   from: "@RewardToken2",
                   amount: 5_000_000_000,
                   type: {:token, "@RewardToken2", 0},
-                  reward?: true
+                  reward?: true,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 }
               ]
             }
@@ -256,20 +267,28 @@ defmodule Archethic.RewardTest do
                 %UnspentOutput{
                   from: "@Alen2",
                   amount: 200_000_000,
-                  type: :UCO
+                  type: :UCO,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 },
-                %UnspentOutput{from: "@Bob8", amount: 1_900_000_000, type: :UCO},
+                %UnspentOutput{
+                  from: "@Bob8",
+                  amount: 1_900_000_000,
+                  type: :UCO,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+                },
                 %UnspentOutput{
                   from: "@RewardToken1",
                   amount: 5_000_000_000,
                   type: {:token, "@RewardToken1", 0},
-                  reward?: true
+                  reward?: true,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 },
                 %UnspentOutput{
                   from: "@RewardToken2",
                   amount: 5_000_000_000,
                   type: {:token, "@RewardToken2", 0},
-                  reward?: true
+                  reward?: true,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 }
               ]
             }
@@ -298,31 +317,36 @@ defmodule Archethic.RewardTest do
                 %UnspentOutput{
                   from: "@Ray1",
                   amount: 200_000_000,
-                  type: :UCO
+                  type: :UCO,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 },
                 %UnspentOutput{
                   from: "@RewardToken1",
                   amount: 5_000_000_000,
                   type: {:token, "@RewardToken1", 0},
-                  reward?: true
+                  reward?: true,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 },
                 %UnspentOutput{
                   from: "@RewardToken2",
                   amount: 5_000_000_000,
                   type: {:token, "@RewardToken2", 0},
-                  reward?: true
+                  reward?: true,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 },
                 %UnspentOutput{
                   from: "@RewardToken3",
                   amount: 5_000_000_000,
                   type: {:token, "@RewardToken3", 0},
-                  reward?: true
+                  reward?: true,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 },
                 %UnspentOutput{
                   from: "@RewardToken4",
                   amount: 200_000_000,
                   type: {:token, "@RewardToken4", 0},
-                  reward?: true
+                  reward?: true,
+                  timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
                 }
               ]
             }
@@ -390,13 +414,15 @@ defmodule Archethic.RewardTest do
                 from: "@RewardToken1",
                 amount: 1_000_000_000,
                 type: {:token, "@RewardToken1", 0},
-                reward?: true
+                reward?: true,
+                timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
               },
               %UnspentOutput{
                 from: "@RewardToken2",
                 amount: 2_000_000_000,
                 type: {:token, "@RewardToken2", 0},
-                reward?: true
+                reward?: true,
+                timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
               }
             ]
           }

--- a/test/archethic/transaction_chain/transaction/validation_stamp_test.exs
+++ b/test/archethic/transaction_chain/transaction/validation_stamp_test.exs
@@ -69,6 +69,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStampTest do
     gen all(
           from <- StreamData.binary(length: 33),
           amount <- StreamData.positive_integer(),
+          timestamp <- StreamData.constant(DateTime.utc_now() |> DateTime.truncate(:millisecond)),
           type <-
             StreamData.one_of([
               StreamData.constant(:UCO),
@@ -78,7 +79,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStampTest do
               )
             ])
         ) do
-      %UnspentOutput{from: from, amount: amount, type: type}
+      %UnspentOutput{from: from, amount: amount, type: type, timestamp: timestamp}
     end
   end
 end

--- a/test/archethic_web/controllers/faucet_controller_test.exs
+++ b/test/archethic_web/controllers/faucet_controller_test.exs
@@ -167,7 +167,7 @@ defmodule ArchethicWeb.FaucetControllerTest do
       end)
 
       faucet_requests =
-        for request_index <- 1..(faucet_rate_limit + 1) do
+        for _request_index <- 1..(faucet_rate_limit + 1) do
           post(conn, Routes.faucet_path(conn, :create_transfer), address: recipient_address)
         end
 

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -37,7 +37,7 @@ defmodule Archethic.TransactionFactory do
         fee: Fee.calculate(tx, 0.07),
         transaction_movements: Transaction.get_movements(tx)
       }
-      |> LedgerOperations.consume_inputs(tx.address, inputs)
+      |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
 
     validation_stamp =
       %ValidationStamp{
@@ -69,15 +69,17 @@ defmodule Archethic.TransactionFactory do
   def create_valid_transaction_with_inconsistencies(inputs \\ []) do
     tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
 
+    timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+
     ledger_operations =
       %LedgerOperations{
         fee: Fee.calculate(tx, 0.07)
       }
-      |> LedgerOperations.consume_inputs(tx.address, inputs)
+      |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
 
     validation_stamp =
       %ValidationStamp{
-        timestamp: DateTime.utc_now(),
+        timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
         proof_of_election:
@@ -98,14 +100,18 @@ defmodule Archethic.TransactionFactory do
   def create_transaction_with_invalid_proof_of_work(inputs \\ []) do
     tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
 
+    timestamp =
+      DateTime.utc_now()
+      |> DateTime.truncate(:millisecond)
+
     ledger_operations =
       %LedgerOperations{
         fee: Fee.calculate(tx, 0.07)
       }
-      |> LedgerOperations.consume_inputs(tx.address, inputs)
+      |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
 
     validation_stamp = %ValidationStamp{
-      timestamp: DateTime.utc_now(),
+      timestamp: timestamp,
       proof_of_work: <<0, 0, :crypto.strong_rand_bytes(32)::binary>>,
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
@@ -124,15 +130,16 @@ defmodule Archethic.TransactionFactory do
 
   def create_transaction_with_invalid_validation_stamp_signature(inputs \\ []) do
     tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
+    timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
 
     ledger_operations =
       %LedgerOperations{
         fee: Fee.calculate(tx, 0.07)
       }
-      |> LedgerOperations.consume_inputs(tx.address, inputs)
+      |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
 
     validation_stamp = %ValidationStamp{
-      timestamp: DateTime.utc_now(),
+      timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
@@ -151,16 +158,17 @@ defmodule Archethic.TransactionFactory do
 
   def create_transaction_with_invalid_fee(inputs \\ []) do
     tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
+    timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
 
     ledger_operations =
       %LedgerOperations{
         fee: 1_000_000_000
       }
-      |> LedgerOperations.consume_inputs(tx.address, inputs)
+      |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
 
     validation_stamp =
       %ValidationStamp{
-        timestamp: DateTime.utc_now(),
+        timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_election:
           Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
@@ -180,6 +188,7 @@ defmodule Archethic.TransactionFactory do
 
   def create_transaction_with_invalid_transaction_movements(inputs \\ []) do
     tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
+    timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
 
     ledger_operations =
       %LedgerOperations{
@@ -188,11 +197,11 @@ defmodule Archethic.TransactionFactory do
           %TransactionMovement{to: "@Bob4", amount: 30_330_000_000, type: :UCO}
         ]
       }
-      |> LedgerOperations.consume_inputs(tx.address, inputs)
+      |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
 
     validation_stamp =
       %ValidationStamp{
-        timestamp: DateTime.utc_now(),
+        timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
         proof_of_election:
@@ -236,7 +245,7 @@ defmodule Archethic.TransactionFactory do
         fee: Fee.calculate(tx, 0.07),
         transaction_movements: Transaction.get_movements(tx)
       }
-      |> LedgerOperations.consume_inputs(tx.address, inputs)
+      |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
 
     validation_stamp =
       %ValidationStamp{


### PR DESCRIPTION
# Description
Includes a new field in UnspentOutputs : timestamp.Timestamp is a DateTime field with precision of milliseconds. Serde is done through conversion into unix timestamp with milliseconds , and the no_negative_int  size is 8 bytes/ 64 bits.

There are 3 sources of UTXO timestamp generation:
  -  In Network init , during self-validation.
  -  In Memtable loaders for UCO / Token ledger, 
     - Conversion of Transaction Movement to UTXO(with validation timestamp as UTXO timestamp)
     - https://github.com/archethic-foundation/archethic-node/blob/b03f84d7bf85f7ba42eee6b58310922ded6328a8/lib/archethic/account/mem_tables_loader.ex#L105-L106
  - In Validation Context.ex
     - https://github.com/archethic-foundation/archethic-node/blob/b03f84d7bf85f7ba42eee6b58310922ded6328a8/lib/archethic/mining/validation_context.ex#L780-L789
 
## Fixes 
- [ ] #564


## Type of change
- Bug fixs
 -  Test crashes with Reward Scheduler
 -  More determinism with RewardMemtableloader tests
- Minor fix
  -  account/ledgers
     - Update comments/specs/timestamp precision to milliseconds
     - accommodating change for new utxo timestamp field.
  - Ignore unused _request_index var in Faucet_Controller.
- New feature
  - New field in %UnspentOuputs{} -> timestamp
    -  https://github.com/archethic-foundation/archethic-node/blob/b03f84d7bf85f7ba42eee6b58310922ded6328a8/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/unspent_output.ex#L14-L19
  - LedgerOperations methods require timestamp arguments
      - https://github.com/archethic-foundation/archethic-node/blob/b03f84d7bf85f7ba42eee6b58310922ded6328a8/lib/archethic/mining/validation_context.ex#L780-L789
  - Transaction Validator now validates timestamp in utxo
     -  https://github.com/archethic-foundation/archethic-node/blob/b03f84d7bf85f7ba42eee6b58310922ded6328a8/lib/archethic/replication/transaction_validator.ex#L358-L370
- Breaking change 
  -  Additional timestamp parameter passing , TokenLedger/UCOLedger.add_utxo is removed
     -  Dependent upon utxo timestamp
     - https://github.com/archethic-foundation/archethic-node/blob/b03f84d7bf85f7ba42eee6b58310922ded6328a8/lib/archethic/account/mem_tables/token_ledger.ex#L66-L68
 - Require Documentation Update
   - https://github.com/archethic-foundation/archethic-node/blob/b03f84d7bf85f7ba42eee6b58310922ded6328a8/lib/archethic_web/graphql_schema/transaction_type.ex#L160-L168
# How Has This Been Tested?

- [x] Mix test --trace , mix dialyzer, mix credo
- [x] Test with multiple nodes
- [x] mix dev.lbench

# Errors
Errors during bench , 
![Screenshot_20221011_193243](https://user-images.githubusercontent.com/90304197/195112942-1c73aa26-2085-4b3a-9744-89f622c8c2f6.png)



# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
