### PR TITLE
Fix notify last address

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_index.ex
+++ b/lib/archethic/db/embedded_impl/chain_index.ex
@@ -402,7 +402,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
             unix_time = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
             search_last_address_until(genesis_address, unix_time, db_path) ||
-              {address, DateTime.utc_now()}
+              {address, DateTime.from_unix!(0, :millisecond)}
 
           [{_, last_address, last_time}] ->
             {last_address, DateTime.from_unix!(last_time, :millisecond)}
@@ -416,7 +416,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
             unix_time = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
             search_last_address_until(address, unix_time, db_path) ||
-              {address, DateTime.utc_now()}
+              {address, DateTime.from_unix!(0, :millisecond)}
 
           [{_, last_address, last_time}] ->
             {last_address, DateTime.from_unix!(last_time, :millisecond)}

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -1691,10 +1691,9 @@ defmodule Archethic.P2P.Message do
         },
         _
       ) do
-    with {local_last_address, local_last_timestamp} <-
+    with {local_last_address, _} <-
            TransactionChain.get_last_address(genesis_address),
-         true <- local_last_address != last_address,
-         :gt <- DateTime.compare(timestamp, local_last_timestamp) do
+         true <- local_last_address != last_address do
       TransactionChain.register_last_address(genesis_address, last_address, timestamp)
 
       # Stop potential previous smart contract

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -350,6 +350,7 @@ defmodule Archethic.Replication do
         # Send a message to all the previous storage nodes
         address
         |> TransactionChain.list_chain_addresses()
+        |> Stream.concat([{genesis_address, nil}])
         |> Stream.flat_map(fn {address, _} ->
           Election.chain_storage_nodes(address, P2P.authorized_and_available_nodes())
         end)


### PR DESCRIPTION
# Description

`NotifyLastTransactionAddress` message is not sending the notification for the genesis address of a chain. But in multiple case we want to get the last address of a chain from it's genesis address.

- Added genesis address in the address list of the chain
- Updated the default timestamp when requesting last_address from a chain without transaction

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Run 5 nodes with updated sharding parameter (use patch in #671)
- Use faucet multiple time, it should work each time after the first transaction

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
