### PR TITLE
Fix replication chain ingestion

### DIFF
--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -35,7 +35,6 @@ defmodule Archethic.DB do
   @callback write_beacon_summary(Summary.t()) :: :ok
   @callback clear_beacon_summaries() :: :ok
   @callback write_beacon_summaries_aggregate(SummaryAggregate.t()) :: :ok
-  @callback write_transaction_chain(Enumerable.t()) :: :ok
   @callback list_transactions(fields :: list()) :: Enumerable.t()
   @callback list_io_transactions(fields :: list()) :: Enumerable.t()
   @callback add_last_transaction_address(binary(), binary(), DateTime.t()) :: :ok

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -198,27 +198,6 @@ defmodule Archethic.TransactionChain do
   end
 
   @doc """
-  Persist a new transaction chain
-  """
-  @spec write(Enumerable.t()) :: :ok
-  def write(chain) do
-    sorted_chain = Enum.sort_by(chain, & &1.validation_stamp.timestamp, {:desc, DateTime})
-
-    %Transaction{
-      address: tx_address,
-      type: tx_type
-    } = Enum.at(sorted_chain, 0)
-
-    DB.write_transaction_chain(sorted_chain)
-    Enum.each(sorted_chain, &KOLedger.remove_transaction(&1.address))
-
-    Logger.info("Transaction Chain stored",
-      transaction_address: Base.encode16(tx_address),
-      transaction_type: tx_type
-    )
-  end
-
-  @doc """
   Write an invalid transaction
   """
   @spec write_ko_transaction(Transaction.t(), list()) :: :ok

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -785,7 +785,7 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
             })
         })
 
-      assert {:error, error} = PendingTransactionValidation.validate(tx, DateTime.utc_now())
+      assert {:error, _error} = PendingTransactionValidation.validate(tx, DateTime.utc_now())
     end
 
     test "should return :error when we deploy a wrong aeweb ref transaction" do
@@ -810,7 +810,7 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
             })
         })
 
-      assert {:error, reason} = PendingTransactionValidation.validate(tx, DateTime.utc_now())
+      assert {:error, _reason} = PendingTransactionValidation.validate(tx, DateTime.utc_now())
     end
   end
 end

--- a/test/archethic/replication_test.exs
+++ b/test/archethic/replication_test.exs
@@ -80,10 +80,6 @@ defmodule Archethic.ReplicationTest do
     tx = create_valid_transaction(unspent_outputs)
 
     MockDB
-    # |> stub(:write_transaction_chain, fn [^tx] ->
-    #  send(me, :replicated)
-    #  :ok
-    # end)
     |> expect(:write_transaction, fn ^tx, _ ->
       send(me, :replicated)
       :ok

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -41,7 +41,6 @@ defmodule ArchethicCase do
     MockDB
     |> stub(:list_transactions, fn _ -> [] end)
     |> stub(:write_transaction, fn _, _ -> :ok end)
-    |> stub(:write_transaction_chain, fn _ -> :ok end)
     |> stub(:get_transaction, fn _, _ -> {:error, :transaction_not_exists} end)
     |> stub(:get_transaction_chain, fn _, _, _ -> {[], false, nil} end)
     |> stub(:scan_chain, fn _, _, _, _ -> {[], false, nil} end)


### PR DESCRIPTION
# Description

There is some case where a node should replicate a transaction but it do not due to some latency or network issue. If there is a new transaction in this chain and the node is again storage node of this transaction, it will store the previous transaction without ingesting data as it should have been done.
This PR fix this problem by ingesting if needed the previous transaction of a chain

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
