### PR TITLE
Take older oracle chain uco price in tx validation

### DIFF
--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -757,8 +757,9 @@ defmodule Archethic.Mining.ValidationContext do
          validation_time: validation_time,
          resolved_addresses: resolved_addresses
        }) do
-    usd_price =
+    previous_usd_price =
       validation_time
+      |> OracleChain.get_last_scheduling_date()
       |> OracleChain.get_uco_price()
       |> Keyword.fetch!(:usd)
 
@@ -771,7 +772,7 @@ defmodule Archethic.Mining.ValidationContext do
     fee =
       Fee.calculate(
         tx,
-        usd_price,
+        previous_usd_price,
         validation_time
       )
 

--- a/lib/archethic/replication/transaction_validator.ex
+++ b/lib/archethic/replication/transaction_validator.ex
@@ -275,12 +275,13 @@ defmodule Archethic.Replication.TransactionValidator do
            }
          }
        ) do
-    uco_price_usd =
+    previous_usd_price =
       timestamp
+      |> OracleChain.get_last_scheduling_date()
       |> OracleChain.get_uco_price()
       |> Keyword.fetch!(:usd)
 
-    Mining.get_transaction_fee(tx, uco_price_usd, timestamp)
+    Mining.get_transaction_fee(tx, previous_usd_price, timestamp)
   end
 
   defp validate_transaction_movements(


### PR DESCRIPTION
# Description

Prevent race condition during transaction's validation to avoid read conflicts about the UCO price to calculate the transaction's fee.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
