### PR TITLE
compute node reward based on scheduler time

### DIFF
--- a/lib/archethic/reward.ex
+++ b/lib/archethic/reward.ex
@@ -34,6 +34,7 @@ defmodule Archethic.Reward do
   require Logger
 
   @unit_uco 100_000_000
+  @number_of_reward_occurences_per_month Utils.number_of_reward_occurences_per_month()
 
   @doc """
   Get rewards amount for validation nodes
@@ -47,8 +48,12 @@ defmodule Archethic.Reward do
       |> OracleChain.get_uco_price()
       |> Keyword.get(:usd)
 
-    trunc(50 / uco_usd_price / Calendar.ISO.days_in_month(date.year, date.month) * @unit_uco)
+    number_of_reward_occurences_per_month = number_of_reward_occurences_per_month()
+
+    trunc(50 / uco_usd_price / number_of_reward_occurences_per_month * @unit_uco)
   end
+
+  defp number_of_reward_occurences_per_month(), do: @number_of_reward_occurences_per_month
 
   @doc """
   Create a transaction for minting new rewards

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -848,13 +848,11 @@ defmodule Archethic.Utils do
       current_datetime
       |> Date.beginning_of_month()
       |> date_to_datetime_converter.(true)
-      |> IO.inspect(label: "start")
 
     end_of_month_datetime =
       current_datetime
       |> Date.end_of_month()
       |> date_to_datetime_converter.(false)
-      |> IO.inspect(label: "end")
 
     interval
     |> CronParser.parse!(true)

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -12,6 +12,8 @@ defmodule Archethic.Utils do
 
   alias Archethic.P2P.Node
 
+  alias Archethic.Reward.Scheduler, as: RewardScheduler
+
   import Bitwise
 
   @doc """
@@ -783,10 +785,10 @@ defmodule Archethic.Utils do
 
       iex> Utils.previous_date(%Crontab.CronExpression{second: [{:/, :*, 10}], extended: true}, ~U[2022-10-01 01:00:10Z])
       ~U[2022-10-01 01:00:00Z]
-      
+
       iex> Utils.previous_date(%Crontab.CronExpression{second: [{:/, :*, 10}], extended: true}, ~U[2022-10-01 01:00:10.100Z])
       ~U[2022-10-01 01:00:10Z]
-      
+
       iex> Utils.previous_date(%Crontab.CronExpression{second: [{:/, :*, 30}], extended: true}, ~U[2022-10-26 07:38:30.569648Z])
       ~U[2022-10-26 07:38:30Z]
   """
@@ -810,5 +812,58 @@ defmodule Archethic.Utils do
       |> Crontab.Scheduler.get_previous_run_date!(naive_date_from)
       |> DateTime.from_naive!("Etc/UTC")
     end
+  end
+
+  @doc """
+  Return the number of occurences for the cron job over the month
+
+  ## Examples
+
+      iex> Utils.number_of_reward_occurences_per_month("0 0 2 * * * *", ~N[2022-11-01 00:00:00.000000])
+      30
+
+      iex> Utils.number_of_reward_occurences_per_month("0 0 2 * * * *", ~N[2022-12-01 00:00:00.000000])
+      31
+
+      iex> Utils.number_of_reward_occurences_per_month("0 */5 * * * * *", ~N[2022-11-01 00:00:00.000000])
+      8640
+  """
+  @spec number_of_reward_occurences_per_month(String.t(), NaiveDateTime.t()) :: Integer.t()
+  def number_of_reward_occurences_per_month(
+        interval \\ Application.get_env(:archethic, RewardScheduler)[:interval],
+        current_datetime \\ NaiveDateTime.utc_now()
+      ) do
+    time = fn
+      true -> " 00:00:00Z"
+      false -> " 23:59:59Z"
+    end
+
+    date_to_datetime_converter = fn date, start_of_month? ->
+      time = time.(start_of_month?)
+
+      date
+      |> to_string()
+      |> Kernel.<>(time)
+      |> NaiveDateTime.from_iso8601!()
+    end
+
+    {start_of_month_datetime, end_of_month_datetime} =
+      current_datetime
+      |> then(
+        &{
+          &1
+          |> Date.beginning_of_month()
+          |> date_to_datetime_converter.(true),
+          &1
+          |> Date.end_of_month()
+          |> date_to_datetime_converter.(false)
+        }
+      )
+
+    interval
+    |> CronParser.parse!(true)
+    |> CronScheduler.get_next_run_dates(start_of_month_datetime)
+    |> Stream.take_while(&(NaiveDateTime.compare(&1, end_of_month_datetime) in [:lt]))
+    |> Enum.count()
   end
 end

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -848,11 +848,13 @@ defmodule Archethic.Utils do
       current_datetime
       |> Date.beginning_of_month()
       |> date_to_datetime_converter.(true)
+      |> IO.inspect(label: "start")
 
     end_of_month_datetime =
       current_datetime
-      |> Date.beginning_of_month()
+      |> Date.end_of_month()
       |> date_to_datetime_converter.(false)
+      |> IO.inspect(label: "end")
 
     interval
     |> CronParser.parse!(true)

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -828,7 +828,7 @@ defmodule Archethic.Utils do
       iex> Utils.number_of_reward_occurences_per_month("0 */5 * * * * *", ~N[2022-11-01 00:00:00.000000])
       8640
   """
-  @spec number_of_reward_occurences_per_month(String.t(), NaiveDateTime.t()) :: Integer.t()
+  @spec number_of_reward_occurences_per_month(String.t(), NaiveDateTime.t()) :: non_neg_integer()
   def number_of_reward_occurences_per_month(
         interval \\ Application.get_env(:archethic, RewardScheduler)[:interval],
         current_datetime \\ NaiveDateTime.utc_now()

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -841,24 +841,18 @@ defmodule Archethic.Utils do
     date_to_datetime_converter = fn date, start_of_month? ->
       time = time.(start_of_month?)
 
-      date
-      |> to_string()
-      |> Kernel.<>(time)
-      |> NaiveDateTime.from_iso8601!()
+      NaiveDateTime.from_iso8601!("#{date}#{time}")
     end
 
-    {start_of_month_datetime, end_of_month_datetime} =
+    start_of_month_datetime =
       current_datetime
-      |> then(
-        &{
-          &1
-          |> Date.beginning_of_month()
-          |> date_to_datetime_converter.(true),
-          &1
-          |> Date.end_of_month()
-          |> date_to_datetime_converter.(false)
-        }
-      )
+      |> Date.beginning_of_month()
+      |> date_to_datetime_converter.(true)
+
+    end_of_month_datetime =
+      current_datetime
+      |> Date.beginning_of_month()
+      |> date_to_datetime_converter.(false)
 
     interval
     |> CronParser.parse!(true)


### PR DESCRIPTION
# Description

Actually the node_reward transaction is sent based on a configurable interval. n production this interval is set to 1 transaction per day.
In the reward calculation we get the number of days of the current month and divide 50 by this number. This fit well for production configuration but if the node_reward transaction are sent in a different interval than once a day, the reward calculation is not accurate.

We should divide the monthly reward amount (currently 50$) by the number of interval in the current month

Note: 

I saw that sometimes it can take a little bit of time to compute, so I decided to do he computation in compile time to not slow down the execution.

Fixes #693 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The function that will provide the number of occurrences per month was tested with doctests, the reward function in itself is already tested I don't think we should test the calculus in itself but more the behaviour (which is already the case).

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
