### PR TITLE
Adds sobelow for static analysis in dev and ci/cd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
       run: mix compile --warnings-as-errors
     - name: Set credo
       run: mix credo 
+    - name: Run Sobelow
+      run: mix sobelow 
     - name: Run tests
       run: mix test --trace
     - name: Retrieve PLT Cache

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,7 @@ config :git_hooks,
         "mix format --check-formatted",
         "mix compile --warnings-as-errors",
         "mix credo",
+        "mix sobelow",
         "mix knigge.verify",
         "mix test --trace",
         "mix dialyzer"

--- a/mix.exs
+++ b/mix.exs
@@ -68,6 +68,9 @@ defmodule Archethic.MixProject do
       {:dialyxir, "~> 1.0", runtime: false},
       {:logger_file_backend, "~> 0.0.13", only: :dev},
 
+      # Security
+      {:sobelow, ">= 0.11.1", only: [:test, :dev], runtime: false},
+
       # Test
       {:mox, "~> 0.5.2", only: [:test]},
       {:stream_data, "~> 0.5.0", only: [:test], runtime: false},
@@ -116,9 +119,17 @@ defmodule Archethic.MixProject do
       # run single node
       "dev.run": ["deps.get", "cmd mix dev.clean", "cmd iex -S mix"],
       # Must be run before git push --no-verify | any(dialyzer issue)
-      "dev.checks": ["clean", "format", "compile", "credo", "cmd mix test --trace", "dialyzer"],
+      "dev.checks": [
+        "clean",
+        "format",
+        "compile",
+        "credo",
+        "sobelow",
+        "cmd mix test --trace",
+        "dialyzer"
+      ],
       # paralele checks
-      "dev.pchecks": ["  clean &   format &    compile &   credo &   test &   dialyzer"],
+      "dev.pchecks": ["  clean &   format &    compile &   credo &   sobelow & test &   dialyzer"],
       # docker test-net with 3 nodes
       "dev.docker": [
         "cmd docker-compose down",

--- a/mix.lock
+++ b/mix.lock
@@ -64,6 +64,7 @@
   "recon": {:hex, :recon, "2.5.2", "cba53fa8db83ad968c9a652e09c3ed7ddcc4da434f27c3eaa9ca47ffb2b1ff03", [:mix, :rebar3], [], "hexpm", "2c7523c8dee91dff41f6b3d63cba2bd49eb6d2fe5bf1eec0df7f87eb5e230e1c"},
   "retry": {:hex, :retry, "0.14.1", "722d1b0cf87096b71213f5801d99fface7ca76adc83fc9dbf3e1daee952aef10", [:mix], [], "hexpm", "b3a609f286f6fe4f6b2c15f32cd4a8a60427d78d05d7b68c2dd9110981111ae0"},
   "sizeable": {:hex, :sizeable, "1.0.2", "625fe06a5dad188b52121a140286f1a6ae1adf350a942cf419499ecd8a11ee29", [:mix], [], "hexpm", "4bab548e6dfba777b400ca50830a9e3a4128e73df77ab1582540cf5860601762"},
+  "sobelow": {:hex, :sobelow, "0.11.1", "23438964486f8112b41e743bbfd402da3e5b296fdc9eacab29914b79c48916dd", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "9897363a7eff96f4809304a90aad819e2ad5e5d24db547af502885146746a53c"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
   "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},


### PR DESCRIPTION
# Description

Adds `sobelow` for static analysis of the code

Refer: https://github.com/nccgroup/sobelow

Fixes #593 

## Type of change
- Changes in dependencies
- mix task changes - `mix dev.checks` & `mix dev.pchecks`
- Git hook for pre_push will now run sobelow checks
- GitHub Actions run sobelow checks

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Ran it locally and on the CI.

Sobelow checks are run and the report is shown.


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
