### PR TITLE
Query P2P in order to determine if an input is spent later on

### DIFF
--- a/test/archethic_test.exs
+++ b/test/archethic_test.exs
@@ -232,12 +232,15 @@ defmodule ArchethicTest do
   end
 
   describe "get_transaction_inputs/1" do
-    test "should request the storages nodes to fetch the inputs remotely" do
+    @tag :toto1
+    test "should request the storages nodes to fetch the inputs remotely, this is latest tx" do
+      address1 = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
       P2P.add_and_connect_node(%Node{
         ip: {127, 0, 0, 1},
         port: 3000,
-        first_public_key: Crypto.last_node_public_key(),
-        last_public_key: Crypto.last_node_public_key(),
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
         network_patch: "AAA",
         geo_patch: "AAA"
       })
@@ -255,26 +258,157 @@ defmodule ArchethicTest do
       })
 
       MockClient
-      |> expect(:send_message, fn _, %GetTransactionInputs{}, _ ->
-        {:ok,
-         %TransactionInputList{
-           inputs: [
-             %VersionedTransactionInput{
-               input: %TransactionInput{
-                 from: "@Bob3",
-                 amount: 1_000_000_000,
-                 spent?: false,
-                 type: :UCO,
-                 timestamp: DateTime.utc_now()
-               },
-               protocol_version: 1
-             }
-           ]
-         }}
+      |> stub(:send_message, fn
+        _, %GetTransactionInputs{address: ^address1}, _ ->
+          {:ok,
+           %TransactionInputList{
+             inputs: [
+               %VersionedTransactionInput{
+                 input: %TransactionInput{
+                   from: "@Bob3",
+                   amount: 1_000_000_000,
+                   spent?: false,
+                   type: :UCO,
+                   timestamp: DateTime.utc_now()
+                 },
+                 protocol_version: 1
+               }
+             ]
+           }}
+
+        _, %GetLastTransactionAddress{address: ^address1}, _ ->
+          {:ok, %LastTransactionAddress{address: address1, timestamp: DateTime.utc_now()}}
       end)
 
       assert [%TransactionInput{from: "@Bob3", amount: 1_000_000_000, spent?: false, type: :UCO}] =
-               Archethic.get_transaction_inputs("@Alice2")
+               Archethic.get_transaction_inputs(address1)
+    end
+
+    test "should request the storages nodes to fetch the inputs remotely, inputs are spent in a later tx" do
+      address1 = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+      address1bis = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
+        network_patch: "AAA",
+        geo_patch: "AAA"
+      })
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: "key1",
+        last_public_key: "key1",
+        network_patch: "AAA",
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: true,
+        authorization_date: DateTime.utc_now()
+      })
+
+      MockClient
+      |> stub(:send_message, fn
+        _, %GetTransactionInputs{address: ^address1}, _ ->
+          {:ok,
+           %TransactionInputList{
+             inputs: [
+               %VersionedTransactionInput{
+                 input: %TransactionInput{
+                   from: "@Bob3",
+                   amount: 1_000_000_000,
+                   spent?: false,
+                   type: :UCO,
+                   timestamp: DateTime.utc_now()
+                 },
+                 protocol_version: 1
+               }
+             ]
+           }}
+
+        _, %GetTransactionInputs{address: ^address1bis}, _ ->
+          {:ok,
+           %TransactionInputList{
+             inputs: []
+           }}
+
+        _, %GetLastTransactionAddress{address: ^address1}, _ ->
+          {:ok, %LastTransactionAddress{address: address1bis, timestamp: DateTime.utc_now()}}
+      end)
+
+      assert [%TransactionInput{from: "@Bob3", amount: 1_000_000_000, spent?: true, type: :UCO}] =
+               Archethic.get_transaction_inputs(address1)
+    end
+
+    test "should request the storages nodes to fetch the inputs remotely, inputs are not spent in a later tx" do
+      address1 = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+      address1bis = Crypto.derive_address(address1)
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
+        network_patch: "AAA",
+        geo_patch: "AAA"
+      })
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: "key1",
+        last_public_key: "key1",
+        network_patch: "AAA",
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: true,
+        authorization_date: DateTime.utc_now()
+      })
+
+      MockClient
+      |> stub(:send_message, fn
+        _, %GetTransactionInputs{address: ^address1}, _ ->
+          {:ok,
+           %TransactionInputList{
+             inputs: [
+               %VersionedTransactionInput{
+                 input: %TransactionInput{
+                   from: "@Bob3",
+                   amount: 1_000_000_000,
+                   spent?: false,
+                   type: :UCO,
+                   timestamp: DateTime.utc_now()
+                 },
+                 protocol_version: 1
+               }
+             ]
+           }}
+
+        _, %GetTransactionInputs{address: ^address1bis}, _ ->
+          {:ok,
+           %TransactionInputList{
+             inputs: [
+               %VersionedTransactionInput{
+                 input: %TransactionInput{
+                   from: "@Bob3",
+                   amount: 1_000_000_000,
+                   spent?: false,
+                   type: :UCO,
+                   timestamp: DateTime.utc_now()
+                 },
+                 protocol_version: 1
+               }
+             ]
+           }}
+
+        _, %GetLastTransactionAddress{address: ^address1}, _ ->
+          {:ok, %LastTransactionAddress{address: address1bis, timestamp: DateTime.utc_now()}}
+      end)
+
+      assert [%TransactionInput{from: "@Bob3", amount: 1_000_000_000, spent?: false, type: :UCO}] =
+               Archethic.get_transaction_inputs(address1)
     end
   end
 


### PR DESCRIPTION
# Description

When retrieving the inputs of an address, we compare them to the inputs of the latest transaction of the address. 
If an input has a match (the same `(token, from)`) in the last transaction, that input is unspent. If there is no match for an input, it means it has been spent.

Fixes #627

## Type of change

- Bug fix

# How Has This Been Tested?

This has been tested via integration tests and with the following scenario on the explorer: 

1. Bastien creates a CC token
2. Bastien creates a DD token
![Screenshot_2022-11-16_14-21-38](https://user-images.githubusercontent.com/74045243/202194239-8cf0606f-7ffe-4c10-b03d-89822a213fb2.png)
3. Bastien transfers some DD token to Hamza
![Screenshot_2022-11-16_14-21-49](https://user-images.githubusercontent.com/74045243/202194516-dcc7df81-849f-40ac-a40b-aa580117afa6.png)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
