### PR TITLE
Fix Transaction subscriber returning wrong number of max confirmations

### DIFF
--- a/lib/archethic_web/transaction_subscriber.ex
+++ b/lib/archethic_web/transaction_subscriber.ex
@@ -148,7 +148,7 @@ defmodule ArchethicWeb.TransactionSubscriber do
 
   def get_max_confirmations(tx_address) do
     tx_address
-    |> Election.chain_storage_nodes(P2P.authorized_nodes())
+    |> Election.chain_storage_nodes(P2P.authorized_and_available_nodes())
     |> Enum.count()
   end
 end


### PR DESCRIPTION
# Description

Transaction subscriber return the maximum number of confirmation, but it was taking all authorized nodes instead of authorized and available nodes

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
