### PR TITLE
AEWeb - Directory listing

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -128,11 +128,12 @@ config :archethic, ArchethicWeb.FaucetController, enabled: true
 # with webpack to recompile .js and .css sources.
 config :archethic, ArchethicWeb.Endpoint,
   explorer_url:
-    Path.join([
-      "https://",
-      "#{System.get_env("ARCHETHIC_DOMAIN_NAME", "localhost")}:#{System.get_env("ARCHETHIC_HTTPS_PORT", "5000")}",
-      "explorer"
-    ]),
+    URI.to_string(%URI{
+      scheme: "https",
+      host: System.get_env("ARCHETHIC_DOMAIN_NAME", "localhost"),
+      port: System.get_env("ARCHETHIC_HTTPS_PORT", "5000") |> String.to_integer(),
+      path: "/explorer"
+    }),
   http: [port: System.get_env("ARCHETHIC_HTTP_PORT", "4000") |> String.to_integer()],
   server: true,
   debug_errors: true,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -127,6 +127,12 @@ config :archethic, ArchethicWeb.FaucetController, enabled: true
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :archethic, ArchethicWeb.Endpoint,
+  explorer_url:
+    Path.join([
+      "https://",
+      "#{System.get_env("ARCHETHIC_DOMAIN_NAME", "localhost")}:#{System.get_env("ARCHETHIC_HTTPS_PORT", "5000")}",
+      "explorer"
+    ]),
   http: [port: System.get_env("ARCHETHIC_HTTP_PORT", "4000") |> String.to_integer()],
   server: true,
   debug_errors: true,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -237,7 +237,6 @@ config :archethic, ArchethicWeb.Endpoint,
           false ->
             System.get_env("ARCHETHIC_DOMAIN_NAME", "mainnet.archethic.net")
         end,
-      port: System.get_env("ARCHETHIC_HTTPS_PORT", "50000") |> String.to_integer(),
       path: "/explorer"
     }),
   http: [:inet6, port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -227,21 +227,19 @@ config :archethic, ArchethicWeb.FaucetController,
 # before starting your production server.
 config :archethic, ArchethicWeb.Endpoint,
   explorer_url:
-    (case(System.get_env("ARCHETHIC_NETWORK_TYPE") == "testnet") do
-       true ->
-         Path.join([
-           "https://",
-           "#{System.get_env("ARCHETHIC_DOMAIN_NAME", "testnet.archethic.net")}:#{System.get_env("ARCHETHIC_HTTPS_PORT", "50000")}",
-           "explorer"
-         ])
+    URI.to_string(%URI{
+      scheme: "https",
+      host:
+        case(System.get_env("ARCHETHIC_NETWORK_TYPE") == "testnet") do
+          true ->
+            System.get_env("ARCHETHIC_DOMAIN_NAME", "testnet.archethic.net")
 
-       false ->
-         Path.join([
-           "https://",
-           "#{System.get_env("ARCHETHIC_DOMAIN_NAME", "mainnet.archethic.net")}:#{System.get_env("ARCHETHIC_HTTPS_PORT", "50000")}",
-           "explorer"
-         ])
-     end),
+          false ->
+            System.get_env("ARCHETHIC_DOMAIN_NAME", "mainnet.archethic.net")
+        end,
+      port: System.get_env("ARCHETHIC_HTTPS_PORT", "50000") |> String.to_integer(),
+      path: "/explorer"
+    }),
   http: [:inet6, port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],
   url: [host: nil, port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],
   cache_static_manifest: "priv/static/cache_manifest.json",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -227,11 +227,21 @@ config :archethic, ArchethicWeb.FaucetController,
 # before starting your production server.
 config :archethic, ArchethicWeb.Endpoint,
   explorer_url:
-    Path.join([
-      "https://",
-      "#{System.get_env("ARCHETHIC_DOMAIN_NAME", "mainnet.archethic.net")}:#{System.get_env("ARCHETHIC_HTTPS_PORT", "50000")}",
-      "explorer"
-    ]),
+    (case(System.get_env("ARCHETHIC_NETWORK_TYPE") == "testnet") do
+       true ->
+         Path.join([
+           "https://",
+           "#{System.get_env("ARCHETHIC_DOMAIN_NAME", "testnet.archethic.net")}:#{System.get_env("ARCHETHIC_HTTPS_PORT", "50000")}",
+           "explorer"
+         ])
+
+       false ->
+         Path.join([
+           "https://",
+           "#{System.get_env("ARCHETHIC_DOMAIN_NAME", "mainnet.archethic.net")}:#{System.get_env("ARCHETHIC_HTTPS_PORT", "50000")}",
+           "explorer"
+         ])
+     end),
   http: [:inet6, port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],
   url: [host: nil, port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],
   cache_static_manifest: "priv/static/cache_manifest.json",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -226,6 +226,12 @@ config :archethic, ArchethicWeb.FaucetController,
 # which you should run after static files are built and
 # before starting your production server.
 config :archethic, ArchethicWeb.Endpoint,
+  explorer_url:
+    Path.join([
+      "https://",
+      "#{System.get_env("ARCHETHIC_DOMAIN_NAME", "mainnet.archethic.net")}:#{System.get_env("ARCHETHIC_HTTPS_PORT", "50000")}",
+      "explorer"
+    ]),
   http: [:inet6, port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],
   url: [host: nil, port: System.get_env("ARCHETHIC_HTTP_PORT", "40000") |> String.to_integer()],
   cache_static_manifest: "priv/static/cache_manifest.json",

--- a/config/test.exs
+++ b/config/test.exs
@@ -155,5 +155,6 @@ config :archethic, Archethic.Utils.DetectNodeResponsiveness, timeout: 1_000
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :archethic, ArchethicWeb.Endpoint,
+  explorer_url: "",
   http: [port: 4002],
   server: false

--- a/lib/archethic_web/controllers/aeweb_root_controller.ex
+++ b/lib/archethic_web/controllers/aeweb_root_controller.ex
@@ -15,7 +15,6 @@ defmodule ArchethicWeb.AEWebRootController do
         WebHostingController.send_response(conn, file_content, encodage, mime_type, cached?, etag)
 
       {:error, {:is_a_directory, transaction}} ->
-        # FIXME: DIR_LISTING is doing the same I/O as GET_WEBSITE so it's not efficient
         {:ok, listing_html, encodage, mime_type, cached?, etag} =
           WebHostingController.dir_listing(conn.request_path, params, transaction, cache_headers)
 
@@ -27,8 +26,11 @@ defmodule ArchethicWeb.AEWebRootController do
           [] ->
             send_resp(conn, 404, "Not Found")
 
+          ["index.html"] ->
+            send_resp(conn, 400, "Not Found")
+
           _path ->
-            params = Map.put(params, "url_path", [])
+            params = Map.put(params, "url_path", ["index.html"])
             index(conn, params)
         end
 

--- a/lib/archethic_web/controllers/aeweb_root_controller.ex
+++ b/lib/archethic_web/controllers/aeweb_root_controller.ex
@@ -8,11 +8,20 @@ defmodule ArchethicWeb.AEWebRootController do
   def index(conn, params = %{"url_path" => url_path}) do
     cache_headers = WebHostingController.get_cache_headers(conn)
 
+    # WHEN IS THIS CALLED ?
+
     case WebHostingController.get_website(params, cache_headers) do
       {:ok, file_content, encodage, mime_type, cached?, etag} ->
         WebHostingController.send_response(conn, file_content, encodage, mime_type, cached?, etag)
 
-      {:error, :not_found} ->
+      {:error, :is_a_directory} ->
+        # FIXME: DIR_LISTING is doing the same I/O as GET_WEBSITE so it's not efficient
+        {:ok, listing_html, encodage, mime_type, cached?, etag} =
+          WebHostingController.dir_listing(params, cache_headers)
+
+        WebHostingController.send_response(conn, listing_html, encodage, mime_type, cached?, etag)
+
+      {:error, :file_not_found} ->
         # If file is not found, returning default file (url can be handled by index file)
         case url_path do
           [] ->

--- a/lib/archethic_web/controllers/aeweb_root_controller.ex
+++ b/lib/archethic_web/controllers/aeweb_root_controller.ex
@@ -8,8 +8,6 @@ defmodule ArchethicWeb.AEWebRootController do
   def index(conn, params = %{"url_path" => url_path}) do
     cache_headers = WebHostingController.get_cache_headers(conn)
 
-    # WHEN IS THIS CALLED ?
-
     case WebHostingController.get_website(params, cache_headers) do
       {:ok, file_content, encodage, mime_type, cached?, etag} ->
         WebHostingController.send_response(conn, file_content, encodage, mime_type, cached?, etag)

--- a/lib/archethic_web/controllers/aeweb_root_controller.ex
+++ b/lib/archethic_web/controllers/aeweb_root_controller.ex
@@ -17,7 +17,7 @@ defmodule ArchethicWeb.AEWebRootController do
       {:error, :is_a_directory} ->
         # FIXME: DIR_LISTING is doing the same I/O as GET_WEBSITE so it's not efficient
         {:ok, listing_html, encodage, mime_type, cached?, etag} =
-          WebHostingController.dir_listing(params, cache_headers)
+          WebHostingController.dir_listing(conn.request_path, params, cache_headers)
 
         WebHostingController.send_response(conn, listing_html, encodage, mime_type, cached?, etag)
 

--- a/lib/archethic_web/controllers/aeweb_root_controller.ex
+++ b/lib/archethic_web/controllers/aeweb_root_controller.ex
@@ -14,10 +14,10 @@ defmodule ArchethicWeb.AEWebRootController do
       {:ok, file_content, encodage, mime_type, cached?, etag} ->
         WebHostingController.send_response(conn, file_content, encodage, mime_type, cached?, etag)
 
-      {:error, :is_a_directory} ->
+      {:error, {:is_a_directory, transaction}} ->
         # FIXME: DIR_LISTING is doing the same I/O as GET_WEBSITE so it's not efficient
         {:ok, listing_html, encodage, mime_type, cached?, etag} =
-          WebHostingController.dir_listing(conn.request_path, params, cache_headers)
+          WebHostingController.dir_listing(conn.request_path, params, transaction, cache_headers)
 
         WebHostingController.send_response(conn, listing_html, encodage, mime_type, cached?, etag)
 

--- a/lib/archethic_web/controllers/api/web_hosting_controller.ex
+++ b/lib/archethic_web/controllers/api/web_hosting_controller.ex
@@ -209,8 +209,9 @@ defmodule ArchethicWeb.API.WebHostingController do
         %{dirs: dirs_acc, files: [item | files_acc]}
 
       {:dir, name}, %{dirs: dirs_acc, files: files_acc} ->
+        # directories url end with a slash for relative url in website to work
         item = %{
-          href: %{href: Path.join(request_path, name)},
+          href: %{href: Path.join([request_path, name]) <> "/"},
           last_modified: timestamp,
           name: name
         }

--- a/lib/archethic_web/controllers/api/web_hosting_controller.ex
+++ b/lib/archethic_web/controllers/api/web_hosting_controller.ex
@@ -128,7 +128,7 @@ defmodule ArchethicWeb.API.WebHostingController do
         Map.keys(json_content_subset)
         |> Enum.map(fn key ->
           case json_content_subset[key] do
-            %{"address" => _, "encodage" => _} ->
+            %{"address" => _} ->
               {:file, key}
 
             _ ->
@@ -245,7 +245,7 @@ defmodule ArchethicWeb.API.WebHostingController do
   defp get_file(json_content, path), do: get_file(json_content, path, nil)
 
   # case when we're parsing a reference tx
-  defp get_file(file = %{"address" => _, "encodage" => _}, [], previous_path_item) do
+  defp get_file(file = %{"address" => _}, [], previous_path_item) do
     {:ok, file, MIME.from_path(previous_path_item)}
   end
 

--- a/lib/archethic_web/controllers/api/web_hosting_controller.ex
+++ b/lib/archethic_web/controllers/api/web_hosting_controller.ex
@@ -163,15 +163,13 @@ defmodule ArchethicWeb.API.WebHostingController do
         end
 
       assigns =
-        Map.keys(json_content_subset)
-        |> Enum.map(fn key ->
-          case json_content_subset[key] do
-            %{"address" => address} ->
-              {:file, key, address}
+        json_content_subset
+        |> Enum.map(fn
+          {key, %{"address" => address}} ->
+            {:file, key, address}
 
-            _ ->
-              {:dir, key}
-          end
+          {key, _} ->
+            {:dir, key}
         end)
         # sort directory last, then DESC order (it will be accumulated in reverse order below)
         |> Enum.sort(fn

--- a/lib/archethic_web/controllers/api/web_hosting_controller.ex
+++ b/lib/archethic_web/controllers/api/web_hosting_controller.ex
@@ -73,10 +73,15 @@ defmodule ArchethicWeb.API.WebHostingController do
 
     with {:ok, address} <- Base.decode16(address, case: :mixed),
          true <- Crypto.valid_address?(address),
-         {:ok, transaction} <- Archethic.get_last_transaction(address) do
-      with {:ok, json_content} <- Jason.decode(transaction.data.content),
+         {:ok,
+          transaction = %Transaction{
+            address: last_address,
+            data: %TransactionData{content: content}
+          }} <-
+           Archethic.get_last_transaction(address) do
+      with {:ok, json_content} <- Jason.decode(content),
            {:ok, file, mime_type} <- get_file(json_content, url_path),
-           {cached?, etag} <- get_cache(cache_headers, transaction.address, url_path),
+           {cached?, etag} <- get_cache(cache_headers, last_address, url_path),
            {:ok, file_content, encodage} <- get_file_content(file, cached?, url_path) do
         {:ok, file_content, encodage, mime_type, cached?, etag}
       else

--- a/lib/archethic_web/controllers/api/web_hosting_controller.ex
+++ b/lib/archethic_web/controllers/api/web_hosting_controller.ex
@@ -46,7 +46,6 @@ defmodule ArchethicWeb.API.WebHostingController do
         send_resp(conn, 400, "Invalid file encodage")
 
       {:error, {:is_a_directory, transaction}} ->
-        # FIXME: DIR_LISTING is doing the same I/O as GET_WEBSITE so it's not efficient
         {:ok, listing_html, encodage, mime_type, cached?, etag} =
           dir_listing(conn.request_path, params, transaction, get_cache_headers(conn))
 
@@ -263,19 +262,12 @@ defmodule ArchethicWeb.API.WebHostingController do
 
   # case when we're on a directory
   defp get_file(json_content, [], _previous_path_item) when is_map(json_content) do
-    case Map.keys(json_content) do
-      [single_key] ->
-        # if there is a single file in a dir, we return it
-        {:ok, Map.get(json_content, single_key), MIME.from_path(single_key)}
+    case Map.get(json_content, "index.html") do
+      nil ->
+        {:error, :is_a_directory}
 
-      _ ->
-        case Map.get(json_content, "index.html") do
-          nil ->
-            {:error, :is_a_directory}
-
-          file ->
-            {:ok, file, "text/html"}
-        end
+      file ->
+        {:ok, file, "text/html"}
     end
   end
 

--- a/lib/archethic_web/controllers/api/web_hosting_controller.ex
+++ b/lib/archethic_web/controllers/api/web_hosting_controller.ex
@@ -196,7 +196,15 @@ defmodule ArchethicWeb.API.WebHostingController do
           cwd: current_working_dir,
           parent_dir_href: parent_dir_href,
           reference_transaction_href: %{
-            href: Path.join(["/", "explorer", "transaction", Base.encode16(transaction.address)])
+            href:
+              Path.join([
+                Keyword.fetch!(
+                  Application.get_env(:archethic, ArchethicWeb.Endpoint),
+                  :explorer_url
+                ),
+                "transaction",
+                Base.encode16(transaction.address)
+              ])
           }
         })
 

--- a/lib/archethic_web/controllers/api/web_hosting_controller.ex
+++ b/lib/archethic_web/controllers/api/web_hosting_controller.ex
@@ -138,91 +138,89 @@ defmodule ArchethicWeb.API.WebHostingController do
       ) do
     url_path = Map.get(params, "url_path", [])
 
-    with {:ok, json_content} <- Jason.decode(content),
-         {cached?, etag} <- get_cache(cache_headers, last_address, url_path) do
-      json_content_subset =
-        case url_path do
-          [] ->
-            json_content
+    with {:ok, json_content} <- Jason.decode(content) do
+      case get_cache(cache_headers, last_address, url_path) do
+        {true, etag} ->
+          {:ok, nil, nil, "text/html", true, etag}
 
-          _ ->
-            {:ok, subset} = Pathex.view(json_content, get_json_path(url_path))
-            subset
-        end
+        {false, etag} ->
+          {json_content_subset, current_working_dir, parent_dir_href} =
+            case url_path do
+              [] ->
+                {json_content, "/", nil}
 
-      {current_working_dir, parent_dir_href} =
-        case url_path do
-          [] ->
-            {"/", nil}
+              _ ->
+                {:ok, subset} = Pathex.view(json_content, get_json_path(url_path))
 
-          _ ->
-            {
-              Path.join(["/" | url_path]),
-              %{href: request_path |> Path.join("..") |> Path.expand()}
-            }
-        end
+                {
+                  subset,
+                  Path.join(["/" | url_path]),
+                  %{href: request_path |> Path.join("..") |> Path.expand()}
+                }
+            end
 
-      assigns =
-        json_content_subset
-        |> Enum.map(fn
-          {key, %{"address" => address}} ->
-            {:file, key, address}
+          assigns =
+            json_content_subset
+            |> Enum.map(fn
+              {key, %{"address" => address}} ->
+                {:file, key, address}
 
-          {key, _} ->
-            {:dir, key}
-        end)
-        # sort directory last, then DESC order (it will be accumulated in reverse order below)
-        |> Enum.sort(fn
-          {:file, a, _}, {:file, b, _} ->
-            a > b
+              {key, _} ->
+                {:dir, key}
+            end)
+            # sort directory last, then DESC order (it will be accumulated in reverse order below)
+            |> Enum.sort(fn
+              {:file, a, _}, {:file, b, _} ->
+                a > b
 
-          {:dir, a}, {:dir, b} ->
-            a > b
+              {:dir, a}, {:dir, b} ->
+                a > b
 
-          {:file, _, _}, {:dir, _} ->
-            true
+              {:file, _, _}, {:dir, _} ->
+                true
 
-          {:dir, _}, {:file, _, _} ->
-            false
-        end)
-        |> Enum.reduce(%{dirs: [], files: []}, fn
-          {:file, name, addresses}, %{dirs: dirs_acc, files: files_acc} ->
-            item = %{
-              href: %{href: Path.join(request_path, name)},
-              last_modified: timestamp,
-              addresses: addresses,
-              name: name
-            }
+              {:dir, _}, {:file, _, _} ->
+                false
+            end)
+            |> Enum.reduce(%{dirs: [], files: []}, fn
+              {:file, name, addresses}, %{dirs: dirs_acc, files: files_acc} ->
+                item = %{
+                  href: %{href: Path.join(request_path, name)},
+                  last_modified: timestamp,
+                  addresses: addresses,
+                  name: name
+                }
 
-            %{dirs: dirs_acc, files: [item | files_acc]}
+                %{dirs: dirs_acc, files: [item | files_acc]}
 
-          {:dir, name}, %{dirs: dirs_acc, files: files_acc} ->
-            item = %{
-              href: %{href: Path.join(request_path, name)},
-              last_modified: timestamp,
-              name: name
-            }
+              {:dir, name}, %{dirs: dirs_acc, files: files_acc} ->
+                item = %{
+                  href: %{href: Path.join(request_path, name)},
+                  last_modified: timestamp,
+                  name: name
+                }
 
-            %{files: files_acc, dirs: [item | dirs_acc]}
-        end)
-        |> Enum.into(%{
-          cwd: current_working_dir,
-          parent_dir_href: parent_dir_href,
-          reference_transaction_href: %{
-            href:
-              Path.join([
-                Keyword.fetch!(
-                  Application.get_env(:archethic, ArchethicWeb.Endpoint),
-                  :explorer_url
-                ),
-                "transaction",
-                Base.encode16(last_address)
-              ])
-          }
-        })
+                %{files: files_acc, dirs: [item | dirs_acc]}
+            end)
+            |> Enum.into(%{
+              cwd: current_working_dir,
+              parent_dir_href: parent_dir_href,
+              reference_transaction_href: %{
+                href:
+                  Path.join([
+                    Keyword.fetch!(
+                      Application.get_env(:archethic, ArchethicWeb.Endpoint),
+                      :explorer_url
+                    ),
+                    "transaction",
+                    Base.encode16(last_address)
+                  ])
+              }
+            })
 
-      {:ok, Phoenix.View.render_to_iodata(ArchethicWeb.DirListingView, "index.html", assigns),
-       nil, "text/html", cached?, etag}
+          {:ok, Phoenix.View.render_to_iodata(ArchethicWeb.DirListingView, "index.html", assigns),
+           nil, "text/html", false, etag}
+      end
     else
       error ->
         error

--- a/lib/archethic_web/templates/dir_listing/index.html.heex
+++ b/lib/archethic_web/templates/dir_listing/index.html.heex
@@ -1,0 +1,93 @@
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Index of <%=@cwd %></title>
+    <style>
+    html {
+        background-color: #f6f6f6;
+        font-family: sans-serif;
+    }
+    body {
+        border: 1px solid #cdcdcd;
+        border-radius: 10px;
+        padding: 3em;
+        min-width: 30em;
+        max-width: 65em;
+        margin: 4em auto;
+        background-color: #fff;
+        color: #000;
+    }
+
+    a {
+        text-decoration: none;
+    }
+
+    table.index {
+        width: 90%;
+        margin: 0 auto;
+    }
+    table.index thead {
+        font-size: 130%;
+    }
+    table.index thead th {
+        text-align: start;
+    }
+    table.index td.size {
+        text-align: end;
+        padding-inline-end: 1em;
+    }
+    </style>
+</head>
+<body>
+
+    <h1>Index of <%=@cwd %></h1>
+
+    <%= if @parent_dir_href do  %>
+        <p><a {@parent_dir_href}>Up to higher level directory</a></p>
+    <% end %>
+
+    <table class="index">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Size</th>
+                <th>Last Modified</th>
+            </tr>
+        </thead>
+        <tbody>
+            <%= for dir <- @dirs do %>
+                <tr>
+                    <td>
+                        <table class="ellipsis">
+                            <tbody>
+                                <tr>
+                                    <td><a class="dir" {dir.href}><%= dir.name %></a></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <td></td>
+                    <td><%= datetime_to_str(dir.last_modified) %></td>
+                </tr>
+            <% end %>
+            <%= for file <- @files do %>
+                <tr>
+                    <td>
+                        <table class="ellipsis">
+                            <tbody>
+                                <tr>
+                                    <td><a class="file" {file.href}><%= file.name %></a></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <td class="size">? KB</td>
+                    <td><%= datetime_to_str(file.last_modified) %></td>
+                </tr>
+            <% end %>
+
+        </tbody>
+    </table>
+
+</body>
+</html>

--- a/lib/archethic_web/templates/dir_listing/index.html.heex
+++ b/lib/archethic_web/templates/dir_listing/index.html.heex
@@ -67,7 +67,7 @@
                         </table>
                     </td>
                     <td></td>
-                    <td><%= datetime_to_str(dir.last_modified) %></td>
+                    <td><%= format_date(dir.last_modified) %></td>
                 </tr>
             <% end %>
             <%= for file <- @files do %>
@@ -82,7 +82,7 @@
                         </table>
                     </td>
                     <td class="size">? KB</td>
-                    <td><%= datetime_to_str(file.last_modified) %></td>
+                    <td><%= format_date(file.last_modified) %></td>
                 </tr>
             <% end %>
 

--- a/lib/archethic_web/templates/dir_listing/index.html.heex
+++ b/lib/archethic_web/templates/dir_listing/index.html.heex
@@ -4,7 +4,7 @@
     <title>Index of <%=@cwd %></title>
     <style>
     html {
-        background-color: #f6f6f6;
+        background-color: #050510;
         font-family: sans-serif;
     }
     body {
@@ -32,62 +32,132 @@
     table.index thead th {
         text-align: start;
     }
-    table.index td.size {
+    table.index .transaction {
         text-align: end;
-        padding-inline-end: 1em;
+        padding-inline-end: 1rem;
+    }
+    table.index .last-modified {
+        width: 1px;
+        white-space: nowrap;
+    }
+    table.index .name {
+        white-space: nowrap;
+    }
+
+    .comma:not(:empty) ~ .comma:not(:empty):before {
+        content: ", ";
+    }
+
+    i.icon {
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+    }
+    i.file {
+        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABxUlEQVR42mNkQABNPj6+NE4ggAn8+/ef4c/fvww/f/5k+Pb1yzSg0CUGNMAIpXmio6PvTZw8RRQk9B+k+e8/hm8/fjI8f/WW4dGzlwx7Ni5/M2fOHBeg1EVsBpiuXrP2lIm5JYrp//79Y/j+4xfDh89fGZRlJRhqqytBhjgjuwRmgNmatetOWljZoLsQbMinL98Z+Hg4weyWpvq3c2bPdgVKnUczYO1JWzsHBmzgx8/fDD9//2FgZgJ67/9/hvy83LdbN63XB0o9hRsA9MJJJ2cXBlzgLyhMvv9geP76HcOq1WsY+tvrzYHCp1AMcHNzx2nAfyAExQooYDds2MiQk5GCagDQ1JNeXl4MhMBfYDhs2rSZITY6EtWAlUAD/Hx9CBoADAKwARHhoWgGrFp9MiDAn6ABIADyQngYmgErVq46GRwURJQBa9etA7ogDNWA5StWngwLDSHKAFAsREaEoxqwdPmKk5HhYUQZsHzlKoboyAgUA0wXLl56Ki4miigDFi1ZxhAfG20GZJ6GZyb/gMB702fMFOXgYMer+QcwHWRmpL/euGG9EpD7hRFJTpOHhyeNgwORnbEb8P37ly9fZgGZ10F8AL8PzRGGBrLfAAAAAElFTkSuQmCC')
+    }
+    i.dir {
+        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABAklEQVR42mNkoBAwAjEXEAcCMTsW+U9AvB6I/+I0gJ2Noe3QJoZKASEgjwkq+h+C795lYPCKZMgC8mZg0fsfbICIIMOcF6cZkrGZ/v8fA0PndIa/7z8BXfAPqgVKv//A8GPeZoYERmE+hjmP1+AwAOgiTjOIP7HZLyjLMJNRmB/ogjMMyYzsUC8wIhQwsgCFWHAHoKAy0AARIYY5r69idwEhIKgBMgAYBq8vkGmALsyAU2QaYAwz4CiZBliADBAAGnCATANsYQbsJtMAJ5ABwGh8uZE8A4R9gAYwMzHkT8hl6Bfgxp5ecIH3Xxj+F05hyIdpUmXAnpnwge9AfJckW7EBAC/gSzisxsnmAAAAAElFTkSuQmCC')
+    }
+    i.up {
+        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABZUlEQVR42mNkwAN8DrpUMbMzsW+02FWPSw0jLgmTNj0T5Uj5YyA1Dzc9tTuRf+440QZIOIpx2s4xPcfAyKgBFbp9PPeswZOtz78RZYDPCeeJHKLsechivz78nrrJeHcOQQPMJxs4S3tK7gIymdCk/r3Y/8rjWOrZ3TgNkPWX5Dfp1bsMYuIImsfnqq7qPVz15ANWA7zOOi5i5WONxRczf778WbzVcF8chgGWC4yCRa2EVuOLGSj4//b0+5Cj0WfXoRjgvMN6IiMTowqrMIsyMy+zOladv/+/+vns1zkmJsa7u5wP52ANRNPZ+pVidkJt2Az4+/Pflh16B33xxoLJbL1KUVvsBvwDGrBT/xB+A4xn61aK2ghid8Gvf1t26x/Bb4DRLJ1KEVtBnC7YY3AUvwGGM7UqhaEGoEuCwmCf4XH8BhjM1KwUtsHtgv1GJ/AboN2iFiPqKjQJm9yfd38WH/E8g5JHABnvhRHOvy3zAAAAAElFTkSuQmCC')
+    }
+
+    h1 {
+        display: flex;
+        align-items: center;
+    }
+    h1 svg {
+        padding-right: 1rem;
     }
     </style>
 </head>
 <body>
 
-    <h1>Index of <%=@cwd %></h1>
+    <h1>
+        <a {@reference_transaction_href}>
+        <svg width="32px" height="32p" viewBox="0 0 218 218" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <title>Hosted on the Archethic public blockchain</title>
+            <defs>
+                <linearGradient x1="-8.15998999%" y1="58.450506%" x2="66.0973524%" y2="37.2317255%" id="linearGradient-1">
+                    <stop stop-color="#00A4DB" offset="0%"></stop>
+                    <stop stop-color="#CC00FF" offset="100%"></stop>
+                </linearGradient>
+                <linearGradient x1="13.7694298%" y1="70.2946817%" x2="60.0277915%" y2="19.3357929%" id="linearGradient-2">
+                    <stop stop-color="#00A4DB" offset="0%"></stop>
+                    <stop stop-color="#CC00FF" offset="100%"></stop>
+                </linearGradient>
+                <linearGradient x1="16.65189%" y1="70.2946817%" x2="59.2299926%" y2="19.3357929%" id="linearGradient-3">
+                    <stop stop-color="#00A4DB" offset="0%"></stop>
+                    <stop stop-color="#CC00FF" offset="100%"></stop>
+                </linearGradient>
+            </defs>
+            <g id="Validated-logos" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Validated-Logo" transform="translate(-1151.000000, -1309.000000)" fill-rule="nonzero">
+                    <g id="Archethic-Logo-alone---Gradient" transform="translate(1151.000000, 1309.000000)">
+                        <path d="M55.9717452,30.2949953 C58.277079,29.8243265 65.4163912,28.4555553 74.5139146,28.5490061 C89.4316778,28.7024124 100.98782,32.6922297 108.068945,35.2014331 C116.253298,38.101278 134.390369,45.4666645 152.733815,62.0157094 C159.656388,68.2608302 164.81779,74.1989492 168.327323,78.6046457 C169.964273,75.2228617 171.37137,71.7537392 172.514589,68.2790329 C174.017362,63.7111362 175.12528,58.9891156 175.807186,54.2455009 L176.885965,46.7441695 C172.516684,42.3747523 166.643523,36.9839067 159.253369,31.4276591 C155.737674,28.7844904 144.550448,20.5939625 130.238404,13.9885802 C118.88985,8.7508255 92.4862729,-3.43530867 58.5307129,0.924794254 C33.3292264,4.16081425 15.6139852,15.0162154 11.5230985,17.6098707 C8.53981908,19.5010955 5.64646187,21.5349769 2.92238625,23.6560074 L1.04831512,25.1150272 L0.769616759,27.531395 C0.365209392,31.035456 0.11704668,34.6576851 0.0315105267,38.2952067 C-0.247180173,50.2677741 1.19223628,68.7749081 9.63331195,88.9492658 C12.0697426,94.7738778 14.991245,100.500378 18.3168742,105.969799 C19.2381942,107.48484 21.0852053,110.396159 23.8264914,114.141509 C23.5437181,112.02193 23.2974525,109.900489 23.0926574,107.808498 C21.8931398,95.5725432 21.901396,83.0760867 23.1158323,70.667379 C24.1207991,60.4006965 25.7914713,52.1547558 26.9904881,46.948848 C27.5354475,44.5832318 28.040416,42.603312 28.4211553,41.1633151 C31.6726839,39.1740889 35.7936053,36.9469019 40.7310209,34.9254186 C43.7633286,33.683696 49.0819767,31.7020174 55.9717452,30.2949953 Z" id="Path" fill="url(#linearGradient-1)"></path>
+                        <path d="M135.687247,175.467609 C126.491554,179.685898 118.667316,182.298453 113.654435,183.818261 C111.37656,184.509155 109.445167,185.043083 108.033833,185.419353 C104.70029,183.492309 100.724186,180.903073 96.5075524,177.47858 C93.9178507,175.375218 89.5412585,171.588065 84.8534403,166.104031 C83.2848761,164.26886 78.5027411,158.541683 73.9633554,150.326804 C66.5204227,136.856728 64.0294757,124.491123 62.5573549,116.88206 C60.8559983,108.087575 57.8798298,88.1295066 62.5680641,63.4061312 C64.3374812,54.0761606 66.7408756,46.4804094 68.6865072,41.1320755 C64.9944792,41.3488233 61.3453646,41.8159434 57.8252983,42.5224924 C53.1980674,43.4514693 48.6411235,44.8118809 44.2816965,46.5653747 L37.3879084,49.3380738 C35.9095239,55.4403879 34.3302508,63.4025281 33.3813186,72.8086841 C32.929927,77.283536 31.6799619,91.4129414 33.3573811,107.557344 C34.6873253,120.358932 37.7815402,150.142853 58.7073874,178.454878 C74.2383399,199.468041 92.4150357,209.959298 96.6858932,212.338608 C99.800201,214.073851 102.990042,215.657193 106.166956,217.045053 L108.352624,218 L110.538309,217.045053 C113.708042,215.660277 116.898392,214.076934 120.019172,212.339332 C130.289317,206.618339 145.215584,196.095424 157.99797,178.454469 C161.688596,173.361873 165.050107,167.882779 167.988909,162.169101 C168.802922,160.586168 170.328373,157.475558 172.105263,153.146627 C170.455618,154.457546 168.785957,155.737013 167.119948,156.964005 C157.377337,164.143678 146.801406,170.369019 135.687247,175.467609 Z" id="Path" fill="url(#linearGradient-2)"></path>
+                        <path d="M217.972525,38.0088274 C217.887479,34.3932609 217.638113,30.7867503 217.230351,27.289059 L216.949992,24.8826949 L215.064572,23.4297153 C212.330223,21.3225159 209.418882,19.2965364 206.41257,17.4084052 C196.516153,11.1971579 180.277677,3.27186689 159.119499,0.793126672 C153.011295,0.0768354488 146.741198,-0.155930281 140.483606,0.101536825 C138.74991,0.173088203 135.380162,0.379079121 130.861778,0.97102332 C132.780695,1.77307401 134.683017,2.60858339 136.539593,3.46694842 C147.400523,8.4843247 157.871801,14.7138956 167.663141,21.9812676 C175.764408,27.9941346 181.836379,33.5976979 185.597384,37.2645285 C187.306269,38.9308112 188.712164,40.3694805 189.727521,41.4276631 C189.759524,45.3328123 189.553612,50.1354559 188.76481,55.5677043 C188.280309,58.904087 187.266142,64.6581516 184.979803,71.5343238 C184.214788,73.8354816 181.771031,80.9160974 177.116176,89.0243355 C169.483699,102.319599 160.326263,110.691172 154.660952,115.789163 C148.113075,121.681382 132.815125,134.271468 109.714883,142.473281 C100.997333,145.568557 93.4233036,147.238649 87.9649123,148.190588 C89.9762048,151.34166 92.1765979,154.330291 94.5140873,157.085326 C97.587657,160.706547 100.98863,164.050863 104.622035,167.024242 L110.367902,171.726415 C116.228849,169.985698 123.702213,167.405247 132.077045,163.547867 C136.061596,161.712648 148.555053,155.762984 161.291677,146.223499 C171.39112,138.659129 194.888008,121.059883 208.313472,88.4524744 C218.277711,64.2517146 218.088901,42.967321 217.972525,38.0088274 Z" id="Path" fill="url(#linearGradient-3)"></path>
+                    </g>
+                </g>
+            </g>
+        </svg>
+        </a>
+        Index of <%=@cwd %>
+    </h1>
 
     <%= if @parent_dir_href do  %>
-        <p><a {@parent_dir_href}>Up to higher level directory</a></p>
+        <p><a {@parent_dir_href}><i class="up icon"></i> Up to higher level directory</a></p>
     <% end %>
 
     <table class="index">
         <thead>
             <tr>
                 <th>Name</th>
-                <th>Size</th>
-                <th>Last Modified</th>
+                <th class="transaction">Transactions</th>
+                <th class="last-modified">Last Modified</th>
             </tr>
         </thead>
         <tbody>
             <%= for dir <- @dirs do %>
                 <tr>
-                    <td>
-                        <table class="ellipsis">
+                    <td class="name">
+                        <table>
                             <tbody>
                                 <tr>
-                                    <td><a class="dir" {dir.href}><%= dir.name %></a></td>
+                                    <td><a {dir.href}><i class="dir icon"></i> <%= dir.name %></a></td>
                                 </tr>
                             </tbody>
                         </table>
                     </td>
-                    <td></td>
-                    <td><%= format_date(dir.last_modified) %></td>
+                    <td class="transaction"></td>
+                    <td class="last-modified"><%= format_date(dir.last_modified) %></td>
                 </tr>
             <% end %>
             <%= for file <- @files do %>
                 <tr>
-                    <td>
-                        <table class="ellipsis">
+                    <td class="name">
+                        <table>
                             <tbody>
                                 <tr>
-                                    <td><a class="file" {file.href}><%= file.name %></a></td>
+                                    <td><a {file.href}><i class="file icon"></i> <%= file.name %></a></td>
                                 </tr>
                             </tbody>
                         </table>
                     </td>
-                    <td class="size">? KB</td>
-                    <td><%= format_date(file.last_modified) %></td>
+                    <td class="transaction">
+                    <%= for address <- prepare_addresses(file.addresses) do %>
+                        <a class="address comma"{address.href}><%= address.text %></a>
+                    <% end %>
+                    </td>
+                    <td class="last-modified"><%= format_date(file.last_modified) %></td>
                 </tr>
             <% end %>
 
         </tbody>
     </table>
+
+
 
 </body>
 </html>

--- a/lib/archethic_web/templates/dir_listing/index.html.heex
+++ b/lib/archethic_web/templates/dir_listing/index.html.heex
@@ -4,7 +4,7 @@
     <title>Index of <%=@cwd %></title>
     <style>
     html {
-        background-color: #050510;
+        background-color: #f6f6f6;
         font-family: sans-serif;
     }
     body {
@@ -108,6 +108,8 @@
 
     <%= if @parent_dir_href do  %>
         <p><a {@parent_dir_href}><i class="up icon"></i> Up to higher level directory</a></p>
+    <% else  %>
+        <p>&nbsp;</p>
     <% end %>
 
     <table class="index">

--- a/lib/archethic_web/views/dir_listing_view.ex
+++ b/lib/archethic_web/views/dir_listing_view.ex
@@ -1,10 +1,4 @@
 defmodule ArchethicWeb.DirListingView do
   @moduledoc false
   use ArchethicWeb, :view
-
-  def datetime_to_str(datetime) do
-    datetime
-    |> DateTime.truncate(:second)
-    |> DateTime.to_string()
-  end
 end

--- a/lib/archethic_web/views/dir_listing_view.ex
+++ b/lib/archethic_web/views/dir_listing_view.ex
@@ -2,12 +2,20 @@ defmodule ArchethicWeb.DirListingView do
   @moduledoc false
   use ArchethicWeb, :view
 
-  @spec prepare_addresses(list(String.t())) :: String.t()
+  @spec prepare_addresses(list(String.t())) :: list(map())
   def prepare_addresses(addresses) do
+    explorer_url =
+      Keyword.fetch!(
+        Application.get_env(:archethic, ArchethicWeb.Endpoint),
+        :explorer_url
+      )
+
     addresses
     |> Enum.map(fn address ->
       %{
-        href: %{href: Path.join(["/", "explorer", "transaction", address])},
+        href: %{
+          href: Path.join([explorer_url, "transaction", address])
+        },
         text: shorten_address(address)
       }
     end)

--- a/lib/archethic_web/views/dir_listing_view.ex
+++ b/lib/archethic_web/views/dir_listing_view.ex
@@ -1,4 +1,20 @@
 defmodule ArchethicWeb.DirListingView do
   @moduledoc false
   use ArchethicWeb, :view
+
+  @spec prepare_addresses(list(String.t())) :: String.t()
+  def prepare_addresses(addresses) do
+    addresses
+    |> Enum.map(fn address ->
+      %{
+        href: %{href: Path.join(["/", "explorer", "transaction", address])},
+        text: shorten_address(address)
+      }
+    end)
+  end
+
+  @spec shorten_address(String.t()) :: String.t()
+  def shorten_address(address) do
+    String.slice(address, 4..13)
+  end
 end

--- a/lib/archethic_web/views/dir_listing_view.ex
+++ b/lib/archethic_web/views/dir_listing_view.ex
@@ -1,0 +1,10 @@
+defmodule ArchethicWeb.DirListingView do
+  @moduledoc false
+  use ArchethicWeb, :view
+
+  def datetime_to_str(datetime) do
+    datetime
+    |> DateTime.truncate(:second)
+    |> DateTime.to_string()
+  end
+end

--- a/lib/archethic_web/views/dir_listing_view.ex
+++ b/lib/archethic_web/views/dir_listing_view.ex
@@ -15,6 +15,6 @@ defmodule ArchethicWeb.DirListingView do
 
   @spec shorten_address(String.t()) :: String.t()
   def shorten_address(address) do
-    String.slice(address, 4..13)
+    String.slice(address, 4..7)
   end
 end

--- a/test/archethic_web/controllers/api/web_hosting_controller_test.exs
+++ b/test/archethic_web/controllers/api/web_hosting_controller_test.exs
@@ -12,6 +12,7 @@ defmodule ArchethicWeb.API.WebHostingControllerTest do
   alias Archethic.P2P.Message.LastTransactionAddress
 
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.TransactionData
 
   import Mox
@@ -423,53 +424,19 @@ defmodule ArchethicWeb.API.WebHostingControllerTest do
       }
       """
 
-      content2 = """
-      {
-        "dir1": {
-          "file10.txt": "H4sIAAAAAAAAA0vLzElVMDTgAgALt2T5CAAAAA",
-          "file11.txt": "H4sIAAAAAAAAA0vLzElVMDTkAgBKhn_gCAAAAA"
-        },
-        "dir2": {
-          "hello.txt": "H4sIAAAAAAAAA_NIzcnJ1yupKFHQyM_LqVRIy8xJVcjMU0jJLDLS5AIAt5R0vB4AAAA"
-        },
-        "dir3": {
-          "index.html": "H4sIAAAAAAAAA7PJMLRz8QwyVsjMS0mt0Msoyc2x0QeKcQEAL-DoARkAAAA"
-        },
-        "file1.txt": "H4sIAAAAAAAAA0vLzElVMFTgAgBapaazCAAAAA",
-        "file2.txt": "H4sIAAAAAAAAA0vLzElVMOICAMGeIz8HAAAA",
-        "file3.txt": "H4sIAAAAAAAAA0vLzElVMOYCAICvOCYHAAAA"
-      }
-      """
-
       MockClient
       |> stub(:send_message, fn
         _, %GetLastTransactionAddress{address: address}, _ ->
           {:ok, %LastTransactionAddress{address: address}}
 
-        _,
-        %GetTransaction{
-          address:
-            address =
-                <<0, 0, 34, 84, 150, 163, 128, 213, 0, 92, 182, 131, 116, 233, 184, 180, 93, 126,
-                  15, 80, 90, 66, 248, 205, 97, 203, 212, 60, 54, 132, 197, 203, 172, 186>>
-        },
-        _ ->
+        _, %GetTransaction{address: address}, _ ->
           {:ok,
            %Transaction{
              address: address,
-             data: %TransactionData{content: content}
-           }}
-
-        _,
-        %GetTransaction{
-          address:
-            <<0, 0, 113, 251, 194, 32, 95, 62, 186, 57, 211, 16, 186, 241, 91, 216, 154, 1, 155,
-              9, 41, 190, 118, 183, 134, 72, 82, 203, 104, 201, 205, 101, 2, 222>>
-        },
-        _ ->
-          {:ok,
-           %Transaction{
-             data: %TransactionData{content: content2}
+             data: %TransactionData{content: content},
+             validation_stamp: %ValidationStamp{
+               timestamp: DateTime.utc_now()
+             }
            }}
       end)
 


### PR DESCRIPTION
# Description

Display a directory listing when the user hits an endpoint that correspond to a directory and the directory does not contain a `index.html` file.
This should be performant because only 1 transaction is downloaded (the reference transaction). But, because of this we cannot determine the files' sizes. 

I used Firefox source as template.

Fixes #596

## Type of change

- New feature 

# How Has This Been Tested?

Tested with unit tests.
Tested with the `aewebcli` with the following structure [myaewebdir.zip](https://github.com/archethic-foundation/archethic-node/files/10056869/myaewebdir.zip)

![Screenshot 2022-11-30 at 14-31-20 Index of _](https://user-images.githubusercontent.com/74045243/204809353-e6a65501-5c81-45b4-9f2a-13648c4e9abe.png)


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
