### PR TITLE
:bug: add quorum for requesting balance

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -138,17 +138,28 @@ defmodule Archethic do
     |> get_balance(address)
   end
 
-  defp get_balance([node | rest], address) do
-    case P2P.send_message(node, %GetBalance{address: address}) do
-      {:ok, %Balance{uco: uco, token: token}} ->
-        {:ok, %{uco: uco, token: token}}
+  defp get_balance(nodes, address) do
+    conflict_resolver = fn balances ->
+      {max_uco, max_token} =
+        balances
+        |> Enum.reduce({0, %{}}, fn
+          %Balance{uco: uco, token: token}, {uco_acc, token_acc} ->
+            token_merger = fn _k, v1, v2 -> max(v1, v2) end
 
-      {:error, _} ->
-        get_balance(rest, address)
+            maximum_token = Map.merge(token, token_acc, token_merger)
+            maximum_uco = max(uco, uco_acc)
+
+            {maximum_uco, maximum_token}
+        end)
+
+      %{uco: max_uco, token: max_token}
+    end
+
+    case P2P.quorum_read(nodes, %GetBalance{address: address}, conflict_resolver) do
+      {:ok, %Balance{uco: uco, token: token}} -> {:ok, %{uco: uco, token: token}}
+      error -> error
     end
   end
-
-  defp get_balance([], _), do: {:error, :network_issue}
 
   @doc """
   Request to fetch the inputs for a transaction address from the closest nodes

--- a/test/archethic_test.exs
+++ b/test/archethic_test.exs
@@ -222,12 +222,49 @@ defmodule ArchethicTest do
         authorization_date: DateTime.utc_now()
       })
 
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: "key2",
+        last_public_key: "key2",
+        network_patch: "AAA",
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: true,
+        authorization_date: DateTime.utc_now()
+      })
+
       MockClient
-      |> expect(:send_message, fn _, %GetBalance{}, _ ->
-        {:ok, %Balance{uco: 1_000_000_000}}
+      |> expect(:send_message, 1, fn
+        _, %GetBalance{}, _ ->
+          {:ok,
+           %Balance{
+             uco: 1_000_000_000,
+             token: %{
+               {"ETH", 1} => 1
+             }
+           }}
+      end)
+      |> expect(:send_message, 1, fn
+        _, %GetBalance{}, _ ->
+          {:ok,
+           %Balance{
+             uco: 2_000_000_000,
+             token: %{
+               {"BTC", 2} => 1,
+               {"ETH", 1} => 2
+             }
+           }}
       end)
 
-      assert {:ok, %{uco: 1_000_000_000}} = Archethic.get_balance("@Alice2")
+      assert {:ok,
+              %{
+                uco: 2_000_000_000,
+                token: %{
+                  {"ETH", 1} => 2,
+                  {"BTC", 2} => 1
+                }
+              }} = Archethic.get_balance("@Alice2")
     end
   end
 


### PR DESCRIPTION
# Description

When requesting balance we used to get the value from the first node, we need to do a quorum call and use the max value form the balance.

Fixes #692 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This is tested in get_balance/1 tests in test/archethic_test.exs, I modified the tests to have multiple nodes with multiple balance values and different tokens with different values.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
