### PR TITLE
Fix bootstraping bugs

### DIFF
--- a/lib/archethic/account/mem_tables_loader.ex
+++ b/lib/archethic/account/mem_tables_loader.ex
@@ -41,7 +41,6 @@ defmodule Archethic.Account.MemTablesLoader do
   ]
 
   @excluded_types [
-    :node,
     :oracle,
     :oracle_summary,
     :node_shared_secrets,

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -95,21 +95,13 @@ defmodule Archethic.P2P do
   Add a node first public key to the list of nodes globally synced.
   """
   @spec set_node_globally_synced(first_public_key :: Crypto.key()) :: :ok
-  def set_node_globally_synced(first_public_key) do
-    get_node_info!(first_public_key)
-    |> Node.synced()
-    |> MemTable.add_node()
-  end
+  defdelegate set_node_globally_synced(first_public_key), to: MemTable, as: :set_node_synced
 
   @doc """
   Add a node first public key to the list of nodes globally unsynced.
   """
   @spec set_node_globally_unsynced(first_public_key :: Crypto.key()) :: :ok
-  def set_node_globally_unsynced(first_public_key) do
-    get_node_info!(first_public_key)
-    |> Node.unsynced()
-    |> MemTable.add_node()
-  end
+  defdelegate set_node_globally_unsynced(first_public_key), to: MemTable, as: :set_node_unsynced
 
   @doc """
   Set the node's average availability

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -45,8 +45,9 @@ defmodule Archethic.P2P do
   Register a node and establish a connection with
   """
   @spec add_and_connect_node(Node.t()) :: :ok
-  def add_and_connect_node(node = %Node{}) do
+  def add_and_connect_node(node = %Node{first_public_key: first_public_key}) do
     :ok = MemTable.add_node(node)
+    node = get_node_info!(first_public_key)
     do_connect_node(node)
   end
 

--- a/lib/archethic/p2p/mem_table.ex
+++ b/lib/archethic/p2p/mem_table.ex
@@ -736,6 +736,59 @@ defmodule Archethic.P2P.MemTable do
   end
 
   @doc """
+  Mark the node synced
+
+  ## Examples
+
+      iex> MemTable.start_link()
+      iex> node = %Node{
+      ...>   ip: {127, 0, 0, 1},
+      ...>   port: 3000,
+      ...>   http_port: 4000,
+      ...>   first_public_key: "key1",
+      ...>   last_public_key: "key2"
+      ...> }
+      iex> MemTable.add_node(node)
+      iex> :ok = MemTable.set_node_synced("key1")
+      iex> {:ok, %Node{synced?: true}} = MemTable.get_node("key1")
+  """
+  @spec set_node_synced(Crypto.key()) :: :ok
+  def set_node_synced(first_public_key) when is_binary(first_public_key) do
+    synced_pos = Keyword.fetch!(@discovery_index_position, :synced?)
+    :ets.update_element(@discovery_table, first_public_key, {synced_pos, true})
+    Logger.info("Node synced", node: Base.encode16(first_public_key))
+    notify_node_update(first_public_key)
+    :ok
+  end
+
+  @doc """
+  Mark the node unsynced
+
+  ## Examples
+
+      iex> MemTable.start_link()
+      iex> node = %Node{
+      ...>   ip: {127, 0, 0, 1},
+      ...>   port: 3000,
+      ...>   http_port: 4000,
+      ...>   first_public_key: "key1",
+      ...>   last_public_key: "key2"
+      ...> }
+      iex> MemTable.add_node(node)
+      iex> :ok = MemTable.set_node_synced("key1")
+      iex> :ok = MemTable.set_node_unsynced("key1")
+      iex> {:ok, %Node{synced?: false}} = MemTable.get_node("key1")
+  """
+  @spec set_node_unsynced(Crypto.key()) :: :ok
+  def set_node_unsynced(first_public_key) when is_binary(first_public_key) do
+    synced_pos = Keyword.fetch!(@discovery_index_position, :synced?)
+    :ets.update_element(@discovery_table, first_public_key, {synced_pos, false})
+    Logger.info("Node unsynced", node: Base.encode16(first_public_key))
+    notify_node_update(first_public_key)
+    :ok
+  end
+
+  @doc """
   Set the node as available if previously flagged as offline
 
   ## Examples

--- a/lib/archethic/p2p/mem_table.ex
+++ b/lib/archethic/p2p/mem_table.ex
@@ -31,7 +31,8 @@ defmodule Archethic.P2P.MemTable do
     reward_address: 12,
     last_address: 13,
     origin_public_key: 14,
-    synced?: 15
+    synced?: 15,
+    last_update_date: 16
   ]
 
   @doc """
@@ -76,6 +77,7 @@ defmodule Archethic.P2P.MemTable do
       ...>   authorized?: true,
       ...>   authorization_date: ~U[2020-10-22 23:19:45.797109Z],
       ...>   enrollment_date: ~U[2020-10-22 23:19:45.797109Z],
+      ...>   last_update_date: ~U[2020-10-22 23:19:45.797109Z],
       ...>   transport: :tcp,
       ...>   reward_address: <<0, 163, 237, 233, 93, 14, 241, 241, 8, 144, 218, 105, 16, 138, 243, 223, 17, 182,
       ...>     87, 9, 7, 53, 146, 174, 125, 5, 244, 42, 35, 209, 142, 24, 164>>,
@@ -100,7 +102,7 @@ defmodule Archethic.P2P.MemTable do
           <<0, 165, 32, 187, 102, 112, 133, 38, 17, 232, 54, 228, 173, 254, 94, 179, 32, 173,
             88, 122, 234, 88, 139, 82, 26, 113, 42, 8, 183, 190, 163, 221, 112>>,
           <<0, 0, 172, 147, 188, 9, 66, 252, 112, 77, 143, 178, 233, 51, 125, 102, 244, 36, 232,
-            185, 38, 7, 238, 128, 41, 30, 192, 61, 223, 119, 62, 249, 39, 212>>, true
+            185, 38, 7, 238, 128, 41, 30, 192, 61, 223, 119, 62, 249, 39, 212>>, true, ~U[2020-10-22 23:19:45.797109Z]
         }],
         # Globally available nodes
         [{ "key1" }],
@@ -128,6 +130,7 @@ defmodule Archethic.P2P.MemTable do
       ...>   authorized?: true,
       ...>   authorization_date: ~U[2020-10-22 23:19:45.797109Z],
       ...>   enrollment_date: ~U[2020-10-22 23:19:45.797109Z],
+      ...>   last_update_date: ~U[2020-10-22 23:19:45.797109Z],
       ...>   transport: :tcp,
       ...>   reward_address: <<0, 163, 237, 233, 93, 14, 241, 241, 8, 144, 218, 105, 16, 138, 243, 223, 17, 182,
       ...>     87, 9, 7, 53, 146, 174, 125, 5, 244, 42, 35, 209, 142, 24, 164>>,
@@ -145,6 +148,7 @@ defmodule Archethic.P2P.MemTable do
       ...>   last_public_key: "key5",
       ...>   average_availability: 90,
       ...>   availability_history: <<1::1, 1::1>>,
+      ...>   last_update_date: ~U[2020-10-22 23:20:45.797109Z],
       ...>   synced?: false,
       ...>   transport: :sctp,
       ...>   reward_address: <<0, 163, 237, 233, 93, 14, 241, 241, 8, 144, 218, 105, 16, 138, 243, 223, 17, 182,
@@ -171,7 +175,8 @@ defmodule Archethic.P2P.MemTable do
         <<0, 165, 32, 187, 102, 112, 133, 38, 17, 232, 54, 228, 173, 254, 94, 179, 32, 173, 88, 122, 234, 88, 139, 82, 26, 113, 42, 8, 183, 190, 163, 221, 112>>,
         <<0, 0, 172, 147, 188, 9, 66, 252, 112, 77, 143, 178, 233, 51, 125, 102, 244, 36, 232,
           185, 38, 7, 238, 128, 41, 30, 192, 61, 223, 119, 62, 249, 39, 212>>,
-        false
+        false,
+        ~U[2020-10-22 23:20:45.797109Z]
       }]
   """
   @spec add_node(Node.t()) :: :ok
@@ -229,7 +234,8 @@ defmodule Archethic.P2P.MemTable do
          transport: transport,
          reward_address: reward_address,
          last_address: last_address,
-         origin_public_key: origin_public_key
+         origin_public_key: origin_public_key,
+         last_update_date: last_update_date
        }) do
     availability_history =
       if first_public_key == Crypto.first_node_public_key(),
@@ -240,7 +246,7 @@ defmodule Archethic.P2P.MemTable do
       @discovery_table,
       {first_public_key, last_public_key, ip, port, http_port, geo_patch, network_patch,
        average_availability, availability_history, enrollment_date, transport, reward_address,
-       last_address, origin_public_key, synced?}
+       last_address, origin_public_key, synced?, last_update_date}
     )
   end
 
@@ -258,18 +264,33 @@ defmodule Archethic.P2P.MemTable do
          transport: transport,
          reward_address: reward_address,
          last_address: last_address,
-         origin_public_key: origin_public_key
+         origin_public_key: origin_public_key,
+         last_update_date: timestamp
        }) do
     changes = [
       {Keyword.fetch!(@discovery_index_position, :last_public_key), last_public_key},
-      {Keyword.fetch!(@discovery_index_position, :ip), ip},
-      {Keyword.fetch!(@discovery_index_position, :port), port},
-      {Keyword.fetch!(@discovery_index_position, :http_port), http_port},
-      {Keyword.fetch!(@discovery_index_position, :transport), transport},
       {Keyword.fetch!(@discovery_index_position, :reward_address), reward_address},
       {Keyword.fetch!(@discovery_index_position, :last_address), last_address},
       {Keyword.fetch!(@discovery_index_position, :origin_public_key), origin_public_key}
     ]
+
+    # We change connection informations only if these infos are newer than the actual ones
+    timestamp_pos = Keyword.fetch!(@discovery_index_position, :last_update_date)
+    last_update_date = :ets.lookup_element(@discovery_table, first_public_key, timestamp_pos)
+
+    changes =
+      if DateTime.compare(timestamp, last_update_date) != :lt do
+        changes ++
+          [
+            {Keyword.fetch!(@discovery_index_position, :ip), ip},
+            {Keyword.fetch!(@discovery_index_position, :port), port},
+            {Keyword.fetch!(@discovery_index_position, :http_port), http_port},
+            {Keyword.fetch!(@discovery_index_position, :transport), transport},
+            {timestamp_pos, timestamp}
+          ]
+      else
+        changes
+      end
 
     changes =
       if geo_patch != nil do

--- a/lib/archethic/p2p/mem_table_loader.ex
+++ b/lib/archethic/p2p/mem_table_loader.ex
@@ -82,7 +82,7 @@ defmodule Archethic.P2P.MemTableLoader do
     node_key = Crypto.first_node_public_key()
 
     case previously_available do
-      # Ensure the only single node is globally available after a delayed bootstrap 
+      # Ensure the only single node is globally available after a delayed bootstrap
       [{^node_key, {_, avg_availability}}] ->
         P2P.set_node_globally_synced(node_key)
         P2P.set_node_globally_available(node_key)
@@ -137,7 +137,8 @@ defmodule Archethic.P2P.MemTableLoader do
         transport: transport,
         last_address: address,
         reward_address: reward_address,
-        origin_public_key: origin_public_key
+        origin_public_key: origin_public_key,
+        last_update_date: timestamp
       }
 
       node
@@ -156,13 +157,15 @@ defmodule Archethic.P2P.MemTableLoader do
           transport: transport,
           last_address: address,
           reward_address: reward_address,
-          origin_public_key: origin_public_key
+          origin_public_key: origin_public_key,
+          last_update_date: timestamp
       })
     end
 
     Logger.info("Node loaded into in memory p2p tables", node: Base.encode16(first_public_key))
 
     if first_public_key != Crypto.first_node_public_key() do
+      {:ok, %Node{ip: ip, port: port, transport: transport}} = MemTable.get_node(first_public_key)
       {:ok, _pid} = Client.new_connection(ip, port, transport, first_public_key)
       :ok
     else

--- a/lib/archethic/p2p/node.ex
+++ b/lib/archethic/p2p/node.ex
@@ -36,7 +36,7 @@ defmodule Archethic.P2P.Node do
     authorization_date: nil,
     transport: :tcp,
     origin_public_key: nil,
-    last_update_date: ~U[2008-10-31 00:00:00Z]
+    last_update_date: ~U[2019-07-14 00:00:00Z]
   ]
 
   @doc """

--- a/lib/archethic/p2p/node.ex
+++ b/lib/archethic/p2p/node.ex
@@ -35,7 +35,8 @@ defmodule Archethic.P2P.Node do
     authorized?: false,
     authorization_date: nil,
     transport: :tcp,
-    origin_public_key: nil
+    origin_public_key: nil,
+    last_update_date: ~U[2008-10-31 00:00:00Z]
   ]
 
   @doc """
@@ -180,7 +181,8 @@ defmodule Archethic.P2P.Node do
           authorized?: boolean(),
           enrollment_date: nil | DateTime.t(),
           authorization_date: nil | DateTime.t(),
-          transport: P2P.supported_transport()
+          transport: P2P.supported_transport(),
+          last_update_date: DateTime.t()
         }
 
   @doc """
@@ -190,7 +192,7 @@ defmodule Archethic.P2P.Node do
   def cast(
         {first_public_key, last_public_key, ip, port, http_port, geo_patch, network_patch,
          average_availability, availability_history, enrollment_date, transport, reward_address,
-         last_address, origin_public_key, synced?}
+         last_address, origin_public_key, synced?, last_update_date}
       ) do
     %__MODULE__{
       ip: ip,
@@ -207,7 +209,8 @@ defmodule Archethic.P2P.Node do
       transport: transport,
       reward_address: reward_address,
       last_address: last_address,
-      origin_public_key: origin_public_key
+      origin_public_key: origin_public_key,
+      last_update_date: last_update_date
     }
   end
 
@@ -371,6 +374,7 @@ defmodule Archethic.P2P.Node do
       ...>   average_availability: 0.8,
       ...>   enrollment_date: ~U[2020-06-26 08:36:11Z],
       ...>   authorization_date: ~U[2020-06-26 08:36:11Z],
+      ...>   last_update_date: ~U[2020-06-26 08:36:11Z],
       ...>   authorized?: true,
       ...>   reward_address: <<0, 0, 163, 237, 233, 93, 14, 241, 241, 8, 144, 218, 105, 16, 138, 243, 223, 17, 182,
       ...>    87, 9, 7, 53, 146, 174, 125, 5, 244, 42, 35, 209, 142, 24, 164>>,
@@ -418,7 +422,9 @@ defmodule Archethic.P2P.Node do
       88, 122, 234, 88, 139, 82, 26, 113, 42, 8, 183, 190, 163, 221, 112,
       # Origin public key
       0, 0, 130, 83, 96, 217, 99, 234, 242, 235, 175, 236, 109, 166, 95, 250, 255, 90,
-      210, 227, 150, 117, 26, 64, 143, 55, 199, 95, 222, 35, 137, 221, 196, 169
+      210, 227, 150, 117, 26, 64, 143, 55, 199, 95, 222, 35, 137, 221, 196, 169,
+      # Last update date
+      94, 245, 179, 123
       >>
   """
   @spec serialize(__MODULE__.t()) :: bitstring()
@@ -439,7 +445,8 @@ defmodule Archethic.P2P.Node do
         authorization_date: authorization_date,
         reward_address: reward_address,
         last_address: last_address,
-        origin_public_key: origin_public_key
+        origin_public_key: origin_public_key,
+        last_update_date: last_update_date
       }) do
     ip_bin = <<o1, o2, o3, o4>>
     available_bin = if available?, do: 1, else: 0
@@ -455,7 +462,8 @@ defmodule Archethic.P2P.Node do
       geo_patch::binary-size(3), network_patch::binary-size(3), avg_bin::8,
       DateTime.to_unix(enrollment_date)::32, available_bin::1, synced_bin::1, authorized_bin::1,
       authorization_date::32, first_public_key::binary, last_public_key::binary,
-      reward_address::binary, last_address::binary, origin_public_key::binary>>
+      reward_address::binary, last_address::binary, origin_public_key::binary,
+      DateTime.to_unix(last_update_date)::32>>
   end
 
   defp serialize_transport(MockTransport), do: 0
@@ -479,8 +487,8 @@ defmodule Archethic.P2P.Node do
       ...> 0, 0, 165, 32, 187, 102, 112, 133, 38, 17, 232, 54, 228, 173, 254, 94, 179, 32, 173,
       ...> 88, 122, 234, 88, 139, 82, 26, 113, 42, 8, 183, 190, 163, 221, 112,
       ...> 0, 0, 130, 83, 96, 217, 99, 234, 242, 235, 175, 236, 109, 166, 95, 250, 255, 90,
-      ...> 210, 227, 150, 117, 26, 64, 143, 55, 199, 95, 222, 35, 137, 221, 196, 169
-      ...> >>)
+      ...> 210, 227, 150, 117, 26, 64, 143, 55, 199, 95, 222, 35, 137, 221, 196, 169,
+      ...> 94, 245, 179, 123 >>)
       {
         %Node{
             first_public_key: <<0, 0, 182, 67, 168, 252, 227, 203, 142, 164, 142, 248, 159, 209, 249, 247, 86, 64,
@@ -498,6 +506,7 @@ defmodule Archethic.P2P.Node do
             average_availability: 0.8,
             enrollment_date: ~U[2020-06-26 08:36:11Z],
             authorization_date: ~U[2020-06-26 08:36:11Z],
+            last_update_date: ~U[2020-06-26 08:36:11Z],
             authorized?: true,
             reward_address: <<0, 0, 163, 237, 233, 93, 14, 241, 241, 8, 144, 218, 105, 16, 138, 243, 223, 17, 182,
               87, 9, 7, 53, 146, 174, 125, 5, 244, 42, 35, 209, 142, 24, 164>>,
@@ -528,7 +537,9 @@ defmodule Archethic.P2P.Node do
     {last_public_key, rest} = Utils.deserialize_public_key(rest)
     {reward_address, rest} = Utils.deserialize_address(rest)
     {last_address, rest} = Utils.deserialize_address(rest)
-    {origin_public_key, rest} = Utils.deserialize_public_key(rest)
+
+    {origin_public_key, <<last_update_date::32, rest::bitstring>>} =
+      Utils.deserialize_public_key(rest)
 
     {
       %__MODULE__{
@@ -548,7 +559,8 @@ defmodule Archethic.P2P.Node do
         last_public_key: last_public_key,
         reward_address: reward_address,
         last_address: last_address,
-        origin_public_key: origin_public_key
+        origin_public_key: origin_public_key,
+        last_update_date: DateTime.from_unix!(last_update_date)
       },
       rest
     }

--- a/lib/archethic/replication/transaction_validator.ex
+++ b/lib/archethic/replication/transaction_validator.ex
@@ -53,23 +53,28 @@ defmodule Archethic.Replication.TransactionValidator do
   @spec validate(
           validated_transaction :: Transaction.t(),
           previous_transaction :: Transaction.t() | nil,
-          inputs_outputs :: list(TransactionInput.t())
+          inputs_outputs :: list(TransactionInput.t()),
+          self_repair? :: boolean()
         ) ::
           :ok | {:error, error()}
   def validate(
         tx = %Transaction{},
         previous_transaction,
-        inputs
+        inputs,
+        self_repair?
       ) do
-    with :ok <- valid_transaction(tx, inputs, true),
-         :ok <- validate_inheritance(tx, previous_transaction) do
+    with :ok <- valid_transaction(tx, inputs, true, self_repair?),
+         :ok <- validate_inheritance(tx, previous_transaction, self_repair?) do
       validate_chain(tx, previous_transaction)
     end
   end
 
+  defp validate_inheritance(_, _, true), do: :ok
+
   defp validate_inheritance(
          tx = %Transaction{validation_stamp: %ValidationStamp{timestamp: timestamp}},
-         prev_tx
+         prev_tx,
+         false
        ) do
     if Contracts.accept_new_contract?(prev_tx, tx, timestamp) do
       :ok
@@ -91,10 +96,11 @@ defmodule Archethic.Replication.TransactionValidator do
 
   This function called by the replication nodes which are involved in the chain storage
   """
-  @spec validate(Transaction.t()) :: :ok | {:error, error()}
-  def validate(tx = %Transaction{}), do: valid_transaction(tx, [], false)
+  @spec validate(Transaction.t(), boolean()) :: :ok | {:error, error()}
+  def validate(tx = %Transaction{}, self_repair? \\ false),
+    do: valid_transaction(tx, [], false, self_repair?)
 
-  defp valid_transaction(tx = %Transaction{}, inputs, chain_node?) when is_list(inputs) do
+  defp valid_transaction(tx = %Transaction{}, inputs, chain_node?, false) when is_list(inputs) do
     with :ok <- validate_consensus(tx),
          :ok <- validate_validation_stamp(tx) do
       if chain_node? do
@@ -102,6 +108,18 @@ defmodule Archethic.Replication.TransactionValidator do
       else
         :ok
       end
+    else
+      {:error, _} = e ->
+        # TODO: start malicious detection
+        e
+    end
+  end
+
+  defp valid_transaction(tx = %Transaction{}, _, _, true) do
+    with :ok <- validate_consensus(tx),
+         :ok <- validate_node_election(tx),
+         :ok <- validate_no_additional_error(tx) do
+      :ok
     else
       {:error, _} = e ->
         # TODO: start malicious detection

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -108,7 +108,7 @@ defmodule Archethic.SelfRepair.Sync do
   def load_missed_transactions(last_sync_date = %DateTime{}, patch) when is_binary(patch) do
     last_summary_time = BeaconChain.previous_summary_time(DateTime.utc_now())
 
-    if last_summary_time > last_sync_date do
+    if DateTime.compare(last_summary_time, last_sync_date) == :gt do
       Logger.info(
         "Fetch missed transactions from last sync date: #{DateTime.to_string(last_sync_date)}"
       )

--- a/lib/archethic/self_repair/sync/transaction_handler.ex
+++ b/lib/archethic/self_repair/sync/transaction_handler.ex
@@ -103,10 +103,10 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandler do
 
     cond do
       Election.chain_storage_node?(address, type, Crypto.first_node_public_key(), node_list) ->
-        Replication.validate_and_store_transaction_chain(tx)
+        Replication.validate_and_store_transaction_chain(tx, true)
 
       Election.io_storage_node?(tx, Crypto.first_node_public_key(), node_list) ->
-        Replication.validate_and_store_transaction(tx)
+        Replication.validate_and_store_transaction(tx, true)
 
       true ->
         :ok

--- a/lib/archethic/transaction_chain/mem_tables_loader.ex
+++ b/lib/archethic/transaction_chain/mem_tables_loader.ex
@@ -18,7 +18,8 @@ defmodule Archethic.TransactionChain.MemTablesLoader do
     :address,
     :type,
     :previous_public_key,
-    data: [:code]
+    data: [:code],
+    validation_stamp: [:timestamp]
   ]
 
   @excluded_types [

--- a/lib/archethic_web/controllers/api/schema/ownership.ex
+++ b/lib/archethic_web/controllers/api/schema/ownership.ex
@@ -15,8 +15,8 @@ defmodule ArchethicWeb.API.Schema.Ownership do
   def changeset(changeset = %__MODULE__{}, params = %{}) do
     changeset
     |> cast(params, [:secret])
-    |> cast_embed(:authorizedKeys)
-    |> validate_required([:secret, :authorizedKeys])
+    |> cast_embed(:authorizedKeys, required: [:publicKey, :encryptedSecretKey])
+    |> validate_required([:secret])
     |> validate_length(:authorizedKeys,
       max: 256,
       message: "maximum number of authorized keys can be 256"

--- a/test/archethic/replication/transaction_validator_test.exs
+++ b/test/archethic/replication/transaction_validator_test.exs
@@ -78,31 +78,31 @@ defmodule Archethic.Replication.TransactionValidatorTest do
 
       assert {:error, :invalid_atomic_commitment} =
                TransactionFactory.create_transaction_with_not_atomic_commitment(unspent_outputs)
-               |> TransactionValidator.validate()
+               |> TransactionValidator.validate(false)
     end
 
     test "should return {:error, :invalid_proof_of_work} when an invalid proof of work" do
       assert {:error, :invalid_proof_of_work} =
                TransactionFactory.create_transaction_with_invalid_proof_of_work()
-               |> TransactionValidator.validate()
+               |> TransactionValidator.validate(false)
     end
 
     test "should return {:error, :invalid_node_election} when the validation stamp signature is invalid" do
       assert {:error, :invalid_node_election} =
                TransactionFactory.create_transaction_with_invalid_validation_stamp_signature()
-               |> TransactionValidator.validate()
+               |> TransactionValidator.validate(false)
     end
 
     test "should return {:error, :invalid_transaction_fee} when the fees are invalid" do
       assert {:error, :invalid_transaction_fee} =
                TransactionFactory.create_transaction_with_invalid_fee()
-               |> TransactionValidator.validate()
+               |> TransactionValidator.validate(false)
     end
 
     test "should return {:error, :invalid_transaction_movements} when the transaction movements are invalid" do
       assert {:error, :invalid_transaction_movements} =
                TransactionFactory.create_transaction_with_invalid_transaction_movements()
-               |> TransactionValidator.validate()
+               |> TransactionValidator.validate(false)
     end
 
     test "should return {:error, :invalid_transaction_with_inconsistencies} when there is an atomic commitment but with inconsistencies" do
@@ -117,7 +117,7 @@ defmodule Archethic.Replication.TransactionValidatorTest do
 
       assert {:error, :invalid_transaction_with_inconsistencies} =
                TransactionFactory.create_valid_transaction_with_inconsistencies(unspent_outputs)
-               |> TransactionValidator.validate()
+               |> TransactionValidator.validate(false)
     end
 
     test "should return :ok when the transaction is valid" do
@@ -132,7 +132,7 @@ defmodule Archethic.Replication.TransactionValidatorTest do
 
       assert :ok =
                TransactionFactory.create_valid_transaction(unspent_outputs)
-               |> TransactionValidator.validate()
+               |> TransactionValidator.validate(false)
     end
   end
 
@@ -149,7 +149,7 @@ defmodule Archethic.Replication.TransactionValidatorTest do
 
       assert :ok =
                TransactionFactory.create_valid_transaction(unspent_outputs)
-               |> TransactionValidator.validate(nil, unspent_outputs)
+               |> TransactionValidator.validate(nil, unspent_outputs, false)
     end
   end
 end


### PR DESCRIPTION
# Description

Fixes multiple bugs: 
- Node transaction was not added in account mem table loader, causing error in replication when retrieving unspent outputs.
- Time condition to start self repair was not well handled, causing self repair to not start when it should.
- If a node has changed it's IP after some times, new nodes should always connect to the latest IP available even if they didn't synchronize all the node transactions
- Improve of synced? flag update
- Fix Ecto warning
- Fix error `DateTime.to_unix(nil, :second)` while loading transaction with code

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
