### PR TITLE
add graphql query to get version of running code, protocol and transaction

### DIFF
--- a/lib/archethic_web/graphql_schema.ex
+++ b/lib/archethic_web/graphql_schema.ex
@@ -13,6 +13,7 @@ defmodule ArchethicWeb.GraphQLSchema do
   alias __MODULE__.TransactionAttestation
   alias __MODULE__.TransactionError
   alias __MODULE__.OracleData
+  alias __MODULE__.Version
 
   import_types(HexType)
   import_types(DateTimeType)
@@ -23,6 +24,7 @@ defmodule ArchethicWeb.GraphQLSchema do
   import_types(TransactionError)
   import_types(IntegerType)
   import_types(OracleData)
+  import_types(Version)
 
   query do
     @desc """
@@ -166,6 +168,15 @@ defmodule ArchethicWeb.GraphQLSchema do
           {:error, :not_found} ->
             {:error, "Not data found at this date"}
         end
+      end)
+    end
+
+    @desc """
+    List protocol, transaction and code versions
+    """
+    field :version, :version do
+      resolve(fn _, _ ->
+        {:ok, Resolver.get_version()}
       end)
     end
   end

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -12,6 +12,8 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionInput
 
+  alias Archethic.Mining
+
   require Logger
 
   @limit_page 10
@@ -194,6 +196,14 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
         origin_public_key: &1.origin_public_key
       }
     )
+  end
+
+  def get_version do
+    %{
+      code: Mix.Project.config()[:version],
+      protocol: Mining.protocol_version(),
+      transaction: Transaction.version()
+    }
   end
 
   def nearest_endpoints(ip) do

--- a/lib/archethic_web/graphql_schema/version_type.ex
+++ b/lib/archethic_web/graphql_schema/version_type.ex
@@ -1,0 +1,14 @@
+defmodule ArchethicWeb.GraphQLSchema.Version do
+  @moduledoc false
+
+  use Absinthe.Schema.Notation
+
+  @desc """
+  [Version] represents code, transaction and protocol version
+  """
+  object :version do
+    field(:code, :string)
+    field(:transaction, :string)
+    field(:protocol, :string)
+  end
+end

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -32,7 +32,7 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
   alias Archethic.TransactionChain.VersionedTransactionInput
   alias Archethic.TransactionChain.TransactionSummary
 
-  alias alias Archethic.Mining
+  alias Archethic.Mining
 
   import Mox
   @transaction_chain_page_size 10
@@ -412,7 +412,7 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
   end
 
   describe "query: version" do
-    test "should return the code, transaction and storage version", %{conn: conn} do
+    test "should return the code, transaction and protocol version", %{conn: conn} do
       conn =
         post(conn, "/api", %{
           "query" => "query { version { code, protocol, transaction } }"

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -32,6 +32,8 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
   alias Archethic.TransactionChain.VersionedTransactionInput
   alias Archethic.TransactionChain.TransactionSummary
 
+  alias alias Archethic.Mining
+
   import Mox
   @transaction_chain_page_size 10
 
@@ -406,6 +408,35 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
              } = json_response(conn, 200)
 
       assert storage_nonce == Crypto.storage_nonce_public_key() |> Base.encode16()
+    end
+  end
+
+  describe "query: version" do
+    test "should return the code, transaction and storage version", %{conn: conn} do
+      conn =
+        post(conn, "/api", %{
+          "query" => "query { version { code, protocol, transaction } }"
+        })
+
+      code_version = Mix.Project.config()[:version]
+
+      transaction_version =
+        Transaction.version()
+        |> to_string()
+
+      protocol_version =
+        Mining.protocol_version()
+        |> to_string()
+
+      assert %{
+               "data" => %{
+                 "version" => %{
+                   "code" => ^code_version,
+                   "protocol" => ^protocol_version,
+                   "transaction" => ^transaction_version
+                 }
+               }
+             } = json_response(conn, 200)
     end
   end
 


### PR DESCRIPTION
# Description

There is some use case to provide an API that returns versions running on a node.
The API could returns

code version (from mix.exs)
transaction version
protocol version

Fixes #701 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
The graphql was tested by querying the system and making sure that the values returned match.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
