### PR TITLE
Add get first address in smart contract library #740

### DIFF
--- a/lib/archethic/contracts/interpreter/condition.ex
+++ b/lib/archethic/contracts/interpreter/condition.ex
@@ -263,6 +263,14 @@ defmodule Archethic.Contracts.ConditionInterpreter do
     {node, acc}
   end
 
+  # Whitelist the get_first_transaction_address/0 function in condition
+  defp prewalk(
+         node = {{:atom, "get_first_transaction_address"}, _, []},
+         acc = {:ok, %{scope: {:condition, _, _}}}
+       ) do
+    {node, acc}
+  end
+
   # Whitelist the get_genesis_public_key/0 function in condition
   defp prewalk(
          node = {{:atom, "get_genesis_public_key"}, _, []},

--- a/lib/archethic/contracts/interpreter/utils.ex
+++ b/lib/archethic/contracts/interpreter/utils.ex
@@ -268,6 +268,15 @@ defmodule Archethic.Contracts.Interpreter.Utils do
     {node, acc}
   end
 
+  # Whitelist the get_first_address/1 function
+  def prewalk(
+        node = {{:atom, "get_first_transaction_address"}, _, [_address]},
+        acc = {:ok, %{scope: scope}}
+      )
+      when scope != :root do
+    {node, acc}
+  end
+
   # Whitelist the get_genesis_public_key/1 function
   def prewalk(
         node = {{:atom, "get_genesis_public_key"}, _, [_address]},

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -43,6 +43,8 @@ defmodule Archethic.P2P.Message do
     GetTransactionChainLength,
     GetTransactionInputs,
     GetUnspentOutputs,
+    GetFirstTransactionAddress,
+    FirstTransactionAddress,
     LastTransactionAddress,
     ListNodes,
     NewBeaconSlot,
@@ -100,6 +102,8 @@ defmodule Archethic.P2P.Message do
           | GetBalance.t()
           | GetTransactionInputs.t()
           | GetTransactionChainLength.t()
+          | GetFirstTransactionAddress.t()
+          | FirstTransactionAddress.t()
           | NotifyEndOfNodeSync.t()
           | GetLastTransactionAddress.t()
           | NotifyLastTransactionAddress.t()
@@ -200,12 +204,9 @@ defmodule Archethic.P2P.Message do
 
   @doc """
   Serialize a message into binary
-
   ## Examples
-
       iex> Message.encode(%Ok{})
       <<254>>
-
       iex> %Message.GetTransaction{
       ...>  address: <<0, 40, 71, 99, 6, 218, 243, 156, 193, 63, 176, 168, 22, 226, 31, 170, 119, 122,
       ...>    13, 188, 75, 49, 171, 219, 222, 133, 86, 132, 188, 206, 233, 66, 7>>

--- a/lib/archethic/p2p/message/first_transaction_address.ex
+++ b/lib/archethic/p2p/message/first_transaction_address.ex
@@ -1,0 +1,45 @@
+defmodule Archethic.P2P.Message.FirstTransactionAddress do
+  @moduledoc false
+  alias Archethic.Utils
+  @enforce_keys [:address]
+  defstruct [:address]
+
+  @type t() :: %__MODULE__{
+          address: binary()
+        }
+
+  @doc """
+         Serialize FirstTransactionAddress Struct
+
+        iex> %FirstTransactionAddress{
+        ...> address: <<0, 0, 94, 5, 249, 103, 126, 31, 43, 57, 25, 14, 187, 133, 59, 234, 201, 172,
+        ...>  3, 195, 43, 81, 81, 146, 164, 202, 147, 218, 207, 204, 31, 185, 73, 251>>
+        ...> } |> FirstTransactionAddress.serialize()
+        #address
+        <<0, 0, 94, 5, 249, 103, 126, 31, 43, 57, 25, 14, 187, 133, 59, 234, 201, 172,
+        3, 195, 43, 81, 81, 146, 164, 202, 147, 218, 207, 204, 31, 185, 73, 251>>
+  """
+  def serialize(%__MODULE__{address: address}) do
+    <<address::binary>>
+  end
+
+  @doc """
+        DeSerialize FirstTransactionAddress Struct
+
+        iex> # First address
+        ...> <<0, 0, 94, 5, 249, 103, 126, 31, 43, 57, 25, 14, 187, 133, 59, 234, 201, 172,
+        ...> 3, 195, 43, 81, 81, 146, 164, 202, 147, 218, 207, 204, 31, 185, 73, 251>>
+        ...> |> FirstTransactionAddress.deserialize()
+        {
+        %FirstTransactionAddress{
+        address: <<0, 0, 94, 5, 249, 103, 126, 31, 43, 57, 25, 14, 187, 133, 59, 234, 201, 172,
+         3, 195, 43, 81, 81, 146, 164, 202, 147, 218, 207, 204, 31, 185, 73, 251>>
+        }, ""}
+
+  """
+  def deserialize(bin) do
+    {address, <<rest::bitstring>>} = Utils.deserialize_address(bin)
+
+    {%__MODULE__{address: address}, rest}
+  end
+end

--- a/lib/archethic/p2p/message/get_first_transaction_address.ex
+++ b/lib/archethic/p2p/message/get_first_transaction_address.ex
@@ -1,0 +1,65 @@
+defmodule Archethic.P2P.Message.GetFirstTransactionAddress do
+  @moduledoc """
+  Represents a message to request the first address from a transaction chain.
+  Genesis address != first transaction address
+  Hash of current index public key gives current index address
+  Hash of genesis public key gives genesis address
+  Hash of first public key gives first transaction address
+  """
+  alias Archethic.Utils
+  alias Archethic.P2P.Message.FirstTransactionAddress
+  alias Archethic.TransactionChain
+  alias Archethic.P2P.Message.NotFound
+
+  @enforce_keys [:address]
+  defstruct [:address]
+
+  @type t() :: %__MODULE__{
+          address: binary()
+        }
+
+  @doc """
+         Serialize GetFirstTransactionAddress Struct
+
+        iex> %GetFirstTransactionAddress{
+        ...> address: <<0, 0, 94, 5, 249, 103, 126, 31, 43, 57, 25, 14, 187, 133, 59, 234, 201, 172,
+        ...>  3, 195, 43, 81, 81, 146, 164, 202, 147, 218, 207, 204, 31, 185, 73, 251>>
+        ...> } |> GetFirstTransactionAddress.serialize()
+        #address
+        <<0, 0, 94, 5, 249, 103, 126, 31, 43, 57, 25, 14, 187, 133, 59, 234, 201, 172,
+        3, 195, 43, 81, 81, 146, 164, 202, 147, 218, 207, 204, 31, 185, 73, 251>>
+  """
+  def serialize(%__MODULE__{address: address}) do
+    <<address::binary>>
+  end
+
+  @doc """
+        DeSerialize GetFirstTransactionAddress Struct
+
+        iex> # First address
+        ...> <<0, 0, 94, 5, 249, 103, 126, 31, 43, 57, 25, 14, 187, 133, 59, 234, 201, 172,
+        ...> 3, 195, 43, 81, 81, 146, 164, 202, 147, 218, 207, 204, 31, 185, 73, 251>>
+        ...> |> GetFirstTransactionAddress.deserialize()
+        {
+        %GetFirstTransactionAddress{
+        address: <<0, 0, 94, 5, 249, 103, 126, 31, 43, 57, 25, 14, 187, 133, 59, 234, 201, 172,
+         3, 195, 43, 81, 81, 146, 164, 202, 147, 218, 207, 204, 31, 185, 73, 251>>
+        }, ""}
+
+  """
+  def deserialize(bin) do
+    {address, <<rest::bitstring>>} = Utils.deserialize_address(bin)
+
+    {%__MODULE__{address: address}, rest}
+  end
+
+  def process(%__MODULE__{address: address}) do
+    case TransactionChain.get_first_transaction_address(address) do
+      {:error, :transaction_not_exists} ->
+        %NotFound{}
+
+      {:ok, first_address} ->
+        %FirstTransactionAddress{address: first_address}
+    end
+  end
+end

--- a/lib/archethic/p2p/message/message_id.ex
+++ b/lib/archethic/p2p/message/message_id.ex
@@ -25,6 +25,8 @@ defmodule Archethic.P2P.MessageId do
     GetTransactionChainLength,
     GetP2PView,
     GetFirstPublicKey,
+    GetFirstTransactionAddress,
+    FirstTransactionAddress,
     NotifyLastTransactionAddress,
     GetTransactionSummary,
     Ping,
@@ -102,7 +104,7 @@ defmodule Archethic.P2P.MessageId do
     GetLastTransactionAddress => 21,
     NotifyLastTransactionAddress => 22,
     GetTransactionSummary => 23,
-    # id 24 is available for a new message
+    GetFirstTransactionAddress => 24,
     Ping => 25,
     GetBeaconSummary => 26,
     NewBeaconSlot => 27,
@@ -119,6 +121,7 @@ defmodule Archethic.P2P.MessageId do
     NotifyReplicationValidation => 38,
 
     # Responses
+    FirstTransactionAddress => 228,
     AddressList => 229,
     ShardRepair => 230,
     SummaryAggregate => 231,

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -30,7 +30,9 @@ defmodule Archethic.TransactionChain do
     TransactionChainLength,
     TransactionInputList,
     TransactionList,
-    UnspentOutputList
+    UnspentOutputList,
+    GetFirstTransactionAddress,
+    FirstTransactionAddress
   }
 
   alias __MODULE__.MemTables.KOLedger
@@ -260,6 +262,24 @@ defmodule Archethic.TransactionChain do
   def get_last_transaction(address, fields \\ []) when is_binary(address) and is_list(fields) do
     {address, _} = get_last_address(address)
     get_transaction(address, fields)
+  end
+
+  @doc """
+  Get the first transaction Address from a genesis/chain address
+  """
+  @spec get_first_transaction_address(address :: binary()) ::
+          {:ok, address :: binary()} | {:error, :transaction_not_exists}
+  def get_first_transaction_address(address) when is_binary(address) do
+    address =
+      address
+      |> get_genesis_address()
+      |> list_chain_addresses()
+      |> Enum.at(0)
+
+    case address do
+      nil -> {:error, :transaction_not_exists}
+      {address, _datetime} -> {:ok, address}
+    end
   end
 
   @doc """
@@ -981,7 +1001,7 @@ defmodule Archethic.TransactionChain do
 
   @doc """
   Retrieve the genesis address for a chain from P2P Quorom
-  It queries the the network for genesis address
+  It queries the the network for genesis address.
   """
   @spec fetch_genesis_address_remotely(address :: binary(), list(Node.t())) ::
           {:ok, binary()} | {:error, :network_issue}
@@ -989,6 +1009,25 @@ defmodule Archethic.TransactionChain do
     case P2P.quorum_read(nodes, %GetGenesisAddress{address: address}) do
       {:ok, %GenesisAddress{address: genesis_address}} ->
         {:ok, genesis_address}
+
+      _ ->
+        {:error, :network_issue}
+    end
+  end
+
+  @doc """
+  Retrieve the First transaction address for a chain from P2P Quorom
+  """
+  @spec fetch_first_transaction_address_remotely(address :: binary(), nodes :: list(Node.t())) ::
+          {:ok, binary()} | {:error, :network_issue} | {:error, :does_not_exist}
+  def fetch_first_transaction_address_remotely(address, nodes)
+      when is_binary(address) and is_list(nodes) do
+    case P2P.quorum_read(nodes, %GetFirstTransactionAddress{address: address}) do
+      {:ok, %NotFound{}} ->
+        {:error, :does_not_exist}
+
+      {:ok, %FirstTransactionAddress{address: first_address}} ->
+        {:ok, first_address}
 
       _ ->
         {:error, :network_issue}

--- a/test/archethic/contracts/interpreter/library_test.exs
+++ b/test/archethic/contracts/interpreter/library_test.exs
@@ -1,7 +1,36 @@
 defmodule Archethic.Contracts.Interpreter.LibraryTest do
   use ArchethicCase
 
-  alias Archethic.Contracts.Interpreter.Library
+  alias Archethic.{Contracts.Interpreter.Library, P2P, P2P.Node}
+
+  alias P2P.Message.{
+    GetFirstTransactionAddress,
+    FirstTransactionAddress
+  }
 
   doctest Library
+
+  import Mox
+
+  test "get_first_transaction_address/1" do
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      first_public_key: "key1",
+      last_public_key: "key1",
+      network_patch: "AAA",
+      geo_patch: "AAA",
+      available?: true,
+      authorized?: true,
+      authorization_date: DateTime.utc_now()
+    })
+
+    MockClient
+    |> expect(:send_message, fn
+      _, %GetFirstTransactionAddress{address: "addr2"}, _ ->
+        {:ok, %FirstTransactionAddress{address: "addr1"}}
+    end)
+
+    assert "addr1" == Library.get_first_transaction_address("addr2") |> Library.decode_binary()
+  end
 end

--- a/test/archethic/p2p/message/first_transaction_address_test.exs
+++ b/test/archethic/p2p/message/first_transaction_address_test.exs
@@ -1,0 +1,19 @@
+defmodule Archethic.P2P.Message.FirstTransactionAddressTest do
+  @moduledoc false
+  use ExUnit.Case
+
+  alias Archethic.P2P.Message.FirstTransactionAddress
+  alias Archethic.P2P.Message
+
+  doctest FirstTransactionAddress
+
+  test "encode decode" do
+    msg2 = %FirstTransactionAddress{address: <<0::272>>}
+
+    assert msg2 ==
+             msg2
+             |> Message.encode()
+             |> Message.decode()
+             |> elem(0)
+  end
+end

--- a/test/archethic/p2p/message/get_first_transaction_address_test.exs
+++ b/test/archethic/p2p/message/get_first_transaction_address_test.exs
@@ -1,0 +1,49 @@
+defmodule Archethic.P2P.Message.GetFirstTransactionAddressTest do
+  @moduledoc false
+  use ExUnit.Case
+  use ArchethicCase
+
+  alias Archethic.P2P.Message.GetFirstTransactionAddress
+  alias Archethic.P2P.Message.FirstTransactionAddress
+  alias Archethic.P2P.Message
+  doctest GetFirstTransactionAddress
+
+  import Mox
+
+  test "Process" do
+    MockDB
+    |> stub(:get_genesis_address, fn
+      "not_existing_address" ->
+        "not_existing_address"
+
+      "address10" ->
+        "address0"
+    end)
+    |> stub(:list_chain_addresses, fn
+      "not_existing_address" ->
+        []
+
+      "address0" ->
+        [
+          {"address1", DateTime.utc_now() |> DateTime.add(-2000)},
+          {"addr2", DateTime.utc_now() |> DateTime.add(-1000)},
+          {"addr3", DateTime.utc_now() |> DateTime.add(-500)}
+        ]
+    end)
+
+    assert %FirstTransactionAddress{address: "address1"} ==
+             GetFirstTransactionAddress.process(%GetFirstTransactionAddress{
+               address: "address10"
+             })
+  end
+
+  test "encode decode" do
+    msg = %GetFirstTransactionAddress{address: <<0::272>>}
+
+    assert msg ==
+             msg
+             |> Message.encode()
+             |> Message.decode()
+             |> elem(0)
+  end
+end

--- a/test/archethic/transaction_chain_test.exs
+++ b/test/archethic/transaction_chain_test.exs
@@ -17,6 +17,9 @@ defmodule Archethic.TransactionChainTest do
   alias Archethic.P2P.Message.TransactionInputList
   alias Archethic.P2P.Message.UnspentOutputList
   alias Archethic.P2P.Node
+  alias Archethic.P2P.Message.GetFirstTransactionAddress
+  alias Archethic.P2P.Message.FirstTransactionAddress
+  alias Archethic.P2P.Message.NotFound
 
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
@@ -674,6 +677,165 @@ defmodule Archethic.TransactionChainTest do
       end)
 
       assert {:ok, 2} = TransactionChain.fetch_size_remotely("Alice1", nodes)
+    end
+  end
+
+  describe "fetch_first_address_remotely" do
+    test "when first txn exists" do
+      nodes = [
+        %Node{
+          first_public_key: "node1",
+          last_public_key: "node1",
+          ip: {127, 0, 0, 1},
+          port: 3000,
+          available?: true,
+          availability_history: <<1::1>>,
+          authorized?: true,
+          geo_patch: "AAA",
+          authorization_date: DateTime.utc_now()
+        },
+        %Node{
+          first_public_key: "node2",
+          last_public_key: "node2",
+          ip: {127, 0, 0, 1},
+          port: 3001,
+          availability_history: <<1::1>>,
+          geo_patch: "AAA",
+          authorized?: true,
+          authorization_date: DateTime.utc_now()
+        },
+        %Node{
+          first_public_key: "node3",
+          last_public_key: "node3",
+          geo_patch: "AAA",
+          ip: {127, 0, 0, 1},
+          port: 3002,
+          availability_history: <<1::1>>,
+          authorized?: true,
+          authorization_date: DateTime.utc_now()
+        }
+      ]
+
+      Enum.each(nodes, &P2P.add_and_connect_node/1)
+
+      MockClient
+      |> stub(:send_message, fn
+        _, %GetFirstTransactionAddress{address: "addr2"}, _ ->
+          {:ok, %FirstTransactionAddress{address: "addr1"}}
+      end)
+
+      assert {:ok, "addr1"} =
+               TransactionChain.fetch_first_transaction_address_remotely("addr2", nodes)
+    end
+
+    test "when asked from genesis address" do
+      nodes = [
+        %Node{
+          first_public_key: "node1",
+          last_public_key: "node1",
+          ip: {127, 0, 0, 1},
+          port: 3000,
+          available?: true,
+          availability_history: <<1::1>>,
+          authorized?: true,
+          geo_patch: "AAA",
+          authorization_date: DateTime.utc_now()
+        },
+        %Node{
+          first_public_key: "node2",
+          last_public_key: "node2",
+          ip: {127, 0, 0, 1},
+          port: 3001,
+          availability_history: <<1::1>>,
+          geo_patch: "AAA",
+          authorized?: true,
+          authorization_date: DateTime.utc_now()
+        },
+        %Node{
+          first_public_key: "node3",
+          last_public_key: "node3",
+          geo_patch: "AAA",
+          ip: {127, 0, 0, 1},
+          port: 3002,
+          availability_history: <<1::1>>,
+          authorized?: true,
+          authorization_date: DateTime.utc_now()
+        }
+      ]
+
+      Enum.each(nodes, &P2P.add_and_connect_node/1)
+
+      MockClient
+      |> stub(:send_message, fn
+        %Node{
+          first_public_key: "node1"
+        },
+        %GetFirstTransactionAddress{address: "addr0"},
+        _ ->
+          {:ok, %FirstTransactionAddress{address: "addr0"}}
+
+        %Node{
+          first_public_key: "node2"
+        },
+        %GetFirstTransactionAddress{address: "addr0"},
+        _ ->
+          %Archethic.P2P.Message.NotFound{}
+
+        %Node{
+          first_public_key: "node3"
+        },
+        %GetFirstTransactionAddress{address: "addr0"},
+        _ ->
+          {:ok, %FirstTransactionAddress{address: "addr0"}}
+
+        _, _, _ ->
+          {:ok, %NotFound{}}
+      end)
+
+      assert {:ok, "addr0"} =
+               TransactionChain.fetch_first_transaction_address_remotely("addr0", nodes)
+
+      assert {:error, :does_not_exist} =
+               TransactionChain.fetch_first_transaction_address_remotely(
+                 "not_existing_address",
+                 nodes
+               )
+    end
+  end
+
+  describe "First Tx" do
+    setup do
+      MockDB
+      |> stub(:get_genesis_address, fn
+        "not_existing_address" ->
+          "not_existing_address"
+
+        "addr10" ->
+          "addr0"
+      end)
+      |> stub(:list_chain_addresses, fn
+        "not_existing_address" ->
+          []
+
+        "addr0" ->
+          [
+            {"addr1", DateTime.utc_now() |> DateTime.add(-2000)},
+            {"addr2", DateTime.utc_now() |> DateTime.add(-1000)},
+            {"addr3", DateTime.utc_now() |> DateTime.add(-500)}
+          ]
+      end)
+      |> stub(:get_transaction, fn "addr1", _ ->
+        {:ok, %Transaction{address: "addr1"}}
+      end)
+
+      :ok
+    end
+
+    test "get_first_transaction_address/2" do
+      assert {:ok, "addr1"} = TransactionChain.get_first_transaction_address("addr10")
+
+      assert {:error, :transaction_not_exists} =
+               TransactionChain.get_first_transaction_address("not_existing_address")
     end
   end
 end


### PR DESCRIPTION
# Description

This pr introduces a support for a new function for SC  Library that is `get_tx_address` with new p2p message
 `GetTxFirstAddress` .
- Need
   -  Genesis address is not same as first tx address
   - genesis address is the name of the file of the tx chain
   - genesis_address = hash(genesis_public_key) i=0
   - first_tx_address = hash( first public key) i= 1

Fixes 

- [ ] #740 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- Unit Tests 
- Integrations tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
