### PR TITLE
Handle ipv6 local ip in node settings page

### DIFF
--- a/lib/archethic_web/live/settings_live.ex
+++ b/lib/archethic_web/live/settings_live.ex
@@ -23,11 +23,18 @@ defmodule ArchethicWeb.SettingsLive do
 
   def mount(_params, %{"remote_ip" => remote_ip}, socket) do
     # Only authorized the page in the node's private network
-    private_ip? =
-      Regex.match?(
-        @ip_validate_regex,
-        :inet.ntoa(remote_ip) |> to_string()
-      )
+    ip =
+      case remote_ip do
+        {_, _, _, _} ->
+          :inet.ntoa(remote_ip) |> to_string()
+
+        _ ->
+          :inet.ipv4_mapped_ipv6_address(remote_ip)
+          |> :inet.ntoa()
+          |> to_string()
+      end
+
+    private_ip? = Regex.match?(@ip_validate_regex, ip)
 
     new_socket =
       socket


### PR DESCRIPTION
# Description

Node settings page on explorer is only available on local network. The filter to verify if client ip is local do not handle ipv6 address.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
