### PR TITLE
oracle live should only update oracle summary on first page

### DIFF
--- a/lib/archethic_web/live/chains/oracle_live.ex
+++ b/lib/archethic_web/live/chains/oracle_live.ex
@@ -142,20 +142,25 @@ defmodule ArchethicWeb.OracleChainLive do
 
   def handle_info(
         {:new_transaction, address, :oracle_summary, timestamp},
-        socket
+        socket = %{assigns: %{current_date_page: current_page}}
       ) do
-    new_assign =
-      socket
-      |> update(:dates, &[OracleChain.next_summary_date(timestamp) | &1])
-      |> update(
-        :transactions,
-        &[
-          %{address: address, type: :oracle_summary, timestamp: timestamp} | &1
-        ]
-      )
-      |> assign(:summary_passed?, true)
+    if current_page == 1 do
+      # Only update the oracle summary when you are on the first page
+      new_assign =
+        socket
+        |> update(:dates, &[OracleChain.next_summary_date(timestamp) | &1])
+        |> update(
+          :transactions,
+          &[
+            %{address: address, type: :oracle_summary, timestamp: timestamp} | &1
+          ]
+        )
+        |> assign(:summary_passed?, true)
 
-    {:noreply, new_assign}
+      {:noreply, new_assign}
+    else
+      {:noreply, socket}
+    end
   end
 
   defp get_oracle_dates do


### PR DESCRIPTION
# Description

In the explorer there is a view of all the oracle transactions. On the first page, it add the new oracle and oracle summary transaction in the displayed list.
But if we are on a different page (past transactions) the new oracle summary transactions are added in the displayed list while it should not.

Fixes #699 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The whole liveview is not tested for now and as we are planning to change it very soon it's not worth it to add tests for now.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
