### PR TITLE
Add getGenesisAddress query to graphql

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -374,7 +374,7 @@ defmodule Archethic do
         TransactionChain.fetch_genesis_address_remotely(address)
 
       genesis_address ->
-        genesis_address
+        {:ok, genesis_address}
     end
   end
 

--- a/lib/archethic_web/graphql_schema.ex
+++ b/lib/archethic_web/graphql_schema.ex
@@ -41,6 +41,17 @@ defmodule ArchethicWeb.GraphQLSchema do
     end
 
     @desc """
+    Query the network to find the genesis address of a transaction
+    """
+    field :get_genesis_address, :genesis_address do
+      arg(:address, non_null(:address))
+
+      resolve(fn %{address: address}, _ ->
+        Resolver.get_genesis_address(address)
+      end)
+    end
+
+    @desc """
     Query the network to find the last transaction from an address
     """
     field :last_transaction, :transaction do

--- a/lib/archethic_web/graphql_schema.ex
+++ b/lib/archethic_web/graphql_schema.ex
@@ -43,7 +43,7 @@ defmodule ArchethicWeb.GraphQLSchema do
     @desc """
     Query the network to find the genesis address of a transaction
     """
-    field :get_genesis_address, :genesis_address do
+    field :genesis_address, :genesis_address do
       arg(:address, non_null(:address))
 
       resolve(fn %{address: address}, _ ->

--- a/lib/archethic_web/graphql_schema.ex
+++ b/lib/archethic_web/graphql_schema.ex
@@ -43,7 +43,7 @@ defmodule ArchethicWeb.GraphQLSchema do
     @desc """
     Query the network to find the genesis address of a transaction
     """
-    field :genesis_address, :genesis_address do
+    field :genesis_address, :address do
       arg(:address, non_null(:address))
 
       resolve(fn %{address: address}, _ ->

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -26,7 +26,6 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
       _ ->
         {:ok, %{genesis: address}}
     end
-
   end
 
   def get_balance(address) do

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -19,26 +19,12 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
   @limit_page 10
 
   def get_genesis_address(address) do
-    t1 = Task.async(fn -> TransactionChain.fetch_genesis_address_remotely(address) end)
-    with {:ok, {:ok, genesis_address}} <- Task.yield(t1) do
-      {:ok, %{genesis: genesis_address}}
-    else
-      {:ok, {:error, :network_issue}} ->
-        {:error, "Network issue"}
+    case Archethic.fetch_genesis_address_remotely(address) do
+      ^address ->
+        {:ok, %{genesis: address}}
 
-      {:ok, {:error, :decode_error}} ->
-        {:error, "Error in decoding transaction"}
-
-      {:ok, {:error, :transaction_not_found}} ->
-        {:error, "Transaction does not exist!"}
-
-      {:exit, reason} ->
-        Logger.debug("Task exited with reason")
-        Logger.debug(reason)
-        {:error, "Task Exited!"}
-
-      nil ->
-        {:error, "Task didn't responded within timeout!"}
+      genesis ->
+        {:ok, %{genesis: genesis}}
     end
   end
 

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -20,12 +20,13 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
 
   def get_genesis_address(address) do
     case Archethic.fetch_genesis_address_remotely(address) do
-      ^address ->
-        {:ok, %{genesis: address}}
+      {:ok, genesis_address} ->
+        {:ok, %{genesis: genesis_address}}
 
-      genesis ->
-        {:ok, %{genesis: genesis}}
+      _ ->
+        {:ok, %{genesis: address}}
     end
+
   end
 
   def get_balance(address) do

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -21,10 +21,10 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
   def get_genesis_address(address) do
     case Archethic.fetch_genesis_address_remotely(address) do
       {:ok, genesis_address} ->
-        {:ok, %{genesis: genesis_address}}
+        {:ok, genesis_address}
 
       _ ->
-        {:ok, %{genesis: address}}
+        {:ok, address}
     end
   end
 

--- a/lib/archethic_web/graphql_schema/transaction_type.ex
+++ b/lib/archethic_web/graphql_schema/transaction_type.ex
@@ -90,11 +90,6 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
     field(:transfers, list_of(:uco_transfer))
   end
 
-  @desc "[Genesis] represents genesis address of a transaction chain"
-  object :genesis_address do
-    field(:genesis, :address)
-  end
-
   @desc "[TokenLedger] represents the transfers to perform on the UCO ledger"
   object :token_ledger do
     field(:transfers, list_of(:token_transfer))

--- a/lib/archethic_web/graphql_schema/transaction_type.ex
+++ b/lib/archethic_web/graphql_schema/transaction_type.ex
@@ -90,6 +90,11 @@ defmodule ArchethicWeb.GraphQLSchema.TransactionType do
     field(:transfers, list_of(:uco_transfer))
   end
 
+  @desc "[Genesis] represents genesis address of a transaction chain"
+  object :genesis_address do
+    field(:genesis, :address)
+  end
+
   @desc "[TokenLedger] represents the transfers to perform on the UCO ledger"
   object :token_ledger do
     field(:transfers, list_of(:token_transfer))

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -494,10 +494,10 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
         })
 
       assert %{
-          "data" => %{
-            "genesisAddress" => genesis
-          }
-        } = json_response(conn, 200)
+               "data" => %{
+                 "genesisAddress" => genesis
+               }
+             } = json_response(conn, 200)
 
       assert genesis == Base.encode16(genesis_addr)
     end

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -475,6 +475,57 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
     end
   end
 
+  describe "query: genesis_address" do
+    test "should return the genesis address", %{conn: conn} do
+      addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+      genesis_addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+      MockClient
+      |> stub(:send_message, fn _, %GetFirstAddress{}, _ ->
+        {:ok, %FirstAddress{address: genesis_addr}}
+      end)
+
+      conn =
+        post(conn, "/api", %{
+          "query" => "query {
+            genesisAddress(address: \"#{Base.encode16(addr)}\") {
+              genesis
+            }
+          }"
+        })
+
+      assert %{
+        "data" => %{
+          "genesisAddress" => %{
+            "genesis" => genesis_addr
+          }
+        }
+      } = json_response(conn, 200)
+
+    end
+    test "should return same address", %{conn: conn} do
+      addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+      conn =
+        post(conn, "/api", %{
+          "query" => "query {
+            genesisAddress(address: \"#{Base.encode16(addr)}\") {
+              genesis
+            }
+          }"
+        })
+
+      assert %{
+        "data" => %{
+          "genesisAddress" => %{
+            "genesis" => addr
+          }
+        }
+      } = json_response(conn, 200)
+
+    end
+  end
   describe "query: transaction_inputs" do
     test "should return a list of ledger inputs", %{conn: conn} do
       addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -496,17 +496,16 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
         })
 
       assert %{
-        "data" => %{
-          "genesisAddress" => %{
-            "genesis" => genesis
-          }
-        }
-      } = json_response(conn, 200)
+               "data" => %{
+                 "genesisAddress" => %{
+                   "genesis" => genesis
+                 }
+               }
+             } = json_response(conn, 200)
 
       assert genesis == Base.encode16(genesis_addr)
-
-
     end
+
     test "should return same address", %{conn: conn} do
       addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
 
@@ -520,17 +519,17 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
         })
 
       assert %{
-        "data" => %{
-          "genesisAddress" => %{
-            "genesis" => genesis
-          }
-        }
-      } = json_response(conn, 200)
+               "data" => %{
+                 "genesisAddress" => %{
+                   "genesis" => genesis
+                 }
+               }
+             } = json_response(conn, 200)
 
       assert genesis == Base.encode16(addr)
-
     end
   end
+
   describe "query: transaction_inputs" do
     test "should return a list of ledger inputs", %{conn: conn} do
       addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -489,19 +489,15 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
       conn =
         post(conn, "/api", %{
           "query" => "query {
-            genesisAddress(address: \"#{Base.encode16(addr)}\") {
-              genesis
-            }
+            genesisAddress(address: \"#{Base.encode16(addr)}\")
           }"
         })
 
       assert %{
-               "data" => %{
-                 "genesisAddress" => %{
-                   "genesis" => genesis
-                 }
-               }
-             } = json_response(conn, 200)
+          "data" => %{
+            "genesisAddress" => genesis
+          }
+        } = json_response(conn, 200)
 
       assert genesis == Base.encode16(genesis_addr)
     end
@@ -512,17 +508,13 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
       conn =
         post(conn, "/api", %{
           "query" => "query {
-            genesisAddress(address: \"#{Base.encode16(addr)}\") {
-              genesis
-            }
+            genesisAddress(address: \"#{Base.encode16(addr)}\")
           }"
         })
 
       assert %{
                "data" => %{
-                 "genesisAddress" => %{
-                   "genesis" => genesis
-                 }
+                 "genesisAddress" => genesis
                }
              } = json_response(conn, 200)
 

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -498,10 +498,13 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
       assert %{
         "data" => %{
           "genesisAddress" => %{
-            "genesis" => genesis_addr
+            "genesis" => genesis
           }
         }
       } = json_response(conn, 200)
+
+      assert genesis == Base.encode16(genesis_addr)
+
 
     end
     test "should return same address", %{conn: conn} do
@@ -519,10 +522,12 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
       assert %{
         "data" => %{
           "genesisAddress" => %{
-            "genesis" => addr
+            "genesis" => genesis
           }
         }
       } = json_response(conn, 200)
+
+      assert genesis == Base.encode16(addr)
 
     end
   end


### PR DESCRIPTION
# Description

This Pr aims to add a `getGenesisAddress` query to graphql to make it easier to find the genesis address of a transaction.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Start a node, open the explorer, find a transaction and query the graphql endpoint to retrieve the genesis address.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
