### PR TITLE
Add send timeout on connection

### DIFF
--- a/lib/archethic/p2p/client/transport/tcp_impl.ex
+++ b/lib/archethic/p2p/client/transport/tcp_impl.ex
@@ -3,7 +3,15 @@ defmodule Archethic.P2P.Client.Transport.TCPImpl do
 
   alias Archethic.P2P.Client.Transport
 
-  @options [:binary, packet: 4, active: :once, keepalive: true, reuseaddr: true]
+  @options [
+    :binary,
+    packet: 4,
+    active: :once,
+    keepalive: true,
+    reuseaddr: true,
+    send_timeout: 30_000,
+    send_timeout_close: true
+  ]
 
   @behaviour Transport
 


### PR DESCRIPTION
# Description

Add a `send_timeout` of 30 sec when opening tcp connection

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
