### PR TITLE
GraphQL: return token.ownerships

### DIFF
--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -46,6 +46,7 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
          {:ok,
           {:ok,
            definition = %{
+             "ownerships" => ownerships,
              "supply" => supply,
              "type" => type
            }}} <- Task.yield(t2) do
@@ -75,6 +76,7 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
          decimals: decimals,
          properties: properties,
          collection: collection,
+         ownerships: ownerships,
          id: token_id
        }}
     else
@@ -99,11 +101,15 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
 
   defp get_transaction_content(address) do
     case Archethic.search_transaction(address) do
-      {:ok, %Transaction{data: %TransactionData{content: content}, type: type}}
+      {:ok,
+       %Transaction{data: %TransactionData{content: content, ownerships: ownerships}, type: type}}
       when type in [:token, :mint_rewards] ->
         case Jason.decode(content) do
-          {:ok, map} -> {:ok, map}
-          _ -> {:error, :decode_error}
+          {:ok, map} ->
+            {:ok, map |> Map.put("ownerships", ownerships)}
+
+          _ ->
+            {:error, :decode_error}
         end
 
       _ ->

--- a/lib/archethic_web/graphql_schema/transaction_type.ex
+++ b/lib/archethic_web/graphql_schema/transaction_type.ex
@@ -243,6 +243,7 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
   - decimals: Number of decimals of the token
   - properties: Properties of the token (if any)
   - collection: List of properties for a collection (if any)
+  - ownerships: authorization/delegations containing list of secrets and their authorized public keys to proof the ownership
   - id: Unique identification of the token on the chain
   """
   object :token do
@@ -253,6 +254,7 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
     field(:type, :string)
     field(:properties, :token_properties)
     field(:collection, list_of(:token_properties))
+    field(:ownerships, list_of(:ownership))
     field(:decimals, :integer)
     field(:id, :string)
   end

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -151,7 +151,7 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
   end
 
   describe "query: token" do
-    test "should retrieve the first page of transaction stored locally", %{conn: conn} do
+    test "should return the ownerships", %{conn: conn} do
       token_addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
 
       MockClient


### PR DESCRIPTION
# Description

Add the possibility to retrieve the token's ownerships. Similar to `transaction.data.ownerships`
Fix #714 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on a local node
![Screenshot 2022-11-29 at 11-11-09 GraphiQL Workspace](https://user-images.githubusercontent.com/74045243/204503626-2db4d37b-ad06-4ea6-876f-bc6269e78365.png)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
