### PR TITLE
Connection's reconnect is asynchronous

### DIFF
--- a/test/archethic/p2p/client/connection_test.exs
+++ b/test/archethic/p2p/client/connection_test.exs
@@ -17,6 +17,10 @@ defmodule Archethic.P2P.Client.ConnectionTest do
         node_public_key: "key1"
       )
 
+    assert {:initializing, _} = :sys.get_state(pid)
+
+    Process.sleep(10)
+
     assert {{:connected, _socket}, %{request_id: 0, messages: %{}}} = :sys.get_state(pid)
   end
 
@@ -350,6 +354,9 @@ defmodule Archethic.P2P.Client.ConnectionTest do
           node_public_key: "key1"
         )
 
+      assert {:initializing, _} = :sys.get_state(pid)
+      Process.sleep(10)
+
       assert {{:connected, _socket}, %{availability_timer: {start, 0}}} = :sys.get_state(pid)
       assert start != nil
     end
@@ -414,6 +421,9 @@ defmodule Archethic.P2P.Client.ConnectionTest do
           port: 3000,
           node_public_key: Crypto.first_node_public_key()
         )
+
+      assert {:initializing, _} = :sys.get_state(pid)
+      Process.sleep(10)
 
       assert {{:connected, _socket}, %{availability_timer: {start, 0}}} = :sys.get_state(pid)
       assert start != nil


### PR DESCRIPTION
# Description

Reconnect workflow used to be synchronous, which meant all incoming messages were queued to be processed later, and the callers had to wait until eventually they receive a :timeout. 

This PR changed the reconnect workflow to be asynchronous, so the callers can get a :closed error message without delay.

**NOTE**: the first connection is still asynchronous to be able to keep existing code.

Fixes #710

## Type of change

- Bug fix

# How Has This Been Tested?

Case added to the unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
