### PR TITLE
Fix connection bugs

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -30,11 +30,11 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :archethic, Archethic.BeaconChain.SlotTimer,
   # Every 10 seconds
-  interval: "*/10 * * * * *"
+  interval: "*/10 * * * * * *"
 
 config :archethic, Archethic.BeaconChain.SummaryTimer,
   # Every minute
-  interval: "0 * * * * *"
+  interval: "0 * * * * * *"
 
 config :archethic, Archethic.Bootstrap,
   reward_address: System.get_env("ARCHETHIC_REWARD_ADDRESS", "") |> Base.decode16!(case: :mixed)
@@ -85,9 +85,9 @@ config :archethic, Archethic.Governance.Pools,
 
 config :archethic, Archethic.OracleChain.Scheduler,
   # Poll new changes every 10 seconds
-  polling_interval: "*/10 * * * * *",
-  # Aggregate chain at the 50th second
-  summary_interval: "0 * * * * *"
+  polling_interval: "*/10 * * * * * *",
+  # Aggregate every minute
+  summary_interval: "0 * * * * * *"
 
 # -----Start-of-Networking-dev-configs-----
 config :archethic, Archethic.Networking,
@@ -104,7 +104,7 @@ config :archethic, Archethic.Networking.Scheduler, interval: "0 * * * * * *"
 
 config :archethic, Archethic.Reward.Scheduler,
   # At the 30th second
-  interval: "30 * * * * *"
+  interval: "30 * * * * * *"
 
 config :archethic, Archethic.SelfRepair.Scheduler,
   # Every minute at the 5th second

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -176,11 +176,12 @@ config :archethic, Archethic.Networking.IPLookup.Static,
 # -----end-of-Networking-prod-configs-----
 
 config :archethic, Archethic.Networking.Scheduler,
-  interval: System.get_env("ARCHETHIC_NETWORKING_UPDATE_SCHEDULER", "0 0 * * * * *")
+  # Every 5 minutes
+  interval: System.get_env("ARCHETHIC_NETWORKING_UPDATE_SCHEDULER", "0 */5 * * * * *")
 
 config :archethic, Archethic.OracleChain.Scheduler,
   # Poll new changes every minute
-  polling_interval: System.get_env("ARCHETHIC_ORACLE_CHAIN_POLLING_INTERVAL", "0 * * * * *"),
+  polling_interval: System.get_env("ARCHETHIC_ORACLE_CHAIN_POLLING_INTERVAL", "0 * * * * * *"),
   # Aggregate chain every day at midnight
   summary_interval: System.get_env("ARCHETHIC_ORACLE_CHAIN_SUMMARY_INTERVAL", "0 0 0 * * * *")
 
@@ -195,7 +196,7 @@ config :archethic,
 config :archethic, Archethic.SharedSecrets.NodeRenewalScheduler,
   # Every day at 23:50:00
   interval:
-    System.get_env("ARCHETHIC_SHARED_SECRETS_RENEWAL_SCHEDULER_INTERVAL", "0 50 0 * * * *"),
+    System.get_env("ARCHETHIC_SHARED_SECRETS_RENEWAL_SCHEDULER_INTERVAL", "0 50 23 * * * *"),
   # Every day at midnight
   application_interval:
     System.get_env("ARCHETHIC_SHARED_SECRETS_APPLICATION_INTERVAL", "0 0 0 * * * *")

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -59,13 +59,8 @@ defmodule Archethic.P2P do
     if first_public_key == Crypto.first_node_public_key() do
       :ok
     else
-      case Client.new_connection(ip, port, transport, first_public_key) do
-        {:ok, _pid} ->
-          :ok
-
-        {:error, {:already_started, _pid}} ->
-          :ok
-      end
+      {:ok, _pid} = Client.new_connection(ip, port, transport, first_public_key)
+      :ok
     end
   end
 

--- a/lib/archethic/p2p/client/connection/supervisor.ex
+++ b/lib/archethic/p2p/client/connection/supervisor.ex
@@ -25,4 +25,12 @@ defmodule Archethic.P2P.Client.ConnectionSupervisor do
       }
     )
   end
+
+  @doc """
+  Terminate a connection process
+  """
+  @spec cancel_connection(pid) :: :ok | {:error, :not_found}
+  def cancel_connection(pid) do
+    DynamicSupervisor.terminate_child(__MODULE__, pid)
+  end
 end

--- a/lib/archethic/p2p/client/transport/tcp_impl.ex
+++ b/lib/archethic/p2p/client/transport/tcp_impl.ex
@@ -9,7 +9,7 @@ defmodule Archethic.P2P.Client.Transport.TCPImpl do
 
   @impl Transport
   def handle_connect(ip, port) do
-    :gen_tcp.connect(ip, port, @options)
+    :gen_tcp.connect(ip, port, @options, 4000)
   end
 
   @impl Transport

--- a/lib/archethic/p2p/listener_protocol.ex
+++ b/lib/archethic/p2p/listener_protocol.ex
@@ -51,9 +51,6 @@ defmodule Archethic.P2P.ListenerProtocol do
         %{message: Archethic.P2P.Message.name(message)}
       )
 
-      Archethic.P2P.MemTable.increase_node_availability(sender_public_key)
-      Archethic.P2P.Client.Connection.start_availability_timer(sender_public_key)
-
       start_processing_time = System.monotonic_time()
       response = Archethic.P2P.Message.process(message)
 

--- a/lib/archethic/p2p/mem_table_loader.ex
+++ b/lib/archethic/p2p/mem_table_loader.ex
@@ -145,13 +145,8 @@ defmodule Archethic.P2P.MemTableLoader do
     Logger.info("Node loaded into in memory p2p tables", node: Base.encode16(first_public_key))
 
     if first_public_key != Crypto.first_node_public_key() do
-      case Client.new_connection(ip, port, transport, first_public_key) do
-        {:ok, _} ->
-          :ok
-
-        {:error, {:already_started, _}} ->
-          :ok
-      end
+      {:ok, _pid} = Client.new_connection(ip, port, transport, first_public_key)
+      :ok
     else
       :ok
     end

--- a/test/archethic/p2p/client/connection_test.exs
+++ b/test/archethic/p2p/client/connection_test.exs
@@ -258,7 +258,8 @@ defmodule Archethic.P2P.Client.ConnectionTest do
 
       assert {_, %{availability_timer: {nil, 1}}} = :sys.get_state(pid)
 
-      :ok = Connection.start_availability_timer(Crypto.first_node_public_key())
+      # restart timer simulating a reconnection
+      send(pid, :start_timer)
 
       assert {_, %{availability_timer: {start, 1}}} = :sys.get_state(pid)
       assert start != nil
@@ -342,7 +343,8 @@ defmodule Archethic.P2P.Client.ConnectionTest do
 
       assert {_, %{availability_timer: {nil, 0}}} = :sys.get_state(pid)
 
-      :ok = Connection.start_availability_timer(Crypto.first_node_public_key())
+      # restart timer simulating a reconnection
+      send(pid, :start_timer)
 
       assert {_, %{availability_timer: {start, 0}}} = :sys.get_state(pid)
 


### PR DESCRIPTION
# Description

Fixes some bug in connection between nodes:
- Add a timeout in tcp handle_connect. Default timeout is infinity so the process stay stuck in this function if the server is unreachable.
- If a node changes it's ip, the connection module associated to the node is not notified. Now whenever a node is updated, if the connection informations change (ip, port, transport), the connection process is killed and a new one is started with the new informations

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Run 3 nodes
- Stop one and restart it with other port parameter

Connection should be updated and nodes can contact each other

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
