### PR TITLE
Fix request timeout

### DIFF
--- a/lib/archethic/bootstrap.ex
+++ b/lib/archethic/bootstrap.ex
@@ -230,7 +230,8 @@ defmodule Archethic.Bootstrap do
           &(&1.first_public_key == Crypto.first_node_public_key())
         )
 
-      do_resync_network_chain([:oracle, :node_shared_secrets], nodes)
+      [:oracle, :node_shared_secrets, :reward]
+      |> Enum.each(&do_resync_network_chain(&1, nodes))
     end
   end
 
@@ -240,40 +241,41 @@ defmodule Archethic.Bootstrap do
 
   # by type: Get gen addr, get last address (remotely  & locally)
   # compare, if dont match, fetch last tx remotely
-  def do_resync_network_chain(type_list, nodes) when is_list(nodes) do
-    Task.Supervisor.async_stream_nolink(Archethic.TaskSupervisor, type_list, fn type ->
-      with addr when is_binary(addr) <- get_genesis_addr(type),
-           {:ok, rem_last_addr} <- TransactionChain.resolve_last_address(addr),
-           {local_last_addr, _} <- TransactionChain.get_last_address(addr),
-           false <- rem_last_addr == local_last_addr,
-           {:ok, tx} <- TransactionChain.fetch_transaction_remotely(rem_last_addr, nodes),
-           :ok <- Replication.validate_and_store_transaction_chain(tx) do
-        Logger.info("Enforced Resync: Success", transaction_type: type)
+  def do_resync_network_chain(type, nodes) when is_list(nodes) do
+    with addr when is_binary(addr) <- get_genesis_addr(type),
+         {:ok, rem_last_addr} <- TransactionChain.resolve_last_address(addr),
+         {local_last_addr, _} <- TransactionChain.get_last_address(addr),
+         false <- rem_last_addr == local_last_addr,
+         {:ok, tx} <- TransactionChain.fetch_transaction_remotely(rem_last_addr, nodes),
+         :ok <- Replication.validate_and_store_transaction_chain(tx) do
+      Logger.info("Enforced Resync: Success", transaction_type: type)
+      :ok
+    else
+      true ->
+        Logger.info("Enforced Resync: No new transaction to sync", transaction_type: type)
         :ok
-      else
-        true ->
-          Logger.info("Enforced Resync: No new transaction to sync", transaction_type: type)
-          :ok
 
-        e when e in [nil, []] ->
-          Logger.debug("Enforced Resync: Transaction not available", transaction_type: type)
-          :ok
+      e when e in [nil, []] ->
+        Logger.debug("Enforced Resync: Transaction not available", transaction_type: type)
+        :ok
 
-        e ->
-          Logger.debug("Enforced Resync: Unexpected Error", transaction_type: type)
-          Logger.debug(e)
-      end
-    end)
-    |> Stream.run()
+      e ->
+        Logger.debug("Enforced Resync: Unexpected Error", transaction_type: type)
+        Logger.debug(e)
+    end
   end
 
-  @spec get_genesis_addr(:node_shared_secrets | :oracle) :: binary() | nil
+  @spec get_genesis_addr(:node_shared_secrets | :oracle | :reward) :: binary() | nil
   defp get_genesis_addr(:oracle) do
     Archethic.OracleChain.genesis_address().current |> elem(0)
   end
 
   defp get_genesis_addr(:node_shared_secrets) do
     Archethic.SharedSecrets.genesis_address(:node_shared_secrets)
+  end
+
+  defp get_genesis_addr(:reward) do
+    Archethic.Reward.genesis_address()
   end
 
   defp first_initialization(

--- a/lib/archethic/mining/transaction_context.ex
+++ b/lib/archethic/mining/transaction_context.ex
@@ -10,7 +10,6 @@ defmodule Archethic.Mining.TransactionContext do
   alias Archethic.Election
 
   alias Archethic.P2P
-  alias Archethic.P2P.Message
   alias Archethic.P2P.Message.Ok
   alias Archethic.P2P.Message.Ping
   alias Archethic.P2P.Node
@@ -61,7 +60,7 @@ defmodule Archethic.Mining.TransactionContext do
     prev_tx_task = request_previous_tx(previous_address, prev_tx_nodes_split)
     nodes_view_task = request_nodes_view(node_public_keys)
 
-    prev_tx = Task.await(prev_tx_task, Message.get_max_timeout())
+    prev_tx = Task.await(prev_tx_task)
     nodes_view = Task.await(nodes_view_task)
 
     %{
@@ -102,15 +101,16 @@ defmodule Archethic.Mining.TransactionContext do
     Task.Supervisor.async(
       TaskSupervisor,
       fn ->
-        case TransactionChain.fetch_transaction_remotely(previous_address, nodes) do
+        # Timeout of 4 sec because the coordinator node wait 5 sec to get the context
+        # from the cross validation nodes
+        case TransactionChain.fetch_transaction_remotely(previous_address, nodes, 4000) do
           {:ok, tx} ->
             tx
 
           {:error, _} ->
             nil
         end
-      end,
-      timeout: Message.get_max_timeout()
+      end
     )
   end
 

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -268,10 +268,10 @@ defmodule Archethic.Replication do
 
     {previous_transaction, inputs} =
       if self_repair? do
-        {Task.await(t1, Message.get_max_timeout()), []}
+        {Task.await(t1, Message.get_max_timeout() + 1000), []}
       else
-        t2 = Task.Supervisor.async(TaskSupervisor, fn -> fetch_inputs(tx, download_nodes) end)
-        {Task.await(t1, Message.get_max_timeout()), Task.await(t2)}
+        inputs = fetch_inputs(tx, download_nodes)
+        {Task.await(t1, Message.get_max_timeout() + 1000), inputs}
       end
 
     Logger.debug("Previous transaction #{inspect(previous_transaction)}",

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -495,7 +495,7 @@ defmodule Archethic.BootstrapTest do
 
       assert :ok =
                Bootstrap.do_resync_network_chain(
-                 [:node_shared_secrets],
+                 :node_shared_secrets,
                  _nodes = P2P.authorized_and_available_nodes()
                )
     end
@@ -523,7 +523,7 @@ defmodule Archethic.BootstrapTest do
 
       assert :ok =
                Bootstrap.do_resync_network_chain(
-                 [:node_shared_secrets],
+                 :node_shared_secrets,
                  _nodes = P2P.authorized_and_available_nodes()
                )
 
@@ -598,7 +598,7 @@ defmodule Archethic.BootstrapTest do
 
       assert :ok =
                Bootstrap.do_resync_network_chain(
-                 [:node_shared_secrets],
+                 :node_shared_secrets,
                  _nodes = P2P.authorized_and_available_nodes()
                )
 


### PR DESCRIPTION
# Description

- Fix timeout on replication  so the task don't fall in timeout before the message timeout
- Update the timeout to 4s for fetch the context during mining validation (mining timeout for getting cross validation node context is 5sec)
- Remove the task in post_bootstrap while re syncing the network chain

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
