### PR TITLE
Add buning address to io storage nodes only if burning is intentionna…

### DIFF
--- a/lib/archethic/account/mem_tables_loader.ex
+++ b/lib/archethic/account/mem_tables_loader.ex
@@ -9,10 +9,6 @@ defmodule Archethic.Account.MemTablesLoader do
 
   alias Archethic.Crypto
 
-  alias Archethic.Election
-
-  alias Archethic.P2P
-
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.ValidationStamp
@@ -23,8 +19,6 @@ defmodule Archethic.Account.MemTablesLoader do
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
-
-  alias Archethic.Utils
 
   require Logger
 
@@ -81,12 +75,11 @@ defmodule Archethic.Account.MemTablesLoader do
             timestamp: timestamp,
             protocol_version: protocol_version,
             ledger_operations: %LedgerOperations{
-              fee: fee,
               unspent_outputs: unspent_outputs,
-              transaction_movements: transaction_movements
-            }
+            transaction_movements: transaction_movements
           }
-        },
+        }
+      },
         io_transaction?
       ) do
     unless io_transaction? do

--- a/lib/archethic/account/mem_tables_loader.ex
+++ b/lib/archethic/account/mem_tables_loader.ex
@@ -96,27 +96,6 @@ defmodule Archethic.Account.MemTablesLoader do
       TokenLedger.spend_all_unspent_outputs(previous_address)
     end
 
-    burn_storage_nodes =
-      Election.storage_nodes(
-        LedgerOperations.burning_address(),
-        P2P.authorized_and_available_nodes(timestamp)
-      )
-
-    transaction_movements =
-      if Utils.key_in_node_list?(burn_storage_nodes, Crypto.first_node_public_key()) and
-           fee > 0 do
-        [
-          %TransactionMovement{
-            to: LedgerOperations.burning_address(),
-            amount: fee,
-            type: :UCO
-          }
-          | transaction_movements
-        ]
-      else
-        transaction_movements
-      end
-
     :ok =
       set_transaction_movements(
         address,

--- a/lib/archethic/account/mem_tables_loader.ex
+++ b/lib/archethic/account/mem_tables_loader.ex
@@ -76,10 +76,10 @@ defmodule Archethic.Account.MemTablesLoader do
             protocol_version: protocol_version,
             ledger_operations: %LedgerOperations{
               unspent_outputs: unspent_outputs,
-            transaction_movements: transaction_movements
+              transaction_movements: transaction_movements
+            }
           }
-        }
-      },
+        },
         io_transaction?
       ) do
     unless io_transaction? do

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -1011,10 +1011,11 @@ defmodule Archethic.Mining.DistributedWorkflow do
     end)
   end
 
-  defp maybe_add_burning_address(resolved_addresses, burning_node, tx_mvts) do
-    case Enum.any?(tx_mvts, fn tx_mvt -> tx_mvt.to == burning_node end) do
+  defp maybe_add_burning_address(resolved_addresses, burning_address, tx_mvts) do
+    case Enum.any?(tx_mvts, fn tx_mvt -> tx_mvt.to == burning_address end) do
       true ->
-        Enum.concat(resolved_addresses, [LedgerOperations.burning_address()])
+        Enum.concat(resolved_addresses, [burning_address])
+
       _ ->
         resolved_addresses
     end

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -38,7 +38,6 @@ defmodule Archethic.Mining.DistributedWorkflow do
 
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.TransactionSummary
@@ -189,10 +188,6 @@ defmodule Archethic.Mining.DistributedWorkflow do
       else
         resolved_addresses
         |> Enum.map(fn {_origin, resolved} -> resolved end)
-        |> maybe_add_burning_address(
-          LedgerOperations.burning_address(),
-          tx.validation_stamp.ledger_operations.transaction_movements
-        )
         |> Election.io_storage_nodes(authorized_nodes)
       end
 
@@ -1009,15 +1004,5 @@ defmodule Archethic.Mining.DistributedWorkflow do
 
       :ok
     end)
-  end
-
-  defp maybe_add_burning_address(resolved_addresses, burning_address, tx_mvts) do
-    case Enum.any?(tx_mvts, fn tx_mvt -> tx_mvt.to == burning_address end) do
-      true ->
-        Enum.concat(resolved_addresses, [burning_address])
-
-      _ ->
-        resolved_addresses
-    end
   end
 end

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -29,7 +29,6 @@ defmodule Archethic.Mining.StandaloneWorkflow do
 
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
   alias Archethic.TransactionChain.TransactionSummary
 
   require Logger
@@ -79,10 +78,6 @@ defmodule Archethic.Mining.StandaloneWorkflow do
       else
         resolved_addresses
         |> Enum.map(fn {_origin, resolved} -> resolved end)
-        |> maybe_add_burning_address(
-          LedgerOperations.burning_address(),
-          tx.validation_stamp.ledger_operations.transaction_movements
-        )
         |> Election.io_storage_nodes(authorized_nodes)
       end
 
@@ -342,16 +337,6 @@ defmodule Archethic.Mining.StandaloneWorkflow do
       context
       |> ValidationContext.get_confirmed_replication_nodes()
       |> P2P.broadcast_message(%NotifyPreviousChain{address: tx.address})
-    end
-  end
-
-  defp maybe_add_burning_address(resolved_addresses, burning_node, tx_mvts) do
-    case Enum.any?(tx_mvts, fn tx_mvt -> tx_mvt.to == burning_node end) do
-      true ->
-        Enum.concat(resolved_addresses, [LedgerOperations.burning_address()])
-
-      _ ->
-        resolved_addresses
     end
   end
 end

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -79,7 +79,10 @@ defmodule Archethic.Mining.StandaloneWorkflow do
       else
         resolved_addresses
         |> Enum.map(fn {_origin, resolved} -> resolved end)
-        |> Enum.concat([LedgerOperations.burning_address()])
+        |> maybe_add_burning_address(
+          LedgerOperations.burning_address(),
+          tx.validation_stamp.ledger_operations.transaction_movements
+        )
         |> Election.io_storage_nodes(authorized_nodes)
       end
 
@@ -339,6 +342,16 @@ defmodule Archethic.Mining.StandaloneWorkflow do
       context
       |> ValidationContext.get_confirmed_replication_nodes()
       |> P2P.broadcast_message(%NotifyPreviousChain{address: tx.address})
+    end
+  end
+
+  defp maybe_add_burning_address(resolved_addresses, burning_node, tx_mvts) do
+    case Enum.any?(tx_mvts, fn tx_mvt -> tx_mvt.to == burning_node end) do
+      true ->
+        Enum.concat(resolved_addresses, [LedgerOperations.burning_address()])
+
+      _ ->
+        resolved_addresses
     end
   end
 end

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -545,7 +545,7 @@ defmodule Archethic.TransactionChain do
       tx
       |> Transaction.get_movements()
       |> Enum.map(&{&1.to, &1.type})
-      |> Enum.filter(&(&1.to != LedgerOperations.burning_address()))
+      |> Enum.filter(fn {to, _} -> to != LedgerOperations.burning_address() end)
       |> Enum.concat(recipients)
 
     Task.Supervisor.async_stream_nolink(

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -565,6 +565,9 @@ defmodule Archethic.TransactionChain do
               {{to, type}, to}
           end
 
+        ^burning_address ->
+          {burning_address, burning_address}
+
         to ->
           case resolve_last_address(to, time) do
             {:ok, resolved} ->

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -43,6 +43,8 @@ defmodule Archethic.TransactionChain do
   alias __MODULE__.TransactionData
   alias __MODULE__.Transaction.ValidationStamp
 
+  alias __MODULE__.Transaction.ValidationStamp.LedgerOperations
+
   alias __MODULE__.Transaction.ValidationStamp.LedgerOperations.TransactionMovement.Type,
     as: TransactionMovementType
 
@@ -543,6 +545,7 @@ defmodule Archethic.TransactionChain do
       tx
       |> Transaction.get_movements()
       |> Enum.map(&{&1.to, &1.type})
+      |> Enum.filter(&(&1.to != LedgerOperations.burning_address()))
       |> Enum.concat(recipients)
 
     Task.Supervisor.async_stream_nolink(

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -553,8 +553,8 @@ defmodule Archethic.TransactionChain do
       TaskSupervisor,
       addresses,
       fn
-        {burning_address, _} ->
-          {{burning_address, type}, resolved}
+        {^burning_address, type} ->
+          {{burning_address, type}, burning_address}
 
         {to, type} ->
           case resolve_last_address(to, time) do

--- a/test/archethic/account/mem_tables_loader_test.exs
+++ b/test/archethic/account/mem_tables_loader_test.exs
@@ -148,7 +148,9 @@ defmodule Archethic.Account.MemTablesLoaderTest do
                    timestamp: ^timestamp
                  }
                }
-             ] = UCOLedger.get_unspent_outputs(LedgerOperations.burning_address())
+             ] = TokenLedger.get_unspent_outputs(LedgerOperations.burning_address())
+
+      assert [] = UCOLedger.get_unspent_outputs(LedgerOperations.burning_address())
 
       assert [
                %VersionedUnspentOutput{
@@ -255,6 +257,11 @@ defmodule Archethic.Account.MemTablesLoaderTest do
               to: "@Bob3",
               amount: 1_000_000_000,
               type: {:token, "@CharlieToken", 0}
+            },
+            %TransactionMovement{
+              to: LedgerOperations.burning_address(),
+              amount: 100_000_000,
+              type: {:token, "@Charlie2", 0}
             }
           ],
           unspent_outputs: [
@@ -382,11 +389,6 @@ defmodule Archethic.Account.MemTablesLoaderTest do
             %TransactionMovement{
               to: "@Bob3",
               amount: 1_000_000_000,
-              type: {:token, "@CharlieToken", 0}
-            },
-            %TransactionMovement{
-              to: LedgerOperations.burning_address(),
-              amount: 1_000_000,
               type: {:token, "@CharlieToken", 0}
             },
             %TransactionMovement{

--- a/test/archethic/account/mem_tables_loader_test.exs
+++ b/test/archethic/account/mem_tables_loader_test.exs
@@ -385,6 +385,11 @@ defmodule Archethic.Account.MemTablesLoaderTest do
               type: {:token, "@CharlieToken", 0}
             },
             %TransactionMovement{
+              to: LedgerOperations.burning_address(),
+              amount: 1_000_000,
+              type: {:token, "@CharlieToken", 0}
+            },
+            %TransactionMovement{
               to: "@Tom4",
               amount: 200_000_000,
               type: {:token, "@RewardToken1", 0}


### PR DESCRIPTION
…l (#711)

# Description

Store burning fee movements only if they are intentionnals

Fixes # (issue)

- Now checking if the burning node address is part of the transaction movement list's recipients, to guess if fee burning was intentionnal. If not intentionnal, remove the burning address from resolved io storage nodes

- kept the [test](https://github.com/archethic-foundation/archethic-node/blob/develop/lib/archethic/account/mem_tables_loader.ex#L106) wich will add the burning address to the transaction movements if some burning movements have been recorded from point above.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

test coming soon

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
