### PR TITLE
:racehorse: remove old daily keys from ets table

### DIFF
--- a/lib/archethic/crypto/keystore/shared_secrets/software_impl.ex
+++ b/lib/archethic/crypto/keystore/shared_secrets/software_impl.ex
@@ -125,7 +125,7 @@ defmodule Archethic.Crypto.SharedSecretsKeystore.SoftwareImpl do
 
   @impl SharedSecretsKeystore
   def sign_with_daily_nonce_key(data, timestamp) do
-    [{key, sign_fun}] =
+    [{_, sign_fun}] =
       case :ets.prev(@daily_keys, DateTime.to_unix(timestamp)) do
         :"$end_of_table" ->
           :ets.lookup(@daily_keys, DateTime.to_unix(timestamp))
@@ -134,14 +134,7 @@ defmodule Archethic.Crypto.SharedSecretsKeystore.SoftwareImpl do
           :ets.lookup(@daily_keys, key)
       end
 
-    remove_older_daily_keys(key)
     sign_fun.(data)
-  end
-
-  defp remove_older_daily_keys(key) do
-    :ets.select_delete(@daily_keys, [
-      {{:"$1", :_}, [{:>, :"$1", key}], [true]}
-    ])
   end
 
   @impl SharedSecretsKeystore
@@ -251,6 +244,7 @@ defmodule Archethic.Crypto.SharedSecretsKeystore.SoftwareImpl do
       end
 
       :ets.insert(@daily_keys, {DateTime.to_unix(timestamp), sign_daily_nonce_fun})
+      remove_older_daily_keys(DateTime.to_unix(timestamp))
 
       :ets.insert(@keystore_table, {:transaction_sign_fun, transaction_sign_fun})
       :ets.insert(@keystore_table, {:network_pool_sign_fun, network_pool_sign_fun})
@@ -260,6 +254,23 @@ defmodule Archethic.Crypto.SharedSecretsKeystore.SoftwareImpl do
       :ets.insert(@keystore_table, {:network_pool_seed_wrap_fun, network_pool_seed_wrap_fun})
 
       :ok
+    end
+  end
+
+  defp remove_older_daily_keys(unix_timestamp) do
+    case :ets.prev(@daily_keys, unix_timestamp) do
+      :"$end_of_table" ->
+        :ok
+
+      prev_unix_timestamp ->
+        # generate match pattern
+        # :ets.fun2ms(fn {key, _sign_function} -> key < prev_unix_timestamp end)
+
+        match_pattern = [
+          {{:"$1", :_}, [{:<, :"$1", prev_unix_timestamp}], [true]}
+        ]
+
+        :ets.select_delete(@daily_keys, match_pattern)
     end
   end
 

--- a/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
+++ b/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
@@ -141,6 +141,24 @@ defmodule Archethic.Crypto.SharedSecrets.SoftwareImplTest do
     assert pub == Keystore.network_pool_public_key(2)
   end
 
+  test ":archethic_shared_secrets_daily_keys should keep 2 most recent elements" do
+    Keystore.start_link()
+
+    timestamp_1 = ~U[2021-04-08 06:35:17Z]
+    timestamp_2 = ~U[2021-04-08 06:36:17Z]
+    timestamp_3 = ~U[2021-04-08 06:37:17Z]
+
+    load_secrets(timestamp_1)
+    load_secrets(timestamp_2)
+    load_secrets(timestamp_3)
+
+    unix_timestamp_2 = DateTime.to_unix(timestamp_2)
+    unix_timestamp_3 = DateTime.to_unix(timestamp_3)
+
+    assert [{unix_timestamp_2, _}, {unix_timestamp_3, _}] =
+             :ets.tab2list(:archethic_shared_secrets_daily_keys)
+  end
+
   defp load_secrets(timestamp = %DateTime{}) do
     public_key = Crypto.last_node_public_key()
 

--- a/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
+++ b/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
@@ -141,7 +141,7 @@ defmodule Archethic.Crypto.SharedSecrets.SoftwareImplTest do
     assert pub == Keystore.network_pool_public_key(2)
   end
 
-  test ":archethic_shared_secrets_daily_keys should keep 2 most recent elements" do
+  test ":archethic_shared_secrets_daily_keys should keep only 2 most recent elements" do
     Keystore.start_link()
 
     timestamp_1 = ~U[2021-04-08 06:35:17Z]

--- a/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
+++ b/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
@@ -155,7 +155,7 @@ defmodule Archethic.Crypto.SharedSecrets.SoftwareImplTest do
     unix_timestamp_2 = DateTime.to_unix(timestamp_2)
     unix_timestamp_3 = DateTime.to_unix(timestamp_3)
 
-    assert [{unix_timestamp_2, _}, {unix_timestamp_3, _}] =
+    assert [{^unix_timestamp_2, _}, {^unix_timestamp_3, _}] =
              :ets.tab2list(:archethic_shared_secrets_daily_keys)
   end
 


### PR DESCRIPTION
# Description

The daily keys (created by node shared secrets) are stored in an ets table, but we only use the current daily key and the previous one, so we don't need to store all the previous daily keys in the ets table

Fixes #697 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
We add 3 entries in the ets table and we make sure that only the last 2 entries remain.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
