### PR TITLE
Stop self repair if transaction's processing failed

### DIFF
--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -276,7 +276,7 @@ defmodule Archethic.SelfRepair.Sync do
     Logger.info("Need to synchronize #{Enum.count(transaction_summaries)} transactions")
     Logger.debug("Transaction to sync #{inspect(transaction_summaries)}")
 
-    Task.Supervisor.async_stream_nolink(
+    Task.Supervisor.async_stream(
       TaskSupervisor,
       transaction_summaries,
       &TransactionHandler.download_transaction(&1, node_patch),


### PR DESCRIPTION
# Description

This change ensures the self-repair will be halted if the transaction processing is failing

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
