### PR TITLE
Use current node view for downloading while in self repair

### DIFF
--- a/lib/archethic/beacon_chain.ex
+++ b/lib/archethic/beacon_chain.ex
@@ -285,10 +285,10 @@ defmodule Archethic.BeaconChain do
        [ ]
   ```
   """
-  @spec fetch_and_aggregate_summaries(DateTime.t()) :: SummaryAggregate.t()
-  def fetch_and_aggregate_summaries(date = %DateTime{}) do
+  @spec fetch_and_aggregate_summaries(DateTime.t(), list(Node.t())) :: SummaryAggregate.t()
+  def fetch_and_aggregate_summaries(date = %DateTime{}, download_nodes) do
     authorized_nodes =
-      P2P.authorized_and_available_nodes()
+      download_nodes
       |> Enum.reject(&(&1.first_public_key == Crypto.first_node_public_key()))
 
     list_subsets()
@@ -380,13 +380,13 @@ defmodule Archethic.BeaconChain do
   @doc """
   Fetch a summaries aggregate for a given date
   """
-  @spec fetch_summaries_aggregate(DateTime.t()) ::
+  @spec fetch_summaries_aggregate(DateTime.t(), list(Node.t())) ::
           {:ok, SummaryAggregate.t()} | {:error, :not_exists} | {:error, :network_issue}
-  def fetch_summaries_aggregate(summary_time = %DateTime{}) do
+  def fetch_summaries_aggregate(summary_time = %DateTime{}, download_nodes) do
     storage_nodes =
       summary_time
       |> Crypto.derive_beacon_aggregate_address()
-      |> Election.chain_storage_nodes(P2P.authorized_and_available_nodes())
+      |> Election.chain_storage_nodes(download_nodes)
 
     conflict_resolver = fn results ->
       # Prioritize results over not found

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -61,7 +61,8 @@ defmodule Archethic.Replication do
           type: type,
           validation_stamp: %ValidationStamp{timestamp: timestamp}
         },
-        self_repair? \\ false
+        self_repair? \\ false,
+        download_nodes \\ P2P.authorized_and_available_nodes()
       ) do
     if TransactionChain.transaction_exists?(address) do
       Logger.warning("Transaction already exists",
@@ -83,7 +84,7 @@ defmodule Archethic.Replication do
         transaction_type: type
       )
 
-      {previous_tx, inputs} = fetch_context(tx, self_repair?)
+      {previous_tx, inputs} = fetch_context(tx, self_repair?, download_nodes)
 
       # Validate the transaction and check integrity from the previous transaction
       case TransactionValidator.validate(
@@ -103,7 +104,7 @@ defmodule Archethic.Replication do
 
           # Stream the insertion of the chain
           tx
-          |> stream_previous_chain()
+          |> stream_previous_chain(download_nodes)
           |> Stream.reject(&Enum.empty?/1)
           |> Stream.each(&TransactionChain.write/1)
           |> Stream.run()
@@ -207,15 +208,15 @@ defmodule Archethic.Replication do
     end
   end
 
-  defp fetch_context(tx = %Transaction{type: type}, self_repair?) do
+  defp fetch_context(tx = %Transaction{type: type}, self_repair?, download_nodes) do
     if Transaction.network_type?(type) do
-      fetch_context_for_network_transaction(tx, self_repair?)
+      fetch_context_for_network_transaction(tx, self_repair?, download_nodes)
     else
-      fetch_context_for_regular_transaction(tx, self_repair?)
+      fetch_context_for_regular_transaction(tx, self_repair?, download_nodes)
     end
   end
 
-  defp fetch_context_for_network_transaction(tx = %Transaction{}, self_repair?) do
+  defp fetch_context_for_network_transaction(tx = %Transaction{}, self_repair?, download_nodes) do
     previous_address = Transaction.previous_address(tx)
 
     Logger.debug(
@@ -238,7 +239,7 @@ defmodule Archethic.Replication do
             transaction_type: tx.type
           )
 
-          TransactionContext.fetch_transaction(previous_address)
+          TransactionContext.fetch_transaction(previous_address, download_nodes)
       end
 
     Logger.debug("Previous transaction #{inspect(previous_transaction)}",
@@ -246,12 +247,12 @@ defmodule Archethic.Replication do
       transaction_type: tx.type
     )
 
-    inputs = if self_repair?, do: [], else: fetch_inputs(tx)
+    inputs = if self_repair?, do: [], else: fetch_inputs(tx, download_nodes)
 
     {previous_transaction, inputs}
   end
 
-  defp fetch_context_for_regular_transaction(tx = %Transaction{}, self_repair?) do
+  defp fetch_context_for_regular_transaction(tx = %Transaction{}, self_repair?, download_nodes) do
     previous_address = Transaction.previous_address(tx)
 
     t1 =
@@ -262,14 +263,14 @@ defmodule Archethic.Replication do
           transaction_type: tx.type
         )
 
-        TransactionContext.fetch_transaction(previous_address)
+        TransactionContext.fetch_transaction(previous_address, download_nodes)
       end)
 
     {previous_transaction, inputs} =
       if self_repair? do
         {Task.await(t1, Message.get_max_timeout()), []}
       else
-        t2 = Task.Supervisor.async(TaskSupervisor, fn -> fetch_inputs(tx) end)
+        t2 = Task.Supervisor.async(TaskSupervisor, fn -> fetch_inputs(tx, download_nodes) end)
         {Task.await(t1, Message.get_max_timeout()), Task.await(t2)}
       end
 
@@ -281,7 +282,10 @@ defmodule Archethic.Replication do
     {previous_transaction, inputs}
   end
 
-  defp fetch_inputs(tx = %Transaction{validation_stamp: %ValidationStamp{timestamp: tx_time}}) do
+  defp fetch_inputs(
+         tx = %Transaction{validation_stamp: %ValidationStamp{timestamp: tx_time}},
+         download_nodes
+       ) do
     previous_address = Transaction.previous_address(tx)
 
     Logger.debug(
@@ -291,7 +295,7 @@ defmodule Archethic.Replication do
     )
 
     previous_address
-    |> TransactionContext.fetch_transaction_inputs(tx_time)
+    |> TransactionContext.fetch_transaction_inputs(tx_time, download_nodes)
     |> tap(fn inputs ->
       Logger.debug("Got #{inspect(inputs)} for #{Base.encode16(previous_address)}",
         transaction_address: Base.encode16(tx.address),
@@ -300,17 +304,17 @@ defmodule Archethic.Replication do
     end)
   end
 
-  defp stream_previous_chain(tx = %Transaction{type: type}) do
+  defp stream_previous_chain(tx = %Transaction{type: type}, download_nodes) do
     previous_address = Transaction.previous_address(tx)
 
     if Transaction.network_type?(type) do
-      stream_network_tx_chain(tx)
+      stream_network_tx_chain(tx, download_nodes)
     else
-      TransactionContext.stream_transaction_chain(previous_address)
+      TransactionContext.stream_transaction_chain(previous_address, download_nodes)
     end
   end
 
-  defp stream_network_tx_chain(tx = %Transaction{}) do
+  defp stream_network_tx_chain(tx = %Transaction{}, download_nodes) do
     previous_address = Transaction.previous_address(tx)
 
     if TransactionChain.transaction_exists?(previous_address) do
@@ -322,7 +326,7 @@ defmodule Archethic.Replication do
         transaction_type: tx.type
       )
 
-      TransactionContext.stream_transaction_chain(previous_address)
+      TransactionContext.stream_transaction_chain(previous_address, download_nodes)
     end
   end
 

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -125,21 +125,25 @@ defmodule Archethic.SelfRepair.Sync do
   defp do_load_missed_transactions(last_sync_date, last_summary_time, patch) do
     start = System.monotonic_time()
 
-    summaries_aggregates = fetch_summaries_aggregates(last_sync_date, last_summary_time)
-    last_aggregate = BeaconChain.fetch_and_aggregate_summaries(last_summary_time)
+    download_nodes = P2P.authorized_and_available_nodes()
+
+    summaries_aggregates =
+      fetch_summaries_aggregates(last_sync_date, last_summary_time, download_nodes)
+
+    last_aggregate = BeaconChain.fetch_and_aggregate_summaries(last_summary_time, download_nodes)
     ensure_download_last_aggregate(last_aggregate)
 
     last_aggregate = aggregate_with_local_summaries(last_aggregate, last_summary_time)
 
     summaries_aggregates
     |> Stream.concat([last_aggregate])
-    |> Enum.each(&process_summary_aggregate(&1, patch))
+    |> Enum.each(&process_summary_aggregate(&1, patch, download_nodes))
 
     :telemetry.execute([:archethic, :self_repair], %{duration: System.monotonic_time() - start})
     Archethic.Bootstrap.NetworkConstraints.persist_genesis_address()
   end
 
-  defp fetch_summaries_aggregates(last_sync_date, last_summary_time) do
+  defp fetch_summaries_aggregates(last_sync_date, last_summary_time, download_nodes) do
     last_sync_date
     |> BeaconChain.next_summary_dates()
     # Take only the previous summaries before the last one
@@ -149,7 +153,7 @@ defmodule Archethic.SelfRepair.Sync do
     # Fetch the beacon summaries aggregate
     |> Task.async_stream(fn date ->
       Logger.debug("Fetch summary aggregate for #{date}")
-      BeaconChain.fetch_summaries_aggregate(date)
+      BeaconChain.fetch_summaries_aggregate(date, download_nodes)
     end)
     |> Stream.filter(fn
       {:ok, {:ok, %SummaryAggregate{}}} ->
@@ -221,14 +225,15 @@ defmodule Archethic.SelfRepair.Sync do
 
   At the end of the execution, the summaries aggregate will persisted locally if the node is member of the shard of the summary
   """
-  @spec process_summary_aggregate(SummaryAggregate.t(), binary()) :: :ok
+  @spec process_summary_aggregate(SummaryAggregate.t(), binary(), list(Node.t())) :: :ok
   def process_summary_aggregate(
         aggregate = %SummaryAggregate{
           summary_time: summary_time,
           transaction_summaries: transaction_summaries,
           p2p_availabilities: p2p_availabilities
         },
-        node_patch
+        node_patch,
+        download_nodes
       ) do
     start_time = System.monotonic_time()
 
@@ -237,7 +242,7 @@ defmodule Archethic.SelfRepair.Sync do
       |> Enum.reject(&TransactionChain.transaction_exists?(&1.address))
       |> Enum.filter(&TransactionHandler.download_transaction?/1)
 
-    synchronize_transactions(transactions_to_sync, node_patch)
+    synchronize_transactions(transactions_to_sync, node_patch, download_nodes)
 
     :telemetry.execute(
       [:archethic, :self_repair, :process_aggregate],
@@ -270,23 +275,23 @@ defmodule Archethic.SelfRepair.Sync do
     store_aggregate(aggregate)
   end
 
-  defp synchronize_transactions([], _node_patch), do: :ok
+  defp synchronize_transactions([], _node_patch, _), do: :ok
 
-  defp synchronize_transactions(transaction_summaries, node_patch) do
+  defp synchronize_transactions(transaction_summaries, node_patch, download_nodes) do
     Logger.info("Need to synchronize #{Enum.count(transaction_summaries)} transactions")
     Logger.debug("Transaction to sync #{inspect(transaction_summaries)}")
 
     Task.Supervisor.async_stream(
       TaskSupervisor,
       transaction_summaries,
-      &TransactionHandler.download_transaction(&1, node_patch),
+      &TransactionHandler.download_transaction(&1, node_patch, download_nodes),
       on_timeout: :kill_task,
       timeout: Message.get_max_timeout() + 2000,
       max_concurrency: 100
     )
     |> Stream.filter(&match?({:ok, _}, &1))
     |> Stream.each(fn {:ok, tx} ->
-      :ok = TransactionHandler.process_transaction(tx)
+      :ok = TransactionHandler.process_transaction(tx, download_nodes)
     end)
     |> Stream.run()
   end

--- a/lib/archethic/self_repair/sync/transaction_handler.ex
+++ b/lib/archethic/self_repair/sync/transaction_handler.ex
@@ -51,10 +51,12 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandler do
   @doc """
   Request the transaction for the closest storage nodes and replicate it locally.
   """
-  @spec download_transaction(TransactionSummary.t(), patch :: binary()) :: Transaction.t()
+  @spec download_transaction(TransactionSummary.t(), patch :: binary(), list(Node.t())) ::
+          Transaction.t()
   def download_transaction(
         %TransactionSummary{address: address, type: type, timestamp: _timestamp},
-        node_patch
+        node_patch,
+        download_nodes
       )
       when is_binary(node_patch) do
     Logger.info("Synchronize missed transaction",
@@ -64,7 +66,7 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandler do
 
     storage_nodes =
       address
-      |> Election.chain_storage_nodes_with_type(type, P2P.authorized_and_available_nodes())
+      |> Election.chain_storage_nodes_with_type(type, download_nodes)
       |> Enum.reject(&(&1.first_public_key == Crypto.first_node_public_key()))
       |> P2P.nearest_nodes()
       |> Enum.filter(&Node.locally_available?/1)
@@ -91,19 +93,20 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandler do
     end
   end
 
-  @spec process_transaction(Transaction.t()) :: :ok | {:error, :invalid_transaction}
+  @spec process_transaction(Transaction.t(), list(Node.t())) ::
+          :ok | {:error, :invalid_transaction}
   def process_transaction(
         tx = %Transaction{
           address: address,
           type: type
-        }
+        },
+        download_nodes
       ) do
-    node_list =
-      [P2P.get_node_info() | P2P.authorized_and_available_nodes()] |> P2P.distinct_nodes()
+    node_list = [P2P.get_node_info() | download_nodes] |> P2P.distinct_nodes()
 
     cond do
       Election.chain_storage_node?(address, type, Crypto.first_node_public_key(), node_list) ->
-        Replication.validate_and_store_transaction_chain(tx, true)
+        Replication.validate_and_store_transaction_chain(tx, true, download_nodes)
 
       Election.io_storage_node?(tx, Crypto.first_node_public_key(), node_list) ->
         Replication.validate_and_store_transaction(tx, true)

--- a/lib/archethic_web/live/chains/beacon_live.ex
+++ b/lib/archethic_web/live/chains/beacon_live.ex
@@ -225,7 +225,7 @@ defmodule ArchethicWeb.BeaconChainLive do
 
   defp list_transactions_from_summaries(date = %DateTime{}) do
     %SummaryAggregate{transaction_summaries: tx_summaries} =
-      BeaconChain.fetch_and_aggregate_summaries(date)
+      BeaconChain.fetch_and_aggregate_summaries(date, P2P.authorized_and_available_nodes())
 
     Enum.sort_by(tx_summaries, & &1.timestamp, {:desc, DateTime})
   end

--- a/test/archethic/beacon_chain_test.exs
+++ b/test/archethic/beacon_chain_test.exs
@@ -220,7 +220,10 @@ defmodule Archethic.BeaconChainTest do
       end)
 
       %SummaryAggregate{transaction_summaries: transaction_summaries} =
-        BeaconChain.fetch_and_aggregate_summaries(summary_time)
+        BeaconChain.fetch_and_aggregate_summaries(
+          summary_time,
+          P2P.authorized_and_available_nodes()
+        )
 
       assert [addr1] == Enum.map(transaction_summaries, & &1.address)
     end
@@ -314,7 +317,10 @@ defmodule Archethic.BeaconChainTest do
       end)
 
       %SummaryAggregate{transaction_summaries: transaction_summaries} =
-        BeaconChain.fetch_and_aggregate_summaries(summary_time)
+        BeaconChain.fetch_and_aggregate_summaries(
+          summary_time,
+          P2P.authorized_and_available_nodes()
+        )
 
       transaction_addresses = Enum.map(transaction_summaries, & &1.address)
 
@@ -400,7 +406,11 @@ defmodule Archethic.BeaconChainTest do
 
       assert %SummaryAggregate{
                p2p_availabilities: %{"A" => %{node_availabilities: node_availabilities}}
-             } = BeaconChain.fetch_and_aggregate_summaries(summary_time)
+             } =
+               BeaconChain.fetch_and_aggregate_summaries(
+                 summary_time,
+                 P2P.authorized_and_available_nodes()
+               )
 
       expected_availabilities =
         [summary_v1, summary_v2, summary_v3, summary_v4]
@@ -492,7 +502,11 @@ defmodule Archethic.BeaconChainTest do
                p2p_availabilities: %{
                  "A" => %{node_average_availabilities: node_average_availabilities}
                }
-             } = BeaconChain.fetch_and_aggregate_summaries(summary_time)
+             } =
+               BeaconChain.fetch_and_aggregate_summaries(
+                 summary_time,
+                 P2P.authorized_and_available_nodes()
+               )
 
       expected_average_availabilities =
         [summary_v1, summary_v2, summary_v3, summary_v4]

--- a/test/archethic/replication/transaction_context_test.exs
+++ b/test/archethic/replication/transaction_context_test.exs
@@ -47,7 +47,8 @@ defmodule Archethic.Replication.TransactionContextTest do
       authorization_date: DateTime.utc_now()
     })
 
-    assert %Transaction{} = TransactionContext.fetch_transaction("@Alice1")
+    assert %Transaction{} =
+             TransactionContext.fetch_transaction("@Alice1", P2P.authorized_and_available_nodes())
   end
 
   test "stream_transaction_chain/1 should retrieve the previous transaction chain" do
@@ -76,7 +77,10 @@ defmodule Archethic.Replication.TransactionContextTest do
     })
 
     assert 1 =
-             TransactionContext.stream_transaction_chain("@Alice1")
+             TransactionContext.stream_transaction_chain(
+               "@Alice1",
+               P2P.authorized_and_available_nodes()
+             )
              |> Enum.count()
   end
 
@@ -125,6 +129,10 @@ defmodule Archethic.Replication.TransactionContextTest do
     })
 
     assert [%TransactionInput{from: "@Bob3", amount: 19_300_000, type: :UCO}] =
-             TransactionContext.fetch_transaction_inputs("@Alice1", DateTime.utc_now())
+             TransactionContext.fetch_transaction_inputs(
+               "@Alice1",
+               DateTime.utc_now(),
+               P2P.authorized_and_available_nodes()
+             )
   end
 end

--- a/test/archethic/self_repair/sync/transaction_handler_test.exs
+++ b/test/archethic/self_repair/sync/transaction_handler_test.exs
@@ -122,7 +122,13 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
     end)
 
     tx_summary = %TransactionSummary{address: "@Alice2", timestamp: DateTime.utc_now()}
-    assert ^tx = TransactionHandler.download_transaction(tx_summary, "AAA")
+
+    assert ^tx =
+             TransactionHandler.download_transaction(
+               tx_summary,
+               "AAA",
+               P2P.authorized_and_available_nodes()
+             )
   end
 
   test "process_transaction/1 should handle the transaction and replicate it" do
@@ -173,7 +179,7 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
       :ok
     end)
 
-    assert :ok = TransactionHandler.process_transaction(tx)
+    assert :ok = TransactionHandler.process_transaction(tx, P2P.authorized_and_available_nodes())
 
     assert_received :transaction_replicated
   end

--- a/test/archethic/self_repair/sync_test.exs
+++ b/test/archethic/self_repair/sync_test.exs
@@ -351,7 +351,8 @@ defmodule Archethic.SelfRepair.SyncTest do
                      }
                    ]
                  },
-                 "AAA"
+                 "AAA",
+                 P2P.authorized_and_available_nodes()
                )
 
       assert_received :transaction_stored


### PR DESCRIPTION
# Description

When a node start for the first time, it has to download all the previous transaction by doing a bootstrap self repair.
Before doing it, the node get the last P2P view available to connect to all nodes.
But after synchronizing the first summary, the node update it's P2P view with it and so has only the first node as authorized and available, but this node may no longer be up. So the node may not be able to download transaction.

To solve this, we should use the latest P2P view to download the transaction in the self repair. We can pass the view in parameter for the self repair, and fetch the transaction using this view (all other controls for election are done on the current view of the node)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

launched a self repair on the actual mainnet while the bootstraping node is not available anymore

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
