### PR TITLE
Fix GraphQL transaction_chain returning more than 10 tx

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -286,10 +286,10 @@ defmodule Archethic do
 
       remote_chain =
         if paging_address != address do
-          address
-          |> TransactionChain.stream_remotely(nodes, paging_address)
-          |> Enum.to_list()
-          |> List.flatten()
+          case TransactionChain.fetch_transaction_chain(nodes, address, paging_address) do
+            {:ok, transactions} -> transactions
+            {:error, _} -> []
+          end
         else
           []
         end

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -705,7 +705,7 @@ defmodule Archethic.TransactionChain do
   end
 
   defp do_stream_chain(nodes, address, paging_state, size) do
-    case fetch_transaction_chain(nodes, address, paging_state) do
+    case do_fetch_transaction_chain(nodes, address, paging_state) do
       {transactions, false, _} ->
         {[transactions], {:end, size + length(transactions)}}
 
@@ -714,11 +714,19 @@ defmodule Archethic.TransactionChain do
     end
   end
 
-  defp fetch_transaction_chain(
-         nodes,
-         address,
-         paging_state
-       ) do
+  @doc """
+  Get 10 transactions in a chain after a paging address
+  """
+  @spec fetch_transaction_chain(list(Node.t()), binary(), binary()) ::
+          {:ok, list(Transaction.t())} | {:error, :network_issue}
+  def fetch_transaction_chain(nodes, address, paging_address) do
+    case do_fetch_transaction_chain(nodes, address, paging_address) do
+      {transactions, _more?, _paging_state} -> {:ok, transactions}
+      error -> error
+    end
+  end
+
+  defp do_fetch_transaction_chain(nodes, address, paging_state) do
     conflict_resolver = fn results ->
       results
       |> Enum.sort(
@@ -740,8 +748,8 @@ defmodule Archethic.TransactionChain do
        %TransactionList{transactions: transactions, more?: more?, paging_state: paging_state}} ->
         {transactions, more?, paging_state}
 
-      {:error, :network_issue} ->
-        raise "Cannot fetch transaction chain"
+      error ->
+        error
     end
   end
 


### PR DESCRIPTION
# Description

This issue fix a bug on graphQL API when a user request a transaction chain, it was return more than 10 transactions

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a chain with more than 10 transactions, the graphql request 
```
{
  transactionChain(address: "last_chain_address") {
    address
  }
}
```
should return then 10 first transactions

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
