### PR TITLE
Separate chain and io transaction in DB storage

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -11,8 +11,6 @@ defmodule Archethic do
   alias __MODULE__.P2P
   alias __MODULE__.P2P.Node
 
-  alias __MODULE__.DB
-
   alias __MODULE__.P2P.Message.Balance
   alias __MODULE__.P2P.Message.GetBalance
   alias __MODULE__.P2P.Message.NewTransaction
@@ -275,7 +273,7 @@ defmodule Archethic do
     try do
       {local_chain, paging_address} =
         with true <- paging_address != nil,
-             true <- DB.transaction_exists?(paging_address),
+             true <- TransactionChain.transaction_exists?(paging_address),
              last_address when last_address != nil <-
                TransactionChain.get_last_local_address(address),
              true <- last_address != paging_address do

--- a/lib/archethic/account.ex
+++ b/lib/archethic/account.ex
@@ -60,6 +60,6 @@ defmodule Archethic.Account do
   @doc """
   Load the transaction into the Account context filling the memory tables for ledgers
   """
-  @spec load_transaction(Transaction.t()) :: :ok
-  defdelegate load_transaction(transaction), to: MemTablesLoader
+  @spec load_transaction(Transaction.t(), boolean()) :: :ok
+  defdelegate load_transaction(transaction, io_transaction?), to: MemTablesLoader
 end

--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -32,6 +32,7 @@ defmodule Archethic.DB do
   @callback write_beacon_summaries_aggregate(SummaryAggregate.t()) :: :ok
   @callback write_transaction_chain(Enumerable.t()) :: :ok
   @callback list_transactions(fields :: list()) :: Enumerable.t()
+  @callback list_io_transactions(fields :: list()) :: Enumerable.t()
   @callback add_last_transaction_address(binary(), binary(), DateTime.t()) :: :ok
   @callback list_last_transaction_addresses() :: Enumerable.t()
 

--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -13,6 +13,8 @@ defmodule Archethic.DB do
 
   use Knigge, otp_app: :archethic, default: EmbeddedImpl
 
+  @type storage_type() :: :chain | :io
+
   @callback get_transaction(address :: binary(), fields :: list()) ::
               {:ok, Transaction.t()} | {:error, :transaction_not_exists}
   @callback get_beacon_summary(summary_address :: binary()) ::
@@ -24,7 +26,7 @@ defmodule Archethic.DB do
               fields :: list(),
               opts :: [paging_state: nil | binary(), after: DateTime.t()]
             ) :: Enumerable.t()
-  @callback write_transaction(Transaction.t()) :: :ok
+  @callback write_transaction(Transaction.t(), storage_type()) :: :ok
   @callback write_beacon_summary(Summary.t()) :: :ok
   @callback clear_beacon_summaries() :: :ok
   @callback write_beacon_summaries_aggregate(SummaryAggregate.t()) :: :ok
@@ -61,7 +63,7 @@ defmodule Archethic.DB do
   @callback get_latest_burned_fees() :: non_neg_integer()
   @callback get_nb_transactions() :: non_neg_integer()
 
-  @callback transaction_exists?(binary()) :: boolean()
+  @callback transaction_exists?(binary(), storage_type()) :: boolean()
 
   @callback register_p2p_summary(list({Crypto.key(), boolean(), float(), DateTime.t()})) :: :ok
 

--- a/lib/archethic/db/embedded_impl.ex
+++ b/lib/archethic/db/embedded_impl.ex
@@ -296,12 +296,20 @@ defmodule Archethic.DB.EmbeddedImpl do
   end
 
   @doc """
-  List all the transactions
+  List all the transactions in chain storage
   """
   @spec list_transactions(fields :: list()) :: Enumerable.t() | list(Transaction.t())
   def list_transactions(fields \\ []) when is_list(fields) do
     ChainIndex.list_genesis_addresses()
     |> Stream.flat_map(&ChainReader.stream_scan_chain(&1, nil, fields, db_path()))
+  end
+
+  @doc """
+  List all the transactions in io storage
+  """
+  @spec list_io_transactions(fields :: list()) :: Enumerable.t() | list(Transaction.t())
+  def list_io_transactions(fields \\ []) do
+    ChainReader.list_io_transactions(fields, db_path())
   end
 
   @doc """

--- a/lib/archethic/db/embedded_impl.ex
+++ b/lib/archethic/db/embedded_impl.ex
@@ -115,7 +115,7 @@ defmodule Archethic.DB.EmbeddedImpl do
     if ChainIndex.transaction_exists?(tx.address, :io, db_path()) do
       {:error, :transaction_already_exists}
     else
-      ChainWriter.write_io_transaction(tx)
+      ChainWriter.write_io_transaction(tx, db_path())
     end
   end
 

--- a/lib/archethic/db/embedded_impl/chain_index.ex
+++ b/lib/archethic/db/embedded_impl/chain_index.ex
@@ -7,6 +7,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
   @vsn Mix.Project.config()[:version]
 
   alias Archethic.Crypto
+  alias Archethic.DB
   alias Archethic.DB.EmbeddedImpl.ChainWriter
   alias Archethic.TransactionChain.Transaction
 
@@ -196,14 +197,18 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
   @doc """
   Determine if a transaction exists
   """
-  @spec transaction_exists?(binary(), String.t()) :: boolean()
-  def transaction_exists?(address = <<_::8, _::8, _subset::8, _digest::binary>>, db_path) do
+  @spec transaction_exists?(binary(), DB.storage_type(), String.t()) :: boolean()
+  def transaction_exists?(address, storage_type \\ :chain, db_path)
+
+  def transaction_exists?(address, storage_type, db_path) do
     case get_tx_entry(address, db_path) do
       {:ok, _} ->
         true
 
       {:error, :not_exists} ->
-        false
+        if storage_type == :io,
+          do: ChainWriter.io_path(db_path, address) |> File.exists?(),
+          else: false
     end
   end
 

--- a/lib/archethic/db/embedded_impl/chain_writer.ex
+++ b/lib/archethic/db/embedded_impl/chain_writer.ex
@@ -32,6 +32,16 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
   end
 
   @doc """
+  write an io transaction in a file name by it's address
+  """
+  @spec write_io_transaction(Transaction.t()) :: :ok
+  def write_io_transaction(tx = %Transaction{address: address}) do
+    partition = :erlang.phash2(address, 20)
+    [{_, pid}] = :ets.lookup(:archethic_db_chain_writers, partition)
+    GenServer.call(pid, {:write_io_transaction, tx})
+  end
+
+  @doc """
   Write a beacon summary in a new file
   """
   @spec write_beacon_summary(Summary.t(), binary()) :: :ok
@@ -100,6 +110,10 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
     |> File.mkdir_p!()
 
     path
+    |> base_io_path()
+    |> File.mkdir_p!()
+
+    path
     |> base_beacon_path()
     |> File.mkdir_p!()
 
@@ -114,6 +128,15 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
         state = %{db_path: db_path}
       ) do
     write_transaction(genesis_address, tx, db_path)
+    {:reply, :ok, state}
+  end
+
+  def handle_call(
+        {:write_io_transaction, tx},
+        _from,
+        state = %{db_path: db_path}
+      ) do
+    write_io_transaction(tx, db_path)
     {:reply, :ok, state}
   end
 
@@ -165,6 +188,24 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
     })
   end
 
+  defp write_io_transaction(tx = %Transaction{address: address}, db_path) do
+    start = System.monotonic_time()
+
+    filename = io_path(db_path, address)
+
+    data = Encoding.encode(tx)
+
+    File.write!(
+      filename,
+      data,
+      [:append, :binary]
+    )
+
+    :telemetry.execute([:archethic, :db], %{duration: System.monotonic_time() - start}, %{
+      query: "write_io_transaction"
+    })
+  end
+
   @doc """
   Return the path of the chain storage location
   """
@@ -175,11 +216,28 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
   end
 
   @doc """
+  Return the path of the io storage location
+  """
+  @spec io_path(String.t(), binary()) :: String.t()
+  def io_path(db_path, address)
+      when is_binary(address) and is_binary(db_path) do
+    Path.join([base_io_path(db_path), Base.encode16(address)])
+  end
+
+  @doc """
   Return the chain base path
   """
   @spec base_chain_path(String.t()) :: String.t()
   def base_chain_path(db_path) do
     Path.join([db_path, "chains"])
+  end
+
+  @doc """
+  Return the io base path
+  """
+  @spec base_io_path(String.t()) :: String.t()
+  def base_io_path(db_path) do
+    Path.join([db_path, "io"])
   end
 
   @doc """

--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -4,7 +4,7 @@ defmodule Archethic.OracleChain.Scheduler do
   """
 
   alias Archethic.Crypto
-  alias Archethic.DB
+
   alias Archethic.Election
 
   alias Archethic.P2P
@@ -307,7 +307,7 @@ defmodule Archethic.OracleChain.Scheduler do
     tx = build_oracle_transaction(summary_date, index, new_oracle_data)
 
     with {:empty, false} <- {:empty, Enum.empty?(new_oracle_data)},
-         {:exists, false} <- {:exists, DB.transaction_exists?(tx.address)},
+         {:exists, false} <- {:exists, TransactionChain.transaction_exists?(tx.address)},
          {:trigger, true} <- {:trigger, trigger_node?(storage_nodes)} do
       send_polling_transaction(tx)
       :keep_state_and_data
@@ -364,7 +364,7 @@ defmodule Archethic.OracleChain.Scheduler do
     storage_nodes = tx_address |> Election.storage_nodes(authorized_nodes)
 
     watcher_pid =
-      with {:exists, false} <- {:exists, DB.transaction_exists?(tx_address)},
+      with {:exists, false} <- {:exists, TransactionChain.transaction_exists?(tx_address)},
            {:trigger, true} <- {:trigger, trigger_node?(storage_nodes)} do
         Logger.debug("Oracle transaction summary sending",
           transaction_address: Base.encode16(tx_address),
@@ -699,7 +699,7 @@ defmodule Archethic.OracleChain.Scheduler do
         next_pub
       )
 
-    if DB.transaction_exists?(tx.address) do
+    if TransactionChain.transaction_exists?(tx.address) do
       Logger.debug(
         "Transaction Already Exists:oracle summary transaction - aggregation: #{inspect(aggregated_content)}",
         transaction_address: Base.encode16(tx.address),

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -111,7 +111,7 @@ defmodule Archethic.Replication do
 
           TransactionChain.write_transaction(tx)
 
-          :ok = ingest_transaction(tx)
+          :ok = ingest_transaction(tx, false)
 
           Logger.info("Replication finished",
             transaction_address: Base.encode16(address),
@@ -176,7 +176,7 @@ defmodule Archethic.Replication do
       case TransactionValidator.validate(tx, self_repair?) do
         :ok ->
           :ok = TransactionChain.write_transaction(tx, :io)
-          ingest_transaction(tx)
+          ingest_transaction(tx, true)
 
           Logger.info("Replication finished",
             transaction_address: Base.encode16(address),
@@ -524,13 +524,13 @@ defmodule Archethic.Replication do
   - Transactions with smart contract deploy instances of them or can put in pending state waiting approval signatures
   - Code approval transactions may trigger the TestNets deployments or hot-reloads
   """
-  @spec ingest_transaction(Transaction.t()) :: :ok
-  def ingest_transaction(tx = %Transaction{}) do
+  @spec ingest_transaction(Transaction.t(), boolean()) :: :ok
+  def ingest_transaction(tx = %Transaction{}, io_transaction?) do
     TransactionChain.load_transaction(tx)
     Crypto.load_transaction(tx)
     P2P.load_transaction(tx)
     SharedSecrets.load_transaction(tx)
-    Account.load_transaction(tx)
+    Account.load_transaction(tx, io_transaction?)
     Contracts.load_transaction(tx)
     OracleChain.load_transaction(tx)
     Reward.load_transaction(tx)

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -158,7 +158,7 @@ defmodule Archethic.Replication do
         },
         self_repair? \\ false
       ) do
-    if TransactionChain.transaction_exists?(address) do
+    if TransactionChain.transaction_exists?(address, :io) do
       Logger.warning("Transaction already exists",
         transaction_address: Base.encode16(address),
         transaction_type: type
@@ -175,7 +175,7 @@ defmodule Archethic.Replication do
 
       case TransactionValidator.validate(tx, self_repair?) do
         :ok ->
-          :ok = TransactionChain.write_transaction(tx)
+          :ok = TransactionChain.write_transaction(tx, :io)
           ingest_transaction(tx)
 
           Logger.info("Replication finished",

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -232,7 +232,7 @@ defmodule Archethic.SelfRepair.Sync do
 
     transactions_to_sync =
       transaction_summaries
-      |> Enum.reject(&TransactionChain.transaction_exists?(&1.address))
+      |> Enum.reject(&TransactionChain.transaction_exists?(&1.address, :io))
       |> Enum.filter(&TransactionHandler.download_transaction?/1)
 
     synchronize_transactions(transactions_to_sync, download_nodes)

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -172,14 +172,15 @@ defmodule Archethic.TransactionChain do
   @doc """
   Persist only one transaction
   """
-  @spec write_transaction(Transaction.t()) :: :ok
+  @spec write_transaction(Transaction.t(), DB.storage_type()) :: :ok
   def write_transaction(
         tx = %Transaction{
           address: address,
           type: type
-        }
+        },
+        storage_type \\ :chain
       ) do
-    DB.write_transaction(tx)
+    DB.write_transaction(tx, storage_type)
     KOLedger.remove_transaction(address)
 
     Logger.info("Transaction stored",
@@ -247,8 +248,8 @@ defmodule Archethic.TransactionChain do
   @doc """
   Determine if the transaction exists
   """
-  @spec transaction_exists?(binary()) :: boolean()
-  defdelegate transaction_exists?(address), to: DB
+  @spec transaction_exists?(binary(), DB.storage_type()) :: boolean()
+  defdelegate transaction_exists?(address, storage_type \\ :chain), to: DB
 
   @doc """
   Return the size of transaction chain

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -59,6 +59,12 @@ defmodule Archethic.TransactionChain do
   defdelegate list_all(fields \\ []), to: DB, as: :list_transactions
 
   @doc """
+  List all the io transactions stored
+  """
+  @spec list_io_transactions(fields :: list()) :: Enumerable.t()
+  defdelegate list_io_transactions(fields \\ []), to: DB
+
+  @doc """
   List all the transaction for a given transaction type sorted by timestamp in descent order
   """
   @spec list_transactions_by_type(type :: Transaction.transaction_type(), fields :: list()) ::

--- a/lib/archethic/utils/detect_node_responsiveness.ex
+++ b/lib/archethic/utils/detect_node_responsiveness.ex
@@ -4,8 +4,10 @@ defmodule Archethic.Utils.DetectNodeResponsiveness do
   """
   @default_timeout Application.compile_env(:archethic, __MODULE__, [])
                    |> Keyword.get(:timeout, 5_000)
-  alias Archethic.DB
+
   alias Archethic.Mining
+
+  alias Archethic.TransactionChain
 
   use GenServer
   @vsn Mix.Project.config()[:version]
@@ -43,7 +45,7 @@ defmodule Archethic.Utils.DetectNodeResponsiveness do
           timeout: timeout
         }
       ) do
-    with {:exists, false} <- {:exists, DB.transaction_exists?(address)},
+    with {:exists, false} <- {:exists, TransactionChain.transaction_exists?(address)},
          {:mining, false} <- {:mining, Mining.processing?(address)},
          {:remaining, true} <- {:remaining, count < max_retry} do
       Logger.info("calling replay fn with count=#{count}",

--- a/test/archethic/bootstrap/network_init_test.exs
+++ b/test/archethic/bootstrap/network_init_test.exs
@@ -228,7 +228,7 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
     me = self()
 
     MockDB
-    |> stub(:write_transaction, fn ^tx ->
+    |> stub(:write_transaction, fn ^tx, _ ->
       send(me, :write_transaction)
       :ok
     end)
@@ -277,7 +277,7 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
     me = self()
 
     MockDB
-    |> expect(:write_transaction, fn tx ->
+    |> expect(:write_transaction, fn tx, _ ->
       send(me, {:transaction, tx})
       :ok
     end)
@@ -429,7 +429,7 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
     me = self()
 
     MockDB
-    |> expect(:write_transaction, fn tx ->
+    |> expect(:write_transaction, fn tx, _ ->
       send(me, {:transaction, tx})
       :ok
     end)

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -263,7 +263,7 @@ defmodule Archethic.BootstrapTest do
 
           validated_tx = %{tx | validation_stamp: stamp}
           :ok = TransactionChain.write([validated_tx])
-          :ok = Replication.ingest_transaction(validated_tx)
+          :ok = Replication.ingest_transaction(validated_tx, false)
 
           {:ok, %Ok{}}
 

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -549,9 +549,9 @@ defmodule Archethic.BootstrapTest do
         ^addr0 -> {addr2, DateTime.utc_now()}
       end)
       |> stub(:transaction_exists?, fn
-        ^addr4 -> false
-        ^addr3 -> false
-        ^addr2 -> true
+        ^addr4, _ -> false
+        ^addr3, _ -> false
+        ^addr2, _ -> true
       end)
       |> expect(:get_transaction, fn ^addr3, _ ->
         {:error, :transaction_not_exists}
@@ -562,7 +562,7 @@ defmodule Archethic.BootstrapTest do
           send(me, {:write_transaction_chain, txn_list})
           :ok
       end)
-      |> expect(:write_transaction, fn _tx ->
+      |> expect(:write_transaction, fn _tx, _ ->
         :ok
       end)
 

--- a/test/archethic/replication_test.exs
+++ b/test/archethic/replication_test.exs
@@ -83,7 +83,7 @@ defmodule Archethic.ReplicationTest do
     #  send(me, :replicated)
     #  :ok
     # end)
-    |> expect(:write_transaction, fn ^tx ->
+    |> expect(:write_transaction, fn ^tx, _ ->
       send(me, :replicated)
       :ok
     end)
@@ -145,7 +145,7 @@ defmodule Archethic.ReplicationTest do
     tx = create_valid_transaction(unspent_outputs)
 
     MockDB
-    |> expect(:write_transaction, fn _ ->
+    |> expect(:write_transaction, fn _, _ ->
       send(me, :replicated)
       :ok
     end)

--- a/test/archethic/reward_test.exs
+++ b/test/archethic/reward_test.exs
@@ -138,7 +138,7 @@ defmodule Archethic.RewardTest do
     end
 
     test "Balance Should be updated with UCO ,for reward movements " do
-      Enum.each(get_reward_transactions(), &AccountTablesLoader.load_transaction(&1))
+      Enum.each(get_reward_transactions(), &AccountTablesLoader.load_transaction(&1, false))
 
       # @Ada1
       # from alen2: 2uco, dan2: 19uco, rewardtoken1: 50, rewardtoken2: 50
@@ -365,7 +365,7 @@ defmodule Archethic.RewardTest do
     end
 
     test "Node Rewards Should not be minted" do
-      AccountTablesLoader.load_transaction(get_node_reward_txns())
+      AccountTablesLoader.load_transaction(get_node_reward_txns(), false)
 
       assert %{
                uco: 0,

--- a/test/archethic/self_repair/repair_worker_test.exs
+++ b/test/archethic/self_repair/repair_worker_test.exs
@@ -57,11 +57,11 @@ defmodule Archethic.SelfRepair.RepairWorkerTest do
 
     MockDB
     |> stub(:transaction_exists?, fn
-      "Bob2" ->
+      "Bob2", _ ->
         send(me, :exists_bob3)
         true
 
-      _ ->
+      _, _ ->
         false
     end)
 
@@ -88,7 +88,7 @@ defmodule Archethic.SelfRepair.RepairWorkerTest do
 
   test "add_message/1 should add new addresses in GenServer state" do
     MockDB
-    |> stub(:transaction_exists?, fn _ -> Process.sleep(100) end)
+    |> stub(:transaction_exists?, fn _, _ -> Process.sleep(100) end)
 
     {:ok, pid} =
       RepairWorker.start_link(

--- a/test/archethic/self_repair/sync/transaction_handler_test.exs
+++ b/test/archethic/self_repair/sync/transaction_handler_test.exs
@@ -173,7 +173,7 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
     end)
 
     MockDB
-    |> stub(:write_transaction, fn ^tx ->
+    |> stub(:write_transaction, fn ^tx, _ ->
       send(me, :transaction_replicated)
       :ok
     end)

--- a/test/archethic/self_repair/sync_test.exs
+++ b/test/archethic/self_repair/sync_test.exs
@@ -168,7 +168,7 @@ defmodule Archethic.SelfRepair.SyncTest do
       me = self()
 
       MockDB
-      |> stub(:write_transaction, fn ^tx ->
+      |> stub(:write_transaction, fn ^tx, _ ->
         send(me, :storage)
         :ok
       end)
@@ -301,7 +301,7 @@ defmodule Archethic.SelfRepair.SyncTest do
       me = self()
 
       MockDB
-      |> stub(:write_transaction, fn ^transfer_tx ->
+      |> stub(:write_transaction, fn ^transfer_tx, _ ->
         send(me, :transaction_stored)
         :ok
       end)

--- a/test/archethic/utils/detect_node_responsiveness_test.exs
+++ b/test/archethic/utils/detect_node_responsiveness_test.exs
@@ -110,7 +110,7 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
     Process.monitor(pid)
 
     MockDB
-    |> stub(:transaction_exists?, fn ^address ->
+    |> stub(:transaction_exists?, fn ^address, _ ->
       false
     end)
 
@@ -170,7 +170,7 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
     {:ok, pid} = DetectNodeResponsiveness.start_link(address, 2, replaying_fn, @timeout)
 
     MockDB
-    |> stub(:transaction_exists?, fn ^address ->
+    |> stub(:transaction_exists?, fn ^address, _ ->
       Process.send_after(me, :transaction_stored, 50)
       true
     end)
@@ -221,10 +221,10 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
     {:ok, pid} = DetectNodeResponsiveness.start_link(address, 2, replaying_fn, @timeout)
 
     MockDB
-    |> expect(:transaction_exists?, fn ^address ->
+    |> expect(:transaction_exists?, fn ^address, _ ->
       false
     end)
-    |> expect(:transaction_exists?, fn ^address ->
+    |> expect(:transaction_exists?, fn ^address, _ ->
       Process.send_after(me, :transaction_stored, 50)
       true
     end)
@@ -276,7 +276,7 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
     {:ok, pid} = DetectNodeResponsiveness.start_link(address, 2, replaying_fn, @timeout)
 
     MockDB
-    |> stub(:transaction_exists?, fn ^address ->
+    |> stub(:transaction_exists?, fn ^address, _ ->
       false
     end)
 
@@ -327,7 +327,7 @@ defmodule Archethic.Utils.DetectNodeResponsivenessTest do
     {:ok, pid} = DetectNodeResponsiveness.start_link(address, 2, replaying_fn, @timeout)
 
     MockDB
-    |> stub(:transaction_exists?, fn ^address ->
+    |> stub(:transaction_exists?, fn ^address, _ ->
       false
     end)
 

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -40,7 +40,7 @@ defmodule ArchethicCase do
 
     MockDB
     |> stub(:list_transactions, fn _ -> [] end)
-    |> stub(:write_transaction, fn _ -> :ok end)
+    |> stub(:write_transaction, fn _, _ -> :ok end)
     |> stub(:write_transaction_chain, fn _ -> :ok end)
     |> stub(:get_transaction, fn _, _ -> {:error, :transaction_not_exists} end)
     |> stub(:get_transaction_chain, fn _, _, _ -> {[], false, nil} end)
@@ -56,7 +56,7 @@ defmodule ArchethicCase do
     |> stub(:count_transactions_by_type, fn _ -> 0 end)
     |> stub(:list_addresses_by_type, fn _ -> [] end)
     |> stub(:list_transactions, fn _ -> [] end)
-    |> stub(:transaction_exists?, fn _ -> false end)
+    |> stub(:transaction_exists?, fn _, _ -> false end)
     |> stub(:register_p2p_summary, fn _ -> :ok end)
     |> stub(:get_last_p2p_summaries, fn -> [] end)
     |> stub(:get_latest_tps, fn -> 0.0 end)


### PR DESCRIPTION
# Description

For now IO transaction are used only for updating the inputs of a transaction. Therefor we don't want to update anything in the ChainIndex like the last address.
So the idea is to create 2 storage folder, one for io tx and one for chain tx, and do not update ChainIndex while writing an io transaction

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Unit tests
- Start 5 node with sharding properties updated
- Create some transactions, nodes should store io transaction in "io" folder
- Stop and restart a node, it should update the account mem table properly

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
