### PR TITLE
Cancel oracle polling timer when a rescheduling is started

### DIFF
--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -253,6 +253,14 @@ defmodule Archethic.OracleChain.Scheduler do
       "Reschedule polling after reception of an oracle summary transaction in scheduled state instead of triggered state"
     )
 
+    case Map.get(data, :polling_timer) do
+      nil ->
+        :skip
+
+      timer ->
+        Process.cancel_timer(timer)
+    end
+
     new_data = update_summary_date(data)
     {:next_state, :triggered, new_data, {:next_event, :internal, :fetch_data}}
   end


### PR DESCRIPTION
# Description

Prevent `poll` event to send when the oracle chain scheduler is rescheduling after an oracle summary transaction. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
