### PR TITLE
Valid the authorized nodes in the node shared secret

### DIFF
--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -394,8 +394,6 @@ defmodule Archethic.Mining.PendingTransactionValidation do
          validation_time
        )
        when is_binary(secret) and byte_size(secret) > 0 and map_size(authorized_keys) > 0 do
-    nodes = P2P.authorized_nodes() ++ NodeRenewal.candidates()
-
     last_scheduling_date = SharedSecrets.get_last_scheduling_date(validation_time)
 
     genesis_address =
@@ -405,12 +403,15 @@ defmodule Archethic.Mining.PendingTransactionValidation do
     {last_address, _} = DB.get_last_chain_address(genesis_address)
 
     with {^last_address, _} <- DB.get_last_chain_address(genesis_address, last_scheduling_date),
-         {:ok, _, _} <-
-           NodeRenewal.decode_transaction_content(content),
+         {:ok, _, _} <- NodeRenewal.decode_transaction_content(content),
          true <-
-           Enum.all?(
-             Map.keys(authorized_keys),
-             &Utils.key_in_node_list?(nodes, &1)
+           authorized_keys
+           |> Map.keys()
+           |> Enum.sort()
+           |> then(
+             &(NodeRenewal.next_authorized_node_public_keys()
+               |> Enum.sort()
+               |> Kernel.==(&1))
            ) do
       :ok
     else

--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -402,17 +402,18 @@ defmodule Archethic.Mining.PendingTransactionValidation do
 
     {last_address, _} = DB.get_last_chain_address(genesis_address)
 
+    sorted_authorized_keys =
+      authorized_keys
+      |> Map.keys()
+      |> Enum.sort()
+
+    sorted_node_renewal_authorized_keys =
+      NodeRenewal.next_authorized_node_public_keys()
+      |> Enum.sort()
+
     with {^last_address, _} <- DB.get_last_chain_address(genesis_address, last_scheduling_date),
          {:ok, _, _} <- NodeRenewal.decode_transaction_content(content),
-         true <-
-           authorized_keys
-           |> Map.keys()
-           |> Enum.sort()
-           |> then(
-             &(NodeRenewal.next_authorized_node_public_keys()
-               |> Enum.sort()
-               |> Kernel.==(&1))
-           ) do
+         true <- sorted_authorized_keys == sorted_node_renewal_authorized_keys do
       :ok
     else
       :error ->

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -186,6 +186,9 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
         available?: true
       })
 
+      MockDB
+      |> expect(:get_latest_tps, fn -> 1000.0 end)
+
       tx =
         Transaction.new(
           :node_shared_secrets,
@@ -205,7 +208,9 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
                 secret: :crypto.strong_rand_bytes(32),
                 authorized_keys: %{
                   "node_key1" => "",
-                  "node_key2" => ""
+                  "node_key2" => "",
+                  # we started and connected this node in setup
+                  Crypto.last_node_public_key() => ""
                 }
               }
             ]

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -223,6 +223,53 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
       :persistent_term.put(:node_shared_secrets_gen_addr, nil)
     end
 
+    test "should return error when authorized nodes are not the same as the candidates" do
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        http_port: 4000,
+        first_public_key: "node_key1",
+        last_public_key: "node_key1",
+        available?: true
+      })
+
+      MockDB
+      |> expect(:get_latest_tps, fn -> 1000.0 end)
+
+      tx =
+        Transaction.new(
+          :node_shared_secrets,
+          %TransactionData{
+            content:
+              <<0, 0, 219, 82, 144, 35, 140, 59, 161, 231, 225, 145, 111, 203, 173, 197, 200, 150,
+                213, 145, 87, 209, 98, 25, 28, 148, 198, 77, 174, 48, 16, 117, 253, 15, 0, 0, 105,
+                113, 238, 128, 201, 90, 172, 230, 46, 99, 215, 130, 104, 26, 196, 222, 157, 89,
+                101, 74, 248, 245, 118, 36, 194, 213, 108, 141, 175, 248, 6, 120>>,
+            code: """
+            condition inherit: [
+              type: node_shared_secrets
+            ]
+            """,
+            ownerships: [
+              %Ownership{
+                secret: :crypto.strong_rand_bytes(32),
+                authorized_keys: %{
+                  # we started and connected this node in setup
+                  Crypto.last_node_public_key() => ""
+                }
+              }
+            ]
+          }
+        )
+
+      :persistent_term.put(:node_shared_secrets_gen_addr, Transaction.previous_address(tx))
+
+      assert {:error, "Invalid node shared secrets transaction authorized nodes"} =
+               PendingTransactionValidation.validate(tx)
+
+      :persistent_term.put(:node_shared_secrets_gen_addr, nil)
+    end
+
     test "should return :ok when a origin transaction is made" do
       P2P.add_and_connect_node(%Node{
         ip: {127, 0, 0, 1},

--- a/test/archethic/shared_secrets/node_renewal_test.exs
+++ b/test/archethic/shared_secrets/node_renewal_test.exs
@@ -13,8 +13,6 @@ defmodule Archethic.SharedSecrets.NodeRenewalTest do
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Ownership
 
-  alias Archethic.SharedSecrets.NodeRenewal
-
   import Mox
 
   test "new_node_shared_secrets_transaction/4 should create a new node shared secrets transaction" do


### PR DESCRIPTION
# Description

Actually during the pending validation, we control if the new authorized nodes in the node shared secret transaction are part of the candidate, but we do not verify if the selected ones are the good ones.
We should not verify if the new authorized nodes are part of the candidate, but directly verify that all authorized nodes are the same as the return of the function NodeRenewal.next_authorized_node_public_keys()


Fixes #694 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

we make sure that the authorized nodes in the transaction are exactly the same as the ones returned by 
next_authorized_node_public_keys function
# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
