### PR TITLE
Update last transaction address only if timestamp is greater

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_index.ex
+++ b/lib/archethic/db/embedded_impl/chain_index.ex
@@ -378,30 +378,12 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
         _ -> true
       end
 
-    write_last_chain_transaction(
-      write_last_chain_transaction?,
-      filename,
-      encoded_data,
-      genesis_address,
-      new_address,
-      unix_time
-    )
-  end
-
-  defp write_last_chain_transaction(false, _, _, _, _, _), do: :ok
-
-  defp write_last_chain_transaction(
-         true,
-         filename,
-         encoded_data,
-         genesis_address,
-         new_address,
-         unix_time
-       ) do
-    with :ok <- File.write!(filename, encoded_data, [:binary, :append]),
-         true <- :ets.insert(:archethic_db_last_index, {genesis_address, new_address, unix_time}) do
-      :ok
+    if write_last_chain_transaction? do
+      :ok = File.write!(filename, encoded_data, [:binary, :append])
+      true = :ets.insert(:archethic_db_last_index, {genesis_address, new_address, unix_time})
     end
+
+    :ok
   end
 
   @doc """

--- a/test/archethic/db/embedded_impl/chain_index_test.exs
+++ b/test/archethic/db/embedded_impl/chain_index_test.exs
@@ -89,11 +89,11 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndexTest do
       genesis_address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
 
       today = DateTime.utc_now()
-      yesterday = DateTime.add(today, -1, :day)
+      tomorrow = DateTime.add(today, 1, :day)
 
       ChainIndex.add_tx(tx_address_1, genesis_address, 100, db_path)
-      ChainIndex.set_last_chain_address(genesis_address, tx_address_1, yesterday, db_path)
-      ChainIndex.set_last_chain_address(genesis_address, tx_address_2, today, db_path)
+      ChainIndex.set_last_chain_address(genesis_address, tx_address_1, today, db_path)
+      ChainIndex.set_last_chain_address(genesis_address, tx_address_2, tomorrow, db_path)
 
       assert {^tx_address_2, _} = ChainIndex.get_last_chain_address(genesis_address, db_path)
     end

--- a/test/archethic/db/embedded_impl/chain_index_test.exs
+++ b/test/archethic/db/embedded_impl/chain_index_test.exs
@@ -62,4 +62,40 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndexTest do
       assert false == ChainIndex.transaction_exists?(:crypto.strong_rand_bytes(32), db_path)
     end
   end
+
+  describe "set_last_chain_address/4" do
+    test "should not update last transaction only if timestamp is lesser", %{db_path: db_path} do
+      {:ok, _pid} = ChainIndex.start_link(path: db_path)
+
+      tx_address_1 = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+      tx_address_2 = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+      genesis_address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+      today = DateTime.utc_now()
+      yesterday = DateTime.add(today, -1, :day)
+
+      ChainIndex.add_tx(tx_address_1, genesis_address, 100, db_path)
+      ChainIndex.set_last_chain_address(genesis_address, tx_address_1, today, db_path)
+      ChainIndex.set_last_chain_address(genesis_address, tx_address_2, yesterday, db_path)
+
+      assert {^tx_address_1, _} = ChainIndex.get_last_chain_address(genesis_address, db_path)
+    end
+
+    test "should update last transaction if timestamp is greater", %{db_path: db_path} do
+      {:ok, _pid} = ChainIndex.start_link(path: db_path)
+
+      tx_address_1 = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+      tx_address_2 = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+      genesis_address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+      today = DateTime.utc_now()
+      yesterday = DateTime.add(today, -1, :day)
+
+      ChainIndex.add_tx(tx_address_1, genesis_address, 100, db_path)
+      ChainIndex.set_last_chain_address(genesis_address, tx_address_1, yesterday, db_path)
+      ChainIndex.set_last_chain_address(genesis_address, tx_address_2, today, db_path)
+
+      assert {^tx_address_2, _} = ChainIndex.get_last_chain_address(genesis_address, db_path)
+    end
+  end
 end

--- a/test/archethic/db/embedded_impl_test.exs
+++ b/test/archethic/db/embedded_impl_test.exs
@@ -691,7 +691,7 @@ defmodule Archethic.DB.EmbeddedTest do
           seed: seed,
           index: 1,
           type: :transfer,
-          timestamp: ~U[2020-03-30 10:13:00Z]
+          timestamp: ~U[2020-03-30 10:14:00Z]
         )
 
       tx2 =
@@ -699,7 +699,7 @@ defmodule Archethic.DB.EmbeddedTest do
           seed: seed,
           index: 2,
           type: :transfer,
-          timestamp: ~U[2020-04-30 10:12:00Z]
+          timestamp: ~U[2020-04-30 10:15:00Z]
         )
 
       tx3 =
@@ -707,7 +707,7 @@ defmodule Archethic.DB.EmbeddedTest do
           seed: seed,
           index: 3,
           type: :transfer,
-          timestamp: ~U[2020-04-30 10:11:00Z]
+          timestamp: ~U[2020-04-30 10:16:00Z]
         )
 
       tx4 =
@@ -715,7 +715,7 @@ defmodule Archethic.DB.EmbeddedTest do
           seed: seed,
           index: 4,
           type: :transfer,
-          timestamp: ~U[2020-04-30 10:11:00Z]
+          timestamp: ~U[2020-04-30 10:17:00Z]
         )
 
       txn_list = [tx0, tx1, tx2, tx3, tx4]


### PR DESCRIPTION
# Description

Actually there is 2 way to set the last address for a chain

from the replication
from the notification of a last address
In both way, if the current last address in the DB has a greater timestamp than the one received, the last address is replaced by the new one. Which is not correct.

 before setting the new last address, we should control that the new timestamp is greater than the one already stored

Fixes #712 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested 2 cases: 

- we should not update last transaction only if timestamp is lesser
- we should update last transaction if timestamp is greater

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
