### PR TITLE
Fix recursion of notify last address

### DIFF
--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -20,16 +20,14 @@ defmodule Archethic.Mining.StandaloneWorkflow do
   alias Archethic.Mining.WorkflowRegistry
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message.NotifyPreviousChain
   alias Archethic.P2P.Message.ReplicateTransaction
   alias Archethic.P2P.Message.ReplicateTransactionChain
   alias Archethic.P2P.Message.ValidationError
   alias Archethic.P2P.Node
 
-  alias Archethic.Replication
-
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
   alias Archethic.TransactionChain.TransactionSummary
 
@@ -331,26 +329,15 @@ defmodule Archethic.Mining.StandaloneWorkflow do
     )
   end
 
-  defp notify_previous_chain(%ValidationContext{
-         transaction: tx,
-         validation_stamp: %ValidationStamp{timestamp: tx_timestamp}
-       }) do
-    previous_address = Transaction.previous_address(tx)
-
-    genesis_address =
-      case TransactionChain.fetch_genesis_address_remotely(previous_address) do
-        {:ok, genesis_address} ->
-          genesis_address
-
-        _ ->
-          previous_address
-      end
-
-    Replication.acknowledge_previous_storage_nodes(
-      tx.address,
-      genesis_address,
-      previous_address,
-      tx_timestamp
-    )
+  defp notify_previous_chain(
+         context = %ValidationContext{
+           transaction: tx
+         }
+       ) do
+    unless Transaction.network_type?(tx.type) do
+      context
+      |> ValidationContext.get_confirmed_replication_nodes()
+      |> P2P.broadcast_message(%NotifyPreviousChain{address: tx.address})
+    end
   end
 end

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1224,6 +1224,19 @@ defmodule Archethic.Mining.ValidationContext do
   end
 
   @doc """
+  Return the list of nodes which confirmed the transaction replication
+  """
+  @spec get_confirmed_replication_nodes(t()) :: list(Node.t())
+  def get_confirmed_replication_nodes(%__MODULE__{
+        chain_storage_nodes: chain_storage_nodes,
+        storage_nodes_confirmations: storage_nodes_confirmations
+      }) do
+    Enum.map(storage_nodes_confirmations, fn {index, _} ->
+      Enum.at(chain_storage_nodes, index)
+    end)
+  end
+
+  @doc """
   Get the list of I/O replication nodes
   """
   @spec get_io_replication_nodes(t()) :: list(Node.t())

--- a/lib/archethic/p2p/message/notify_last_transaction_address.ex
+++ b/lib/archethic/p2p/message/notify_last_transaction_address.ex
@@ -2,15 +2,14 @@ defmodule Archethic.P2P.Message.NotifyLastTransactionAddress do
   @moduledoc """
   Represents a message with to notify a pool of the last address of a previous address
   """
-  @enforce_keys [:last_address, :genesis_address, :previous_address, :timestamp]
-  defstruct [:last_address, :genesis_address, :previous_address, :timestamp]
+  @enforce_keys [:last_address, :genesis_address, :timestamp]
+  defstruct [:last_address, :genesis_address, :timestamp]
 
   alias Archethic.Crypto
 
   @type t :: %__MODULE__{
           last_address: Crypto.versioned_hash(),
           genesis_address: Crypto.versioned_hash(),
-          previous_address: Crypto.versioned_hash(),
           timestamp: DateTime.t()
         }
 end

--- a/lib/archethic/p2p/message/notify_previous_chain.ex
+++ b/lib/archethic/p2p/message/notify_previous_chain.ex
@@ -1,0 +1,11 @@
+defmodule Archethic.P2P.Message.NotifyPreviousChain do
+  @moduledoc """
+  Represents a message used to notify previous chain storage nodes about the last transaction address
+  """
+
+  defstruct [:address]
+
+  @type t :: %__MODULE__{
+          address: binary()
+        }
+end

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -34,6 +34,7 @@ defmodule Archethic.P2P.MessageTest do
   alias Archethic.P2P.Message.NotFound
   alias Archethic.P2P.Message.NotifyEndOfNodeSync
   alias Archethic.P2P.Message.NotifyLastTransactionAddress
+  alias Archethic.P2P.Message.NotifyPreviousChain
   alias Archethic.P2P.Message.Ok
   alias Archethic.P2P.Message.P2PView
   alias Archethic.P2P.Message.Ping
@@ -862,8 +863,19 @@ defmodule Archethic.P2P.MessageTest do
       msg = %NotifyLastTransactionAddress{
         last_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
         genesis_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
-        previous_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
         timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+      }
+
+      assert msg ==
+               msg
+               |> Message.encode()
+               |> Message.decode()
+               |> elem(0)
+    end
+
+    test "NotifyPreviousChain message" do
+      msg = %NotifyPreviousChain{
+        address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
       }
 
       assert msg ==


### PR DESCRIPTION
# Description

Fix infinite recursion of last address notification.

Before, the notification was done by each storage nodes of each previous transactions as recursion.
Now, to avoid infinite loop and improve performances, the storage nodes of the transaction will trigger and elect the right unique nodes to be notified. (because they know all the transaction of the last chain)
 
## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
