### PR TITLE
Fix self repair bugs

### DIFF
--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -45,6 +45,8 @@ defmodule Archethic.DB do
 
   @callback get_last_chain_address(binary()) :: {binary(), DateTime.t()}
   @callback get_last_chain_address(binary(), DateTime.t()) :: {binary(), DateTime.t()}
+  @callback get_last_chain_public_key(binary()) :: Crypto.key()
+  @callback get_last_chain_public_key(binary(), DateTime.t()) :: Crypto.key()
   @callback get_first_chain_address(binary()) :: binary()
   @callback get_first_public_key(Crypto.key()) :: binary()
   @callback scan_chain(

--- a/lib/archethic/db/embedded_impl.ex
+++ b/lib/archethic/db/embedded_impl.ex
@@ -237,6 +237,15 @@ defmodule Archethic.DB.EmbeddedImpl do
   end
 
   @doc """
+  Return the last public key from the given public key until the given date along with its timestamp
+  """
+  @spec get_last_chain_public_key(public_key :: binary(), until :: DateTime.t()) :: Crypto.key()
+  def get_last_chain_public_key(public_key, date = %DateTime{} \\ DateTime.utc_now())
+      when is_binary(public_key) do
+    ChainIndex.get_last_chain_public_key(public_key, date, db_path())
+  end
+
+  @doc """
   Reference a last address from a previous address
   """
   @spec add_last_transaction_address(

--- a/lib/archethic/db/embedded_impl/chain_index.ex
+++ b/lib/archethic/db/embedded_impl/chain_index.ex
@@ -539,6 +539,50 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
   end
 
   @doc """
+  Return the last public key of a chain until a date
+
+  If no key is found, the given public key is returned
+  """
+  @spec get_last_chain_public_key(Crypto.key(), DateTime.t(), String.t()) :: Crypto.key()
+  def get_last_chain_public_key(public_key, until = %DateTime{}, db_path) do
+    # We derive the previous address from the public key to get the genesis address
+    # and its relative file
+    address = Crypto.derive_address(public_key)
+    genesis_address = get_first_chain_address(address, db_path)
+    filepath = chain_keys_path(db_path, genesis_address)
+
+    until = DateTime.to_unix(until, :millisecond)
+
+    case File.open(filepath, [:binary, :read]) do
+      {:ok, fd} ->
+        do_get_last_public_key(fd, until, public_key)
+
+      {:error, _} ->
+        public_key
+    end
+  end
+
+  defp do_get_last_public_key(fd, until, last_public_key) do
+    # We need to extract key metadata information to know how many bytes to decode
+    # as keys can have different sizes based on the curve used
+    with {:ok, <<timestamp::64, curve_id::8, origin_id::8>>} <- :file.read(fd, 10),
+         key_size <- Crypto.key_size(curve_id),
+         {:ok, key} <- :file.read(fd, key_size) do
+      if timestamp < until do
+        public_key = <<curve_id::8, origin_id::8, key::binary>>
+        do_get_last_public_key(fd, until, public_key)
+      else
+        :file.close(fd)
+        last_public_key
+      end
+    else
+      :eof ->
+        :file.close(fd)
+        last_public_key
+    end
+  end
+
+  @doc """
   Stream all the file stats entries to indentify the addresses
   """
   @spec list_all_addresses(String.t()) :: Enumerable.t() | list(binary())

--- a/lib/archethic/db/embedded_impl/chain_writer.ex
+++ b/lib/archethic/db/embedded_impl/chain_writer.ex
@@ -75,7 +75,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
       |> SummaryAggregate.serialize()
       |> Utils.wrap_binary()
 
-    File.write!(filename, data, [:exclusive, :binary])
+    File.write!(filename, data, [:binary])
 
     :telemetry.execute([:archethic, :db], %{duration: System.monotonic_time() - start}, %{
       query: "write_beacon_summaries_aggregate"

--- a/lib/archethic/p2p/mem_table.ex
+++ b/lib/archethic/p2p/mem_table.ex
@@ -231,6 +231,11 @@ defmodule Archethic.P2P.MemTable do
          last_address: last_address,
          origin_public_key: origin_public_key
        }) do
+    availability_history =
+      if first_public_key == Crypto.first_node_public_key(),
+        do: <<1::1>>,
+        else: availability_history
+
     :ets.insert(
       @discovery_table,
       {first_public_key, last_public_key, ip, port, http_port, geo_patch, network_patch,
@@ -292,7 +297,7 @@ defmodule Archethic.P2P.MemTable do
       end
 
     changes =
-      if availability_history != nil do
+      if availability_history != nil and first_public_key != Crypto.first_node_public_key() do
         [
           {Keyword.fetch!(@discovery_index_position, :availability_history), availability_history}
           | changes

--- a/lib/archethic/p2p/node.ex
+++ b/lib/archethic/p2p/node.ex
@@ -31,7 +31,7 @@ defmodule Archethic.P2P.Node do
     available?: false,
     synced?: false,
     average_availability: 1.0,
-    availability_history: <<1::1>>,
+    availability_history: <<0::1>>,
     authorized?: false,
     authorization_date: nil,
     transport: :tcp,

--- a/lib/archethic/replication/transaction_validator.ex
+++ b/lib/archethic/replication/transaction_validator.ex
@@ -5,9 +5,12 @@ defmodule Archethic.Replication.TransactionValidator do
 
   alias Archethic.Contracts
 
+  alias Archethic.DB
+
   alias Archethic.Election
 
   alias Archethic.P2P
+  alias Archethic.P2P.Node
 
   alias Archethic.Mining
 
@@ -201,6 +204,11 @@ defmodule Archethic.Replication.TransactionValidator do
             storage_nodes,
             Election.get_validation_constraints()
           )
+          # Update node last public key with the one at transaction date
+          |> Enum.map(fn node = %Node{first_public_key: public_key} ->
+            last_public_key = DB.get_last_chain_public_key(public_key, tx_timestamp)
+            %{node | last_public_key: last_public_key}
+          end)
 
         valid_coordinator? =
           Enum.any?(

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -155,6 +155,9 @@ defmodule Archethic.SelfRepair.Sync do
       {:ok, {:ok, %SummaryAggregate{}}} ->
         true
 
+      {:ok, {:error, :not_exists}} ->
+        false
+
       _ ->
         raise "Cannot make the self-repair - Previous summary aggregate not fetched"
     end)

--- a/test/archethic/beacon_chain_test.exs
+++ b/test/archethic/beacon_chain_test.exs
@@ -115,7 +115,8 @@ defmodule Archethic.BeaconChainTest do
         available?: true,
         authorization_date: summary_time |> DateTime.add(-10),
         authorized?: true,
-        reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+        reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+        availability_history: <<1::1>>
       }
 
       node2 = %Node{
@@ -128,7 +129,8 @@ defmodule Archethic.BeaconChainTest do
         available?: true,
         authorization_date: summary_time |> DateTime.add(-10),
         authorized?: true,
-        reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+        reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+        availability_history: <<1::1>>
       }
 
       node3 = %Node{
@@ -141,7 +143,8 @@ defmodule Archethic.BeaconChainTest do
         available?: true,
         authorization_date: summary_time |> DateTime.add(-10),
         authorized?: true,
-        reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+        reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+        availability_history: <<1::1>>
       }
 
       node4 = %Node{
@@ -154,7 +157,8 @@ defmodule Archethic.BeaconChainTest do
         available?: true,
         authorization_date: summary_time |> DateTime.add(-10),
         authorized?: true,
-        reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+        reward_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+        availability_history: <<1::1>>
       }
 
       P2P.add_and_connect_node(node1)

--- a/test/archethic/bootstrap/sync_test.exs
+++ b/test/archethic/bootstrap/sync_test.exs
@@ -335,7 +335,8 @@ defmodule Archethic.Bootstrap.SyncTest do
       port: 4390,
       http_port: 4000,
       first_public_key: "key1",
-      last_public_key: "key1"
+      last_public_key: "key1",
+      availability_history: <<1::1>>
     }
 
     :ok = P2P.add_and_connect_node(node)
@@ -366,7 +367,8 @@ defmodule Archethic.Bootstrap.SyncTest do
                port: 3000,
                http_port: 4000,
                first_public_key: "key2",
-               last_public_key: "key2"
+               last_public_key: "key2",
+               availability_history: <<2::2>>
              }
            ] == P2P.list_nodes()
   end

--- a/test/archethic/p2p/mem_table_test.exs
+++ b/test/archethic/p2p/mem_table_test.exs
@@ -1,5 +1,6 @@
 defmodule Archethic.P2P.MemTableTest do
-  use ExUnit.Case
+  # use ExUnit.Case
+  use ArchethicCase
 
   alias Archethic.P2P.MemTable
   alias Archethic.P2P.Node

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -180,7 +180,10 @@ defmodule ArchethicCase do
     |> stub(:set_storage_nonce, fn _ -> :ok end)
 
     MockClient
-    |> stub(:new_connection, fn _, _, _, _ -> {:ok, make_ref()} end)
+    |> stub(:new_connection, fn _, _, _, public_key ->
+      P2PMemTable.increase_node_availability(public_key)
+      {:ok, make_ref()}
+    end)
 
     start_supervised!(TokenLedger)
     start_supervised!(UCOLedger)

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -75,6 +75,7 @@ defmodule ArchethicCase do
     |> stub(:get_beacon_summaries_aggregate, fn _ -> {:error, :not_exists} end)
     |> stub(:clear_beacon_summaries, fn -> :ok end)
     |> stub(:get_beacon_summary, fn _ -> {:error, :not_exists} end)
+    |> stub(:get_last_chain_public_key, fn public_key, _ -> public_key end)
 
     {:ok, shared_secrets_counter} = Agent.start_link(fn -> 0 end)
     {:ok, network_pool_counter} = Agent.start_link(fn -> 0 end)


### PR DESCRIPTION
# Description

When a node bootstrap, it loads networks node with the latest informations about them. Then it launch it's self repair.
During the self repair, controls are done in the replication to check transaction validity. The valid election control is based on the last public key of a node, but it takes the current last public key of a node and not the one when the transaction was signed.
So if a node signed a transaction and then updating it's chain, the last public key is not the same and so the control fails which also fails the self repair.

To fix this we retrieve the last public key of a node at the transaction timestamp.

Other fixes are done when for some reason there is no summary for a date (all nodes off for example), the self repair was crashing. Now if a summary aggregate is not found, the self repair do not crash (but continue crashing for network_issue reason)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To reproduce the error:
- Run a node
- After few time, create a transaction in node's chain (using endpoint/settings for example)
- Start a second node, it should crash during self repair with node_election error

With the update the second node self repair ends well.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
