### PR TITLE
Add default `code_change/4` in GenStateMachine

### DIFF
--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -935,6 +935,8 @@ defmodule Archethic.Mining.DistributedWorkflow do
     {:keep_state_and_data, :postpone}
   end
 
+  def code_change(_old_vsn, state, data, _extra), do: {:ok, state, data}
+
   defp notify_transaction_context(
          %ValidationContext{
            transaction: %Transaction{address: tx_address, type: tx_type},

--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -781,4 +781,6 @@ defmodule Archethic.OracleChain.Scheduler do
     |> get_oracle_data()
     |> Services.fetch_new_data()
   end
+
+  def code_change(_old_vsn, state, data, _extra), do: {:ok, state, data}
 end

--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -443,4 +443,6 @@ defmodule Archethic.P2P.Client.Connection do
         end
     end
   end
+
+  def code_change(_old_vsn, state, data, _extra), do: {:ok, state, data}
 end

--- a/lib/archethic/reward/scheduler.ex
+++ b/lib/archethic/reward/scheduler.ex
@@ -421,4 +421,6 @@ defmodule Archethic.Reward.Scheduler do
   def config_change(conf) do
     GenStateMachine.cast(__MODULE__, {:new_conf, conf})
   end
+
+  def code_change(_old_vsn, state, data, _extra), do: {:ok, state, data}
 end

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -341,4 +341,6 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
     Application.get_env(:archethic, __MODULE__)
     |> Keyword.fetch!(:application_interval)
   end
+
+  def code_change(_old_vsn, state, data, _extra), do: {:ok, state, data}
 end


### PR DESCRIPTION
# Description

During hot upgrades, GenServer handle default code_change,
however, GenStateMachine does not.

Hence, we have to add a default one to make the upgrade successful

## Type of change

Please delete options that are not relevant.

- Enhancement

# How Has This Been Tested?

Using this script: `local_release.sh`

```sh
#!/bin/bash

UPGRADE=0
usage() {
  echo "Usage:"
  echo ""
  echo " Release Archethic node binary"
  echo ""
  echo "  " local_release.sh" Install the release"
  echo "  " local_release.sh -u "       Upgrade the release"
  echo ""
}

while getopts :suhd: option
do
    case "${option}"
    in
        u) UPGRADE=1;;
        h)
          usage
          exit 0
          ;;
        *)
          usage
          exit 1
          ;;
    esac
done
shift $((OPTIND -1))

VERSION=$(grep 'version:' mix.exs | cut -d '"' -f2)

if [ $UPGRADE == 1 ]
then
    mix distillery.release --upgrade
    echo "Copy upgraded release into ../archethic-release/releases/${VERSION}"
    mkdir -p ../archethic-release/releases/$VERSION
    cp _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz ../archethic-release/releases/$VERSION/archethic_node.tar.gz

    echo "Run the upgrade"
    ../archethic-release/bin/archethic_node upgrade $VERSION
else
    mix distillery.release
    mkdir -p ../archethic-release
    tar zxvf _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz -C ../archethic-release
    echo "Release has been installed on ../archethic-release"
fi
```

Then create the first release: 
```bash
./local_release.sh
```

Then start the node
```bash
../archethic-release/bin/archethic-node console
```

Change the mix version
And run the upgrade
```bash
./local_release.sh -u
```

It should have error about the release handler

Without this fix, you will end up with some error like: `{:code_change_failed, _module, _, :undefined}`

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
