### PR TITLE
Origin transaction should verify existing public key#583

### DIFF
--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -331,6 +331,8 @@ defmodule Archethic.Mining.PendingTransactionValidation do
            Utils.deserialize_public_key(content),
          <<key_certificate_size::16, key_certificate::binary-size(key_certificate_size),
            _::binary>> <- rest,
+         {:exists?, false} <-
+           {:exists?, SharedSecrets.has_origin_public_key?(origin_public_key)},
          root_ca_public_key <-
            Crypto.get_root_ca_public_key(origin_public_key),
          true <-
@@ -339,6 +341,9 @@ defmodule Archethic.Mining.PendingTransactionValidation do
     else
       false ->
         {:error, "Invalid Origin transaction with invalid certificate"}
+
+      {:exists?, true} ->
+        {:error, "Invalid Origin transaction Public Key Already Exists"}
 
       _ ->
         {:error, "Invalid Origin transaction's content"}

--- a/lib/archethic/shared_secrets.ex
+++ b/lib/archethic/shared_secrets.ex
@@ -38,6 +38,12 @@ defmodule Archethic.SharedSecrets do
   defdelegate add_origin_public_key(family, key), to: OriginKeyLookup, as: :add_public_key
 
   @doc """
+  Checks if the Origin public key already exists.
+  """
+  @spec has_origin_public_key?(origin_public_key :: Crypto.key()) :: boolean()
+  defdelegate has_origin_public_key?(origin_public_key), to: OriginKeyLookup, as: :has_public_key?
+
+  @doc """
   Get the last network pool address
   """
   @spec get_network_pool_address() :: Crypto.key()
@@ -210,7 +216,7 @@ defmodule Archethic.SharedSecrets do
   end
 
   @doc """
-  Returs Origin id from Origin Public Key
+  Returns Origin id from Origin Public Key
   """
   @spec origin_family_from_public_key(<<_::16, _::_*8>>) :: origin_family()
   def origin_family_from_public_key(<<_curve_id::8, origin_id::8, _public_key::binary>>) do

--- a/lib/archethic_web/controllers/api/origin_key_controller.ex
+++ b/lib/archethic_web/controllers/api/origin_key_controller.ex
@@ -14,6 +14,8 @@ defmodule ArchethicWeb.API.OriginKeyController do
            {:ok, origin_public_key} <- Base.decode16(origin_public_key, case: :mixed),
            {:ok, certificate} <- Base.decode16(certificate, case: :mixed),
            true <- Crypto.valid_public_key?(origin_public_key),
+           {:exists?, false} <-
+             {:exists?, SharedSecrets.has_origin_public_key?(origin_public_key)},
            <<_curve_id::8, origin_id::8, _rest::binary>> <- origin_public_key do
         origin_id
         |> prepare_transaction(origin_public_key, certificate)
@@ -80,6 +82,9 @@ defmodule ArchethicWeb.API.OriginKeyController do
     case error do
       er when er in [:error, false] ->
         {400, %{status: "error - invalid public key"}}
+
+      {:exists?, true} ->
+        {400, %{status: "error - public key exists"}}
 
       _ ->
         {400, %{status: "error - invalid parameters"}}

--- a/test/archethic/shared_secrets_test.exs
+++ b/test/archethic/shared_secrets_test.exs
@@ -1,7 +1,29 @@
 defmodule Archethic.SharedSecretsTest do
   use ExUnit.Case
 
-  alias Archethic.SharedSecrets
+  alias Archethic.{
+    Crypto,
+    SharedSecrets,
+    SharedSecrets.MemTables.OriginKeyLookup
+  }
 
   doctest SharedSecrets
+
+  describe "has_origin_public_key?/1" do
+    setup do
+      start_supervised!(OriginKeyLookup)
+      :ok
+    end
+
+    test "should return false when origin public key does not exist in Origin memtable" do
+      {pb_key, _} = Crypto.derive_keypair("has_origin_public_key", 0)
+      refute SharedSecrets.has_origin_public_key?(pb_key)
+    end
+
+    test "should return true when origin public key does not exist in Origin memtable" do
+      {pb_key, _} = Crypto.derive_keypair("has_origin_public_key", 0)
+      OriginKeyLookup.add_public_key(:software, pb_key)
+      assert SharedSecrets.has_origin_public_key?(pb_key)
+    end
+  end
 end

--- a/test/archethic_web/controllers/api/origin_key_controller_test.exs
+++ b/test/archethic_web/controllers/api/origin_key_controller_test.exs
@@ -2,10 +2,7 @@ defmodule ArchethicWeb.API.OriginKeyControllerTest do
   use ArchethicCase
   use ArchethicWeb.ConnCase
 
-  alias Archethic.Crypto
-
-  alias Archethic.P2P
-  alias Archethic.P2P.Node
+  alias Archethic.{Crypto, P2P, P2P.Node, SharedSecrets, SharedSecrets.MemTables.OriginKeyLookup}
 
   import Mox
 
@@ -21,6 +18,8 @@ defmodule ArchethicWeb.API.OriginKeyControllerTest do
       authorized?: true,
       authorization_date: DateTime.utc_now()
     })
+
+    OriginKeyLookup.start_link()
 
     :ok
   end
@@ -50,6 +49,73 @@ defmodule ArchethicWeb.API.OriginKeyControllerTest do
           origin_public_key:
             "00015403152aeb59b1b584d77c8f326031815674afeade8cba25f18f02737d599c39",
           certificate: ""
+        })
+
+      assert %{
+               "status" => "pending"
+             } = json_response(conn, 201)
+    end
+  end
+
+  describe "Origin Key Lookup Test" do
+    setup do
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.last_node_public_key(),
+        network_patch: "AAA",
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: true,
+        authorization_date: DateTime.utc_now()
+      })
+
+      OriginKeyLookup.start_link([])
+
+      :ok
+    end
+
+    test "should not accept origin transactions when the Origin Public Key already exists.",
+         %{conn: conn} do
+      MockClient
+      |> stub(:send_message, fn _, _, _ ->
+        {:ok, :ok}
+      end)
+
+      {public_key, _} = Crypto.derive_keypair("has_origin_public_key", 0)
+      OriginKeyLookup.add_public_key(:software, public_key)
+      certificate = Crypto.get_key_certificate(public_key)
+
+      assert true == SharedSecrets.has_origin_public_key?(public_key)
+
+      conn =
+        post(conn, "/api/origin_key", %{
+          origin_public_key: public_key |> Base.encode16(),
+          certificate: certificate |> Base.encode16()
+        })
+
+      assert %{
+               "status" => "error - public key exists"
+             } = json_response(conn, 400)
+    end
+
+    test "should accept origin transactions when the Origin Public Key does not exists",
+         %{conn: conn} do
+      MockClient
+      |> stub(:send_message, fn _, _, _ ->
+        {:ok, :ok}
+      end)
+
+      {public_key, _} = Crypto.derive_keypair("does_not_have_origin_public_key2", 0)
+      certificate = Crypto.get_key_certificate(public_key)
+
+      assert false == SharedSecrets.has_origin_public_key?(public_key)
+
+      conn =
+        post(conn, "/api/origin_key", %{
+          origin_public_key: public_key |> Base.encode16(),
+          certificate: certificate |> Base.encode16()
         })
 
       assert %{


### PR DESCRIPTION
# Description
 
`/api/origin_key` -> Origin endpoint is leveraged to add origin public key and its corresponding certificate, An origin transaction is created, on post request, with content as origin_public_key and certificate, But there are no checks for to ensure that this origin public key has already been included in existing transaction. A  check is introduced leveraging the OriginKey store to check if the origin Public key already exists before creating/accepting the transaction.

Checks are done at two different location/Stages:
 - In the `origin Api controller`, During post call
 - In `Pending_transaction_validation.ex` in do_accept_tx(:origin), validation of tx

New error logging for both locations api call and during validation is introduced. 

##Fixes 
- [ ] #583

## Type of change
- Bug fix 
   - Check for existing Origin Public key
- New feature
    -  Check for existing Origin Public key
- This change requires a documentation update
   - New error reporting if origin public key already exists

# How Has This Been Tested?
- [x] mix dev.lbench regression
- [x] Running on multiple nodes
- [x] unit test cases 

### How to test?
- `key certificate is ""` -Crypto.get_key_certificate(public_key)

-  Accepting a Origin tx with no existing origin public key in store
    - Generate pbkey, cert and post an origin api call with base16 encoded public key and certificate
      ``` 
     iex>  alias Archethic.Crypto
     iex>  alias Archethic.SharedSecrets.MemTable.OriginKeyLookup
     iex>  {public_key, _} = Crypto.derive_keypair("has_origin_public_key_Seed", 0)
     iex>  certificate = Crypto.get_key_certificate(public_key)
     iex> pb_key = public_key|>Base.encode16
     iex> cert = certificate|>Base.encode16
      ```
  - Check tx address in Origin Explorer
  
-  Rejecting a Origin tx with existing origin public key in store
   - Add the generated origin public key, via api, or method call
      ``` 
      iex>    OriginKeyLookup.add_public_key(:software, public_key)
      ```
   - Api response will be ```error - public key exists```
# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
