### PR TITLE
Skip replication if there is a (cross)validation error

### DIFF
--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -644,7 +644,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
         }
       )
       when from_state in [:cross_validator, :wait_cross_validation_stamps] do
-    case ValidationContext.get_error_as_atom(context) do
+    case ValidationContext.get_first_error(context) do
       nil ->
         Logger.info("Start replication",
           transaction_address: Base.encode16(tx_address),

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -502,11 +502,8 @@ defmodule Archethic.Mining.DistributedWorkflow do
           transaction_type: tx.type
         )
 
-        next_events = [
-          {:next_event, :internal, {:notify_error, :timeout}}
-        ]
-
-        {:keep_state_and_data, next_events}
+        notify_error(:timeout, data)
+        :stop
 
       _ ->
         new_context =
@@ -580,7 +577,12 @@ defmodule Archethic.Mining.DistributedWorkflow do
         {:add_cross_validation_stamp, cross_validation_stamp = %CrossValidationStamp{}},
         :wait_cross_validation_stamps,
         data = %{
-          context: context = %ValidationContext{transaction: tx}
+          context:
+            context = %ValidationContext{
+              validation_stamp: validation_stamp,
+              cross_validation_stamps: cross_validation_stamps,
+              transaction: tx
+            }
         }
       ) do
     Logger.info("Add cross validation stamp",
@@ -589,60 +591,42 @@ defmodule Archethic.Mining.DistributedWorkflow do
     )
 
     new_context = ValidationContext.add_cross_validation_stamp(context, cross_validation_stamp)
+    new_data = %{data | context: new_context}
 
     if ValidationContext.enough_cross_validation_stamps?(new_context) do
       if ValidationContext.atomic_commitment?(new_context) do
-        {:next_state, :replication, %{data | context: new_context}}
+        {:next_state, :replication, new_data}
       else
-        next_events = [
-          {:next_event, :internal, {:notify_error, :consensus_not_reached}}
-        ]
+        Logger.debug("Validation stamp: #{inspect(validation_stamp, limit: :infinity)}",
+          transaction_address: Base.encode16(tx.address),
+          transaction_type: tx.type
+        )
 
-        {:next_state, :consensus_not_reached, %{data | context: new_context}, next_events}
+        Logger.debug(
+          "Cross validation stamps: #{inspect(cross_validation_stamps, limit: :infinity)}",
+          transaction_address: Base.encode16(tx.address),
+          transaction_type: tx.type
+        )
+
+        Logger.error("Consensus not reached",
+          transaction_address: Base.encode16(tx.address),
+          transaction_type: tx.type
+        )
+
+        MaliciousDetection.start_link(context)
+        notify_error(:consensus_not_reached, new_data)
+        :stop
       end
     else
-      {:keep_state, %{data | context: new_context}}
+      {:keep_state, new_data}
     end
-  end
-
-  def handle_event(
-        :enter,
-        :wait_cross_validation_stamps,
-        :consensus_not_reached,
-        _data = %{
-          context:
-            context = %ValidationContext{
-              transaction: tx,
-              cross_validation_stamps: cross_validation_stamps,
-              validation_stamp: validation_stamp
-            }
-        }
-      ) do
-    Logger.debug("Validation stamp: #{inspect(validation_stamp, limit: :infinity)}",
-      transaction_address: Base.encode16(tx.address),
-      transaction_type: tx.type
-    )
-
-    Logger.debug("Cross validation stamps: #{inspect(cross_validation_stamps, limit: :infinity)}",
-      transaction_address: Base.encode16(tx.address),
-      transaction_type: tx.type
-    )
-
-    Logger.error("Consensus not reached",
-      transaction_address: Base.encode16(tx.address),
-      transaction_type: tx.type
-    )
-
-    MaliciousDetection.start_link(context)
-
-    :keep_state_and_data
   end
 
   def handle_event(
         :enter,
         from_state,
         :replication,
-        _data = %{
+        data = %{
           context:
             context = %ValidationContext{
               transaction: %Transaction{address: tx_address, type: type}
@@ -650,13 +634,22 @@ defmodule Archethic.Mining.DistributedWorkflow do
         }
       )
       when from_state in [:cross_validator, :wait_cross_validation_stamps] do
-    Logger.info("Start replication",
-      transaction_address: Base.encode16(tx_address),
-      transaction_type: type
-    )
+    case ValidationContext.get_error_as_atom(context) do
+      nil ->
+        Logger.info("Start replication",
+          transaction_address: Base.encode16(tx_address),
+          transaction_type: type
+        )
 
-    request_replication(context)
-    :keep_state_and_data
+        request_replication(context)
+        :keep_state_and_data
+
+      err ->
+        Logger.info("Skipped replication because validation failed", err: err)
+
+        notify_error(err, data)
+        :stop
+    end
   end
 
   def handle_event(
@@ -766,19 +759,15 @@ defmodule Archethic.Mining.DistributedWorkflow do
         :info,
         {:replication_error, reason},
         :replication,
-        _data = %{context: %ValidationContext{transaction: tx}}
+        data = %{context: %ValidationContext{transaction: tx}}
       ) do
     Logger.error("Replication error - #{inspect(reason)}",
       transaction_address: Base.encode16(tx.address),
       transaction_type: tx.type
     )
 
-    next_events = [
-      {:next_event, :internal, {:notify_error, reason}}
-    ]
-
-    {:keep_state_and_data, next_events}
-    # :stop
+    notify_error(reason, data)
+    :stop
   end
 
   def handle_event(
@@ -803,13 +792,8 @@ defmodule Archethic.Mining.DistributedWorkflow do
           transaction_type: tx.type
         )
 
-        next_events = [
-          {:next_event, :internal, {:notify_error, :timeout}}
-        ]
-
-        {:keep_state_and_data, next_events}
-
-      # :stop
+        notify_error(:timeout, data)
+        :stop
 
       _ ->
         nb_cross_validation_nodes = length(next_cross_validation_nodes)
@@ -837,71 +821,14 @@ defmodule Archethic.Mining.DistributedWorkflow do
         {:timeout, :stop_timeout},
         :any,
         _state,
-        _data = %{context: %ValidationContext{transaction: tx}}
+        data = %{context: %ValidationContext{transaction: tx}}
       ) do
     Logger.warning("Timeout reached during mining",
       transaction_type: tx.type,
       transaction_address: Base.encode16(tx.address)
     )
 
-    next_events = [
-      {:next_event, :internal, {:notify_error, :timeout}}
-    ]
-
-    {:keep_state_and_data, next_events}
-  end
-
-  def handle_event(
-        :internal,
-        {:notify_error, reason},
-        _,
-        _data = %{
-          context:
-            _context = %ValidationContext{
-              welcome_node: welcome_node = %Node{},
-              transaction: %Transaction{address: tx_address},
-              pending_transaction_error_detail: pending_error_detail
-            }
-        }
-      ) do
-    {error_context, error_reason} =
-      case reason do
-        :invalid_pending_transaction ->
-          {:invalid_transaction, pending_error_detail}
-
-        :invalid_inherit_constraints ->
-          {:invalid_transaction, "Inherit constraints not respected"}
-
-        :insufficient_funds ->
-          {:invalid_transaction, "Insufficient funds"}
-
-        :invalid_proof_of_work ->
-          {:invalid_transaction, "Invalid origin signature"}
-
-        reason ->
-          {:network_issue, reason |> Atom.to_string() |> String.replace("_", " ")}
-      end
-
-    Logger.warning("Invalid transaction #{inspect(error_reason)}",
-      transaction_address: Base.encode16(tx_address)
-    )
-
-    Logger.debug("Notify error back to the welcome node",
-      transaction_address: Base.encode16(tx_address)
-    )
-
-    # Notify error to the welcome node
-    message = %ValidationError{context: error_context, reason: error_reason, address: tx_address}
-
-    Task.Supervisor.async_nolink(Archethic.TaskSupervisor, fn ->
-      P2P.send_message(
-        welcome_node,
-        message
-      )
-
-      :ok
-    end)
-
+    notify_error(:timeout, data)
     :stop
   end
 
@@ -1023,5 +950,57 @@ defmodule Archethic.Mining.DistributedWorkflow do
     }
 
     P2P.broadcast_message(storage_nodes, message)
+  end
+
+  defp notify_error(reason, %{
+         context: %ValidationContext{
+           welcome_node: welcome_node = %Node{},
+           transaction: %Transaction{address: tx_address},
+           pending_transaction_error_detail: pending_error_detail
+         }
+       }) do
+    {error_context, error_reason} =
+      case reason do
+        :invalid_pending_transaction ->
+          {:invalid_transaction, pending_error_detail}
+
+        :invalid_inherit_constraints ->
+          {:invalid_transaction, "Inherit constraints not respected"}
+
+        :insufficient_funds ->
+          {:invalid_transaction, "Insufficient funds"}
+
+        :invalid_proof_of_work ->
+          {:invalid_transaction, "Invalid origin signature"}
+
+        :invalid_validation_stamp ->
+          {:network_issue, "Validation error"}
+
+        :invalid_cross_validation_stamp ->
+          {:network_issue, "Cross validation error"}
+
+        reason ->
+          {:network_issue, reason |> Atom.to_string() |> String.replace("_", " ")}
+      end
+
+    Logger.warning("Invalid transaction #{inspect(error_reason)}",
+      transaction_address: Base.encode16(tx_address)
+    )
+
+    Logger.debug("Notify error back to the welcome node",
+      transaction_address: Base.encode16(tx_address)
+    )
+
+    # Notify error to the welcome node
+    message = %ValidationError{context: error_context, reason: error_reason, address: tx_address}
+
+    Task.Supervisor.async_nolink(Archethic.TaskSupervisor, fn ->
+      P2P.send_message(
+        welcome_node,
+        message
+      )
+
+      :ok
+    end)
   end
 end

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -629,7 +629,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
     MaliciousDetection.start_link(context)
 
     notify_error(:consensus_not_reached, data)
-    :keep_state_and_data
+    :stop
   end
 
   def handle_event(
@@ -982,12 +982,6 @@ defmodule Archethic.Mining.DistributedWorkflow do
 
         :invalid_proof_of_work ->
           {:invalid_transaction, "Invalid origin signature"}
-
-        :invalid_validation_stamp ->
-          {:network_issue, "Validation error"}
-
-        :invalid_cross_validation_stamp ->
-          {:network_issue, "Cross validation error"}
 
         reason ->
           {:network_issue, reason |> Atom.to_string() |> String.replace("_", " ")}

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1261,4 +1261,25 @@ defmodule Archethic.Mining.ValidationContext do
     |> Enum.map(&Enum.at(storage_nodes, &1))
     |> Enum.reject(&Utils.key_in_node_list?(chain_storage_nodes, &1.first_public_key))
   end
+
+  @spec get_error_as_atom(t()) :: atom()
+  def get_error_as_atom(ctx = %__MODULE__{}) do
+    case ctx.validation_stamp.error do
+      nil ->
+        inconsistencies =
+          ctx.cross_validation_stamps
+          |> Enum.flat_map(& &1.inconsistencies)
+
+        case inconsistencies do
+          [] ->
+            nil
+
+          _ ->
+            :invalid_cross_validation_stamp
+        end
+
+      _ ->
+        :invalid_validation_stamp
+    end
+  end
 end

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1262,8 +1262,11 @@ defmodule Archethic.Mining.ValidationContext do
     |> Enum.reject(&Utils.key_in_node_list?(chain_storage_nodes, &1.first_public_key))
   end
 
-  @spec get_error_as_atom(t()) :: atom()
-  def get_error_as_atom(ctx = %__MODULE__{}) do
+  @doc """
+  Get the first available error or nil
+  """
+  @spec get_first_error(t()) :: atom()
+  def get_first_error(ctx = %__MODULE__{}) do
     case ctx.validation_stamp.error do
       nil ->
         inconsistencies =

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1274,12 +1274,12 @@ defmodule Archethic.Mining.ValidationContext do
           [] ->
             nil
 
-          _ ->
-            :invalid_cross_validation_stamp
+          [first_error | _] ->
+            first_error
         end
 
-      _ ->
-        :invalid_validation_stamp
+      err ->
+        err
     end
   end
 end

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -717,6 +717,46 @@ defmodule Archethic.Mining.ValidationContext do
           resolved_addresses: resolved_addresses
         }
       ) do
+    resolved_recipients =
+      Enum.reduce(resolved_addresses, [], fn {to, resolved}, acc ->
+        if to in recipients do
+          [resolved | acc]
+        else
+          acc
+        end
+      end)
+
+    ledger_operations = get_ledger_operations(context)
+
+    validation_stamp =
+      %ValidationStamp{
+        protocol_version: Mining.protocol_version(),
+        timestamp: validation_time,
+        proof_of_work: do_proof_of_work(tx),
+        proof_of_integrity: TransactionChain.proof_of_integrity([tx, prev_tx]),
+        proof_of_election: Election.validation_nodes_election_seed_sorting(tx, validation_time),
+        ledger_operations: ledger_operations,
+        recipients: resolved_recipients,
+        error:
+          get_validation_error(
+            prev_tx,
+            tx,
+            ledger_operations,
+            unspent_outputs,
+            valid_pending_transaction?
+          )
+      }
+      |> ValidationStamp.sign()
+
+    %{context | validation_stamp: validation_stamp}
+  end
+
+  defp get_ledger_operations(%__MODULE__{
+         transaction: tx,
+         unspent_outputs: unspent_outputs,
+         validation_time: validation_time,
+         resolved_addresses: resolved_addresses
+       }) do
     usd_price =
       validation_time
       |> OracleChain.get_uco_price()
@@ -750,51 +790,49 @@ defmodule Archethic.Mining.ValidationContext do
           acc
       end)
 
-    resolved_recipients =
-      Enum.reduce(resolved_addresses, [], fn {to, resolved}, acc ->
-        if to in recipients do
-          [resolved | acc]
-        else
-          acc
-        end
-      end)
+    %LedgerOperations{
+      fee: fee,
+      transaction_movements: resolved_movements
+    }
+    |> LedgerOperations.from_transaction(tx, validation_time)
+    |> LedgerOperations.consume_inputs(
+      tx.address,
+      unspent_outputs,
+      validation_time |> DateTime.truncate(:millisecond)
+    )
+  end
 
-    error =
-      cond do
-        chain_error?(prev_tx, tx) ->
-          :invalid_inherit_constraints
+  @spec get_validation_error(
+          nil | Transaction.t(),
+          Transaction.t(),
+          LedgerOperations.t(),
+          list(UnspentOutput.t()),
+          boolean()
+        ) :: nil | ValidationStamp.error()
+  defp get_validation_error(
+         prev_tx,
+         tx,
+         ledger_operations,
+         unspent_outputs,
+         valid_pending_transaction?
+       ) do
+    cond do
+      chain_error?(prev_tx, tx) ->
+        :invalid_inherit_constraints
 
-        valid_pending_transaction? ->
-          nil
+      has_insufficient_funds?(ledger_operations, unspent_outputs) ->
+        :insufficient_funds
 
-        true ->
-          :invalid_pending_transaction
-      end
+      not valid_pending_transaction? ->
+        :invalid_pending_transaction
 
-    validation_stamp =
-      %ValidationStamp{
-        protocol_version: Mining.protocol_version(),
-        timestamp: validation_time,
-        proof_of_work: do_proof_of_work(tx),
-        proof_of_integrity: TransactionChain.proof_of_integrity([tx, prev_tx]),
-        proof_of_election: Election.validation_nodes_election_seed_sorting(tx, validation_time),
-        ledger_operations:
-          %LedgerOperations{
-            fee: fee,
-            transaction_movements: resolved_movements
-          }
-          |> LedgerOperations.from_transaction(tx, validation_time)
-          |> LedgerOperations.consume_inputs(
-            tx.address,
-            unspent_outputs,
-            validation_time |> DateTime.truncate(:millisecond)
-          ),
-        recipients: resolved_recipients,
-        error: error
-      }
-      |> ValidationStamp.sign()
+      true ->
+        nil
+    end
+  end
 
-    %{context | validation_stamp: validation_stamp}
+  defp has_insufficient_funds?(ledger_ops, inputs) do
+    not LedgerOperations.sufficient_funds?(ledger_ops, inputs)
   end
 
   defp chain_error?(nil, _tx = %Transaction{}), do: false
@@ -1055,24 +1093,25 @@ defmodule Archethic.Mining.ValidationContext do
     ) == fee
   end
 
-  defp valid_stamp_error?(stamp = %ValidationStamp{error: error}, %__MODULE__{
-         transaction: tx,
-         previous_transaction: prev_tx,
-         valid_pending_transaction?: valid_pending_transaction?
-       }) do
-    validated_tx = %{tx | validation_stamp: stamp}
+  defp valid_stamp_error?(
+         stamp = %ValidationStamp{error: error},
+         context = %__MODULE__{
+           transaction: tx,
+           previous_transaction: prev_tx,
+           valid_pending_transaction?: valid_pending_transaction?,
+           unspent_outputs: unspent_outputs
+         }
+       ) do
+    validated_context = %{context | transaction: %{tx | validation_stamp: stamp}}
 
     expected_error =
-      cond do
-        chain_error?(prev_tx, validated_tx) ->
-          :invalid_inherit_constraints
-
-        valid_pending_transaction? ->
-          nil
-
-        true ->
-          :invalid_pending_transaction
-      end
+      get_validation_error(
+        prev_tx,
+        tx,
+        get_ledger_operations(validated_context),
+        unspent_outputs,
+        valid_pending_transaction?
+      )
 
     error == expected_error
   end

--- a/lib/archethic/transaction_chain/transaction/validation_stamp.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp.ex
@@ -21,7 +21,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
     error: nil
   ]
 
-  @type error :: :invalid_pending_transaction | :invalid_inherit_constraints
+  @type error :: :invalid_pending_transaction | :invalid_inherit_constraints | :insufficient_funds
 
   @typedoc """
   Validation performed by a coordinator:
@@ -426,8 +426,10 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
   defp serialize_error(nil), do: 0
   defp serialize_error(:invalid_pending_transaction), do: 1
   defp serialize_error(:invalid_inherit_constraints), do: 2
+  defp serialize_error(:insufficient_funds), do: 3
 
   defp deserialize_error(0), do: nil
   defp deserialize_error(1), do: :invalid_pending_transaction
   defp deserialize_error(2), do: :invalid_inherit_constraints
+  defp deserialize_error(3), do: :insufficient_funds
 end

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -1050,11 +1050,11 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
         %CrossValidationStamp{
           signature:
             Crypto.sign(
-              [ValidationStamp.serialize(context.validation_stamp), <<1>>],
+              [ValidationStamp.serialize(context.validation_stamp), <<>>],
               elem(@publickey1, 1)
             ),
           node_public_key: elem(@publickey1, 0),
-          inconsistencies: [:signature]
+          inconsistencies: []
         }
       )
 
@@ -1063,11 +1063,11 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
         %CrossValidationStamp{
           signature:
             Crypto.sign(
-              [ValidationStamp.serialize(context.validation_stamp), <<1>>],
+              [ValidationStamp.serialize(context.validation_stamp), <<>>],
               elem(@publickey2, 1)
             ),
           node_public_key: elem(@publickey2, 0),
-          inconsistencies: [:signature]
+          inconsistencies: []
         }
       )
 

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -1074,6 +1074,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       assert_receive :validation_error
       refute_receive :ack_replication
       refute_receive :replication_done
+      refute Process.alive?(coordinator_pid)
     end
 
     test "should not replicate if there is a cross validation error", %{tx: tx} do
@@ -1145,6 +1146,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       assert_receive :validation_error
       refute_receive :ack_replication
       refute_receive :replication_done
+      refute Process.alive?(coordinator_pid)
     end
   end
 

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -41,6 +41,14 @@ defmodule Archethic.Mining.ValidationContextTest do
         |> ValidationContext.cross_validate()
     end
 
+    test "should get inconsistency when the user has not enough funds" do
+      validation_context =
+        %ValidationContext{create_context() | unspent_outputs: []}
+        |> ValidationContext.create_validation_stamp()
+
+      assert validation_context.validation_stamp.error == :insufficient_funds
+    end
+
     test "should get inconsistency when the validation stamp signature is invalid" do
       validation_context = create_context()
 


### PR DESCRIPTION
# Description

In the distributed workflow, if there is an error in the validation stamp or in the cross validation stamp, then do not send the replication messages to the storage nodes, and directly notify the error to the welcome node.

`notify_error` used to be an internal event but we had to change this to a function to be able to use it from the `replication.state_enter` callback.

Fixes #696 

**IMPORTANT NOTE:** The scenario `:insufficient_funds` is not checked in the distributed_workflow. This means a transaction from an address with insufficient funds will not mark the stamps as invalid and the transaction will be replicated to the storage nodes where they'll be discarded.

- [x] check for insufficient funds

## Type of change

- Bug fix 

# How Has This Been Tested?

Tests added to the suite.
Scenario tested on the transaction builder (with 3 nodes): Creation of a token with an invalid JSON. You should see the usual error and you should see a "skipped replication" in the logs.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
