### PR TITLE
Prevent update of node availability history during node update

### DIFF
--- a/lib/archethic/p2p/mem_table.ex
+++ b/lib/archethic/p2p/mem_table.ex
@@ -253,7 +253,6 @@ defmodule Archethic.P2P.MemTable do
          geo_patch: geo_patch,
          network_patch: network_patch,
          average_availability: average_availability,
-         availability_history: availability_history,
          enrollment_date: enrollment_date,
          synced?: synced?,
          transport: transport,
@@ -290,16 +289,6 @@ defmodule Archethic.P2P.MemTable do
       if average_availability != nil do
         [
           {Keyword.fetch!(@discovery_index_position, :average_availability), average_availability}
-          | changes
-        ]
-      else
-        changes
-      end
-
-    changes =
-      if availability_history != nil and first_public_key != Crypto.first_node_public_key() do
-        [
-          {Keyword.fetch!(@discovery_index_position, :availability_history), availability_history}
           | changes
         ]
       else


### PR DESCRIPTION
# Description

Prevent update of node's availability history from the node listing in the bootstrap.
The availability history should only be changed locally by the connection itself.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
