### PR TITLE
Add selfsigned certificate by default in prod config

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -240,6 +240,6 @@ config :archethic, ArchethicWeb.Endpoint,
     otp_app: :archethic,
     port: System.get_env("ARCHETHIC_HTTPS_PORT", "50000") |> String.to_integer(),
     sni_fun: &ArchethicWeb.Domain.sni/1,
-    keyfile: System.get_env("ARCHETHIC_WEB_SSL_KEYFILE", ""),
-    certfile: System.get_env("ARCHETHIC_WEB_SSL_CERTFILE", "")
+    keyfile: System.get_env("ARCHETHIC_WEB_SSL_KEYFILE", "priv/cert/selfsigned_key.pem"),
+    certfile: System.get_env("ARCHETHIC_WEB_SSL_CERTFILE", "priv/cert/selfsigned.pem")
   ]

--- a/lib/archethic_web/domain.ex
+++ b/lib/archethic_web/domain.ex
@@ -83,8 +83,20 @@ defmodule ArchethicWeb.Domain do
         keyfile = Keyword.fetch!(https_conf, :keyfile)
         certfile = Keyword.fetch!(https_conf, :certfile)
 
-        key = File.read!(keyfile) |> read_pem() |> hd()
-        cert = File.read!(certfile) |> read_pem() |> hd() |> elem(1)
+        key_content =
+          case File.read(keyfile) do
+            {:ok, content} -> content
+            {:error, _} -> File.read!(Application.app_dir(:archethic, keyfile))
+          end
+
+        cert_content =
+          case File.read(certfile) do
+            {:ok, content} -> content
+            {:error, _} -> File.read!(Application.app_dir(:archethic, certfile))
+          end
+
+        key = key_content |> read_pem() |> hd()
+        cert = cert_content |> read_pem() |> hd() |> elem(1)
 
         [key: key, cert: cert]
     end


### PR DESCRIPTION
# Description

By default there is no certificate for https in prod config. But without certificate, the https endpoint is not launched and so we cannot resolve request for aeweb redirection with dnslink.

To enable this functionnality, a self signed certificate is configured by default so the https endpoint is started and the node can serve aeweb website with certificate and https encryption

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
