### PR TITLE
Add lower timeout for replication error notification

### DIFF
--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -191,7 +191,7 @@ defmodule Archethic.Mining do
   """
   @spec notify_replication_error(binary(), any()) :: :ok
   def notify_replication_error(tx_address, error_reason) do
-    pid = get_mining_process!(tx_address)
+    pid = get_mining_process!(tx_address, 1_000)
     if pid, do: send(pid, {:replication_error, error_reason})
     :ok
   end


### PR DESCRIPTION
# Description

When a validation node has a replication error, the distributed workflow process is ended. But other replication node may send a `ReplicationError` message to this validation node. The validation node will search for the mining process and will return nil after 3 seconds. But the replication node will have a timeout on the response of the `ReplicationError` message.
To avoid it, the timeout to find the mining process is reduced to 1 second as the process should have been already started or closed after an error

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
