### PR TITLE
SC: add get_calls/0  action

### DIFF
--- a/lib/archethic/contracts/interpreter/action.ex
+++ b/lib/archethic/contracts/interpreter/action.ex
@@ -138,15 +138,7 @@ defmodule Archethic.Contracts.ActionInterpreter do
     {node, {:ok, %{context | scope: {:function, function, parent_scope}}}}
   end
 
-  # Whitelist the get_calls/1
-  defp prewalk(
-         node = {{:atom, "get_calls"}, _, [_]},
-         acc = {:ok, %{scope: {:actions, _}}}
-       ) do
-    {node, acc}
-  end
-
-  # Whitelist the get_calls/0
+  # Whitelist the get_calls/0 (this will be expanded to a get_calls(contract.address) in postwalk)
   defp prewalk(
          node = {{:atom, "get_calls"}, _, []},
          acc = {:ok, %{scope: {:actions, _}}}

--- a/lib/archethic/contracts/interpreter/action.ex
+++ b/lib/archethic/contracts/interpreter/action.ex
@@ -138,9 +138,9 @@ defmodule Archethic.Contracts.ActionInterpreter do
     {node, {:ok, %{context | scope: {:function, function, parent_scope}}}}
   end
 
-  # Whitelist the get_inputs/1
+  # Whitelist the get_calls/1
   defp prewalk(
-         node = {{:atom, "get_inputs"}, _, [_]},
+         node = {{:atom, "get_calls"}, _, [_]},
          acc = {:ok, %{scope: {:actions, _}}}
        ) do
     {node, acc}

--- a/lib/archethic/contracts/interpreter/action.ex
+++ b/lib/archethic/contracts/interpreter/action.ex
@@ -146,6 +146,14 @@ defmodule Archethic.Contracts.ActionInterpreter do
     {node, acc}
   end
 
+  # Whitelist the get_calls/0
+  defp prewalk(
+         node = {{:atom, "get_calls"}, _, []},
+         acc = {:ok, %{scope: {:actions, _}}}
+       ) do
+    {node, acc}
+  end
+
   # Whitelist the add_uco_transfer function parameters
   defp prewalk(
          node = {{:atom, "to"}, address},
@@ -322,6 +330,16 @@ defmodule Archethic.Contracts.ActionInterpreter do
       "oracle" ->
         {node, {:ok, :oracle, actions}}
     end
+  end
+
+  defp postwalk(
+         node = {{:atom, "get_calls"}, _, []},
+         test
+       ) do
+    IO.inspect(test)
+
+    # see condition.build_conditions (return ast modified (contract address = subject of get_calls))
+    # return {node, _}
   end
 
   defp postwalk(node, acc) do

--- a/lib/archethic/contracts/interpreter/action.ex
+++ b/lib/archethic/contracts/interpreter/action.ex
@@ -332,14 +332,24 @@ defmodule Archethic.Contracts.ActionInterpreter do
     end
   end
 
+  # expand get_calls() to get_calls(contract.address)
   defp postwalk(
-         node = {{:atom, "get_calls"}, _, []},
-         test
+         {{:atom, "get_calls"}, meta, []},
+         acc
        ) do
-    IO.inspect(test)
+    node = {
+      {:atom, "get_calls"},
+      meta,
+      [
+        {:get_in, meta,
+         [
+           {:scope, meta, nil},
+           ["contract", "address"]
+         ]}
+      ]
+    }
 
-    # see condition.build_conditions (return ast modified (contract address = subject of get_calls))
-    # return {node, _}
+    {node, acc}
   end
 
   defp postwalk(node, acc) do

--- a/lib/archethic/contracts/interpreter/action.ex
+++ b/lib/archethic/contracts/interpreter/action.ex
@@ -138,6 +138,14 @@ defmodule Archethic.Contracts.ActionInterpreter do
     {node, {:ok, %{context | scope: {:function, function, parent_scope}}}}
   end
 
+  # Whitelist the get_inputs/1
+  defp prewalk(
+         node = {{:atom, "get_inputs"}, _, [_]},
+         acc = {:ok, %{scope: {:actions, _}}}
+       ) do
+    {node, acc}
+  end
+
   # Whitelist the add_uco_transfer function parameters
   defp prewalk(
          node = {{:atom, "to"}, address},

--- a/lib/archethic/contracts/interpreter/library.ex
+++ b/lib/archethic/contracts/interpreter/library.ex
@@ -191,16 +191,14 @@ defmodule Archethic.Contracts.Interpreter.Library do
   """
   @spec get_calls(binary()) :: list(map())
   def get_calls(contract_address) do
-    contract_address = Utils.maybe_decode_hex(contract_address)
-
-    # TODO: parallelize?
-    TransactionLookup.list_contract_transactions(contract_address)
-    |> Enum.map(fn {address, _, _} -> address end)
-    |> Enum.map(fn address ->
+    contract_address
+    |> Utils.maybe_decode_hex()
+    |> TransactionLookup.list_contract_transactions()
+    |> Enum.map(fn {address, _, _} ->
+      # TODO: parallelize
       {:ok, tx} = TransactionChain.get_transaction(address, [], :io)
-      tx
+      ContractConstants.from_transaction(tx)
     end)
-    |> Enum.map(&ContractConstants.from_transaction(&1))
   end
 
   @doc """

--- a/lib/archethic/contracts/interpreter/library.ex
+++ b/lib/archethic/contracts/interpreter/library.ex
@@ -5,8 +5,11 @@ defmodule Archethic.Contracts.Interpreter.Library do
     Election,
     P2P,
     P2P.Message.GetFirstPublicKey,
+    P2P.Message.GetGenesisAddress,
     P2P.Message.FirstPublicKey,
-    TransactionChain
+    P2P.Message.GenesisAddress,
+    TransactionChain,
+    TransactionChain.TransactionInput
   }
 
   @doc """
@@ -180,6 +183,15 @@ defmodule Archethic.Contracts.Interpreter.Library do
   def size(binary) when is_binary(binary), do: binary |> decode_binary() |> byte_size()
   def size(list) when is_list(list), do: length(list)
   def size(map) when is_map(map), do: map_size(map)
+
+  @doc """
+  Get the inputs of the transaction with given hexadecimal address
+  """
+  @spec get_inputs(binary()) :: list(TransactionInput.t())
+  def get_inputs(encoded_address) do
+    address = Base.decode16!(encoded_address, case: :mixed)
+    Archethic.get_transaction_inputs(address)
+  end
 
   @doc """
   Get the genesis public key

--- a/lib/archethic/contracts/interpreter/library.ex
+++ b/lib/archethic/contracts/interpreter/library.ex
@@ -5,9 +5,7 @@ defmodule Archethic.Contracts.Interpreter.Library do
     Election,
     P2P,
     P2P.Message.GetFirstPublicKey,
-    P2P.Message.GetGenesisAddress,
     P2P.Message.FirstPublicKey,
-    P2P.Message.GenesisAddress,
     TransactionChain,
     TransactionChain.TransactionInput
   }
@@ -188,8 +186,16 @@ defmodule Archethic.Contracts.Interpreter.Library do
   Get the inputs of the transaction with given hexadecimal address
   """
   @spec get_inputs(binary()) :: list(TransactionInput.t())
-  def get_inputs(encoded_address) do
-    address = Base.decode16!(encoded_address, case: :mixed)
+  def get_inputs(maybe_encoded_address) do
+    address =
+      case Base.decode16(maybe_encoded_address) do
+        :error ->
+          maybe_encoded_address
+
+        {:ok, address} ->
+          address
+      end
+
     Archethic.get_transaction_inputs(address)
   end
 

--- a/lib/archethic/contracts/interpreter/transaction_statements.ex
+++ b/lib/archethic/contracts/interpreter/transaction_statements.ex
@@ -118,6 +118,14 @@ defmodule Archethic.Contracts.Interpreter.TransactionStatements do
     put_in(tx, [Access.key(:data), Access.key(:content)], content)
   end
 
+  def set_content(tx = %Transaction{}, content) when is_integer(content) do
+    put_in(tx, [Access.key(:data), Access.key(:content)], Integer.to_string(content))
+  end
+
+  def set_content(tx = %Transaction{}, content) when is_float(content) do
+    put_in(tx, [Access.key(:data), Access.key(:content)], Float.to_string(content))
+  end
+
   @doc """
   Set transaction smart contract code
 

--- a/lib/archethic/contracts/interpreter/transaction_statements.ex
+++ b/lib/archethic/contracts/interpreter/transaction_statements.ex
@@ -6,6 +6,8 @@ defmodule Archethic.Contracts.Interpreter.TransactionStatements do
   alias Archethic.TransactionChain.TransactionData.Ownership
   alias Archethic.TransactionChain.TransactionData.UCOLedger.Transfer, as: UCOTransfer
 
+  alias Archethic.Contracts.Interpreter.Utils
+
   @doc """
   Set the transaction type
 
@@ -47,7 +49,7 @@ defmodule Archethic.Contracts.Interpreter.TransactionStatements do
     update_in(
       tx,
       [Access.key(:data), Access.key(:ledger), Access.key(:uco), Access.key(:transfers)],
-      &[%UCOTransfer{to: decode_binary(to), amount: amount} | &1]
+      &[%UCOTransfer{to: Utils.maybe_decode_hex(to), amount: amount} | &1]
     )
   end
 
@@ -92,9 +94,9 @@ defmodule Archethic.Contracts.Interpreter.TransactionStatements do
       &[
         %TokenTransfer{
           token_id: Map.get(map_args, "token_id", 0),
-          to: decode_binary(to),
+          to: Utils.maybe_decode_hex(to),
           amount: amount,
-          token_address: decode_binary(token_address)
+          token_address: Utils.maybe_decode_hex(token_address)
         }
         | &1
       ]
@@ -173,9 +175,9 @@ defmodule Archethic.Contracts.Interpreter.TransactionStatements do
 
     ownership =
       Ownership.new(
-        decode_binary(secret),
-        decode_binary(secret_key),
-        Enum.map(authorized_public_keys, &decode_binary(&1))
+        Utils.maybe_decode_hex(secret),
+        Utils.maybe_decode_hex(secret_key),
+        Enum.map(authorized_public_keys, &Utils.maybe_decode_hex(&1))
       )
 
     update_in(
@@ -204,15 +206,7 @@ defmodule Archethic.Contracts.Interpreter.TransactionStatements do
     update_in(
       tx,
       [Access.key(:data), Access.key(:recipients)],
-      &[decode_binary(recipient_address) | &1]
+      &[Utils.maybe_decode_hex(recipient_address) | &1]
     )
-  end
-
-  defp decode_binary(bin) do
-    if String.match?(bin, ~r/^[[:xdigit:]]+$/) do
-      Base.decode16!(bin, case: :mixed)
-    else
-      bin
-    end
   end
 end

--- a/lib/archethic/contracts/interpreter/utils.ex
+++ b/lib/archethic/contracts/interpreter/utils.ex
@@ -378,6 +378,21 @@ defmodule Archethic.Contracts.Interpreter.Utils do
     ast
   end
 
+  @doc """
+  Decode an hexadecimal binary or no-op
+  """
+  @spec maybe_decode_hex(binary()) :: binary()
+  def maybe_decode_hex(bin) do
+    if String.match?(bin, ~r/^[[:xdigit:]]+$/) do
+      case Base.decode16(bin, case: :mixed) do
+        {:ok, bin} -> bin
+        :error -> bin
+      end
+    else
+      bin
+    end
+  end
+
   defp do_postwalk_execution({:=, metadata, [var_name, content]}, acc) do
     put_ast =
       {{:., metadata, [{:__aliases__, metadata, [:Map]}, :put]}, metadata,

--- a/lib/archethic/contracts/interpreter/utils.ex
+++ b/lib/archethic/contracts/interpreter/utils.ex
@@ -340,6 +340,7 @@ defmodule Archethic.Contracts.Interpreter.Utils do
 
   def postwalk(node, acc) when is_binary(node) do
     if String.printable?(node) do
+      # uniform hexadecimal to all uppercase
       case Base.decode16(node, case: :mixed) do
         {:ok, hex} ->
           {Base.encode16(hex), acc}

--- a/lib/archethic/contracts/loader.ex
+++ b/lib/archethic/contracts/loader.ex
@@ -103,16 +103,12 @@ defmodule Archethic.Contracts.Loader do
         protocol_version
       )
 
-      case Worker.execute(contract_address, tx) do
-        :ok ->
-          Logger.info("Transaction towards contract ingested",
-            transaction_address: Base.encode16(tx_address),
-            transaction_type: tx_type
-          )
+      Worker.execute(contract_address, tx)
 
-        _ ->
-          :ok
-      end
+      Logger.info("Transaction towards contract ingested",
+        transaction_address: Base.encode16(tx_address),
+        transaction_type: tx_type
+      )
     end)
   end
 

--- a/lib/archethic/contracts/loader.ex
+++ b/lib/archethic/contracts/loader.ex
@@ -96,9 +96,6 @@ defmodule Archethic.Contracts.Loader do
         transaction_type: tx_type
       )
 
-      # execute asynchronously the contract
-      Worker.execute(contract_address, tx)
-
       TransactionLookup.add_contract_transaction(
         contract_address,
         tx_address,
@@ -106,10 +103,16 @@ defmodule Archethic.Contracts.Loader do
         protocol_version
       )
 
-      Logger.info("Transaction towards contract ingested",
-        transaction_address: Base.encode16(tx_address),
-        transaction_type: tx_type
-      )
+      case Worker.execute(contract_address, tx) do
+        :ok ->
+          Logger.info("Transaction towards contract ingested",
+            transaction_address: Base.encode16(tx_address),
+            transaction_type: tx_type
+          )
+
+        _ ->
+          :ok
+      end
     end)
   end
 

--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -16,7 +16,11 @@ defmodule Archethic.DB do
 
   @type storage_type() :: :chain | :io
 
+  @callback get_transaction(address :: binary()) ::
+              {:ok, Transaction.t()} | {:error, :transaction_not_exists}
   @callback get_transaction(address :: binary(), fields :: list()) ::
+              {:ok, Transaction.t()} | {:error, :transaction_not_exists}
+  @callback get_transaction(address :: binary(), fields :: list(), storage_type :: storage_type()) ::
               {:ok, Transaction.t()} | {:error, :transaction_not_exists}
   @callback get_beacon_summary(summary_address :: binary()) ::
               {:ok, Summary.t()} | {:error, :summary_not_exists}

--- a/lib/archethic/db/embedded_impl.ex
+++ b/lib/archethic/db/embedded_impl.ex
@@ -135,13 +135,7 @@ defmodule Archethic.DB.EmbeddedImpl do
 
       {:error, :transaction_not_exists} ->
         if storage_type == :io do
-          case ChainReader.get_io_transaction(address, fields, db_path()) do
-            nil ->
-              {:error, :transaction_not_exists}
-
-            transaction ->
-              {:ok, transaction}
-          end
+          ChainReader.get_io_transaction(address, fields, db_path())
         else
           {:error, :transaction_not_exists}
         end

--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -202,6 +202,21 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
   end
 
   @doc """
+  Read a transaction from io storage
+  """
+  @spec get_io_transaction(binary(), fields :: list(), db_path :: String.t()) ::
+          Transaction.t() | nil
+  def get_io_transaction(address, fields, db_path) do
+    filepath = ChainWriter.io_path(db_path, address)
+
+    if File.exists?(filepath) do
+      read_io_transaction(filepath, fields)
+    else
+      nil
+    end
+  end
+
+  @doc """
   List all the transactions in io storage
   """
   @spec list_io_transactions(fields :: list(), db_path :: String.t()) ::

--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -205,14 +205,14 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
   Read a transaction from io storage
   """
   @spec get_io_transaction(binary(), fields :: list(), db_path :: String.t()) ::
-          Transaction.t() | nil
+          {:ok, Transaction.t()} | {:error, :transaction_not_exists}
   def get_io_transaction(address, fields, db_path) do
     filepath = ChainWriter.io_path(db_path, address)
 
     if File.exists?(filepath) do
-      read_io_transaction(filepath, fields)
+      {:ok, read_io_transaction(filepath, fields)}
     else
-      nil
+      {:error, :transaction_not_exists}
     end
   end
 

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -142,11 +142,11 @@ defmodule Archethic.TransactionChain do
           {:ok, Transaction.t()}
           | {:error, :transaction_not_exists}
           | {:error, :invalid_transaction}
-  def get_transaction(address, fields \\ []) when is_list(fields) do
+  def get_transaction(address, fields \\ [], storage_type \\ :chain) when is_list(fields) do
     if KOLedger.has_transaction?(address) do
       {:error, :invalid_transaction}
     else
-      DB.get_transaction(address, fields)
+      DB.get_transaction(address, fields, storage_type)
     end
   end
 

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -563,7 +563,7 @@ defmodule Archethic.BootstrapTest do
         ^addr2, _ -> true
         ^addr1, _ -> true
       end)
-      |> expect(:get_transaction, fn ^addr3, _ ->
+      |> expect(:get_transaction, fn ^addr3, _, _ ->
         {:error, :transaction_not_exists}
       end)
       |> stub(:write_transaction, fn tx, _ ->

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -484,6 +484,14 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
          }}
     end)
 
+    MockDB
+    |> stub(:get_transaction, fn _, _, _ ->
+      {:ok, %Transaction{data: %TransactionData{content: "input tx content"}}}
+    end)
+
+    # TODO: find a way to check the inputs from the contract
+    # TODO: maybe with a "set_content json(inputs)"
+
     assert %Transaction{data: %TransactionData{content: "1"}} =
              ~s"""
              actions triggered_by: transaction do

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -310,6 +310,31 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
              |> ActionInterpreter.execute()
   end
 
+  test "get_calls() should be expanded to get_calls(contract.address)" do
+    {:ok, :transaction, ast} =
+      ~S"""
+        actions triggered_by: transaction do
+          get_calls()
+        end
+      """
+      |> Interpreter.sanitize_code()
+      |> elem(1)
+      |> ActionInterpreter.parse()
+
+    assert {{:., [line: 2],
+             [
+               {:__aliases__, [alias: Archethic.Contracts.Interpreter.Library], [:Library]},
+               :get_calls
+             ]}, [line: 2],
+            [
+              {:get_in, meta,
+               [
+                 {:scope, meta, nil},
+                 ["contract", "address"]
+               ]}
+            ]} = ast
+  end
+
   test "shall use get_genesis_address/1 in actions" do
     key = <<0::16, :crypto.strong_rand_bytes(32)::binary>>
 

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -509,7 +509,7 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
     assert %Transaction{data: %TransactionData{content: "1"}} =
              ~s"""
              actions triggered_by: transaction do
-               transactions = get_calls("64F05F5236088FC64D1BB19BD13BC548F1C49A42432AF02AD9024D8A2990B2B4")
+               transactions = get_calls()
                set_content size(transactions)
              end
              """
@@ -517,6 +517,10 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
              |> elem(1)
              |> ActionInterpreter.parse()
              |> elem(2)
-             |> ActionInterpreter.execute()
+             |> ActionInterpreter.execute(%{
+               "contract" => %{
+                 "address" => "64F05F5236088FC64D1BB19BD13BC548F1C49A42432AF02AD9024D8A2990B2B4"
+               }
+             })
   end
 end

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -487,8 +487,8 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
     assert %Transaction{data: %TransactionData{content: "1"}} =
              ~s"""
              actions triggered_by: transaction do
-               address = get_inputs("64F05F5236088FC64D1BB19BD13BC548F1C49A42432AF02AD9024D8A2990B2B4")
-               set_content size(address)
+               inputs = get_inputs("64F05F5236088FC64D1BB19BD13BC548F1C49A42432AF02AD9024D8A2990B2B4")
+               set_content size(inputs)
              end
              """
              |> Interpreter.sanitize_code()

--- a/test/archethic/contracts/interpreter/library_test.exs
+++ b/test/archethic/contracts/interpreter/library_test.exs
@@ -25,12 +25,15 @@ defmodule Archethic.Contracts.Interpreter.LibraryTest do
       authorization_date: DateTime.utc_now()
     })
 
+    addr1 = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::bitstring>>
+    addr2 = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::bitstring>>
+
     MockClient
     |> expect(:send_message, fn
-      _, %GetFirstTransactionAddress{address: "addr2"}, _ ->
-        {:ok, %FirstTransactionAddress{address: "addr1"}}
+      _, %GetFirstTransactionAddress{address: ^addr1}, _ ->
+        {:ok, %FirstTransactionAddress{address: addr2}}
     end)
 
-    assert "addr1" == Library.get_first_transaction_address("addr2") |> Library.decode_binary()
+    assert Base.encode16(addr2) == Library.get_first_transaction_address(Base.encode16(addr1))
   end
 end

--- a/test/archethic/contracts/worker_test.exs
+++ b/test/archethic/contracts/worker_test.exs
@@ -442,7 +442,7 @@ defmodule Archethic.Contracts.WorkerTest do
       PubSub.notify_new_transaction("@Oracle1", :oracle, DateTime.utc_now())
 
       MockDB
-      |> expect(:get_transaction, fn "@Oracle1", _ -> {:ok, oracle_tx} end)
+      |> expect(:get_transaction, fn "@Oracle1", _, _ -> {:ok, oracle_tx} end)
 
       receive do
         {:transaction_sent, tx} ->

--- a/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
+++ b/test/archethic/crypto/keystore/shared_secrets/software_impl_test.exs
@@ -34,7 +34,7 @@ defmodule Archethic.Crypto.SharedSecrets.SoftwareImplTest do
       |> expect(:list_addresses_by_type, fn :node_shared_secrets ->
         [:crypto.strong_rand_bytes(32)]
       end)
-      |> expect(:get_transaction, fn _, _ ->
+      |> expect(:get_transaction, fn _, _, _ ->
         {:ok,
          %Transaction{
            data: %TransactionData{

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -186,7 +186,7 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
       assert :ok = PoolsMemTable.put_pool_member(:technical_council, tx.previous_public_key)
 
       MockDB
-      |> expect(:get_transaction, fn _, _ ->
+      |> expect(:get_transaction, fn _, _, _ ->
         {:ok,
          %Transaction{
            data: %TransactionData{

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -350,7 +350,7 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
       |> stub(:get_last_chain_address, fn address ->
         address
       end)
-      |> stub(:get_transaction, fn _address, [:address, :type] ->
+      |> stub(:get_transaction, fn _address, [:address, :type], _ ->
         {:error, :transaction_not_exists}
       end)
 
@@ -391,7 +391,7 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
       |> stub(:get_last_chain_address, fn address ->
         address
       end)
-      |> stub(:get_transaction, fn _address, [:address, :type] ->
+      |> stub(:get_transaction, fn _address, [:address, :type], _ ->
         {:error, :transaction_not_exists}
       end)
 
@@ -429,7 +429,7 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
       |> stub(:get_last_chain_address, fn address ->
         address
       end)
-      |> stub(:get_transaction, fn _address, [:address, :type] ->
+      |> stub(:get_transaction, fn _address, [:address, :type], _ ->
         {:error, :transaction_not_exists}
       end)
 
@@ -854,7 +854,7 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
       |> expect(:get_last_chain_address, fn _, _ ->
         {"OtherAddress", DateTime.utc_now()}
       end)
-      |> expect(:get_transaction, fn _, _ ->
+      |> expect(:get_transaction, fn _, _, _ ->
         {:ok, %Transaction{type: :node_rewards}}
       end)
 

--- a/test/archethic/oracle_chain/scheduler_test.exs
+++ b/test/archethic/oracle_chain/scheduler_test.exs
@@ -165,7 +165,7 @@ defmodule Archethic.OracleChain.SchedulerTest do
       })
 
       MockDB
-      |> expect(:get_transaction, fn _, _ ->
+      |> expect(:get_transaction, fn _, _, _ ->
         {:ok,
          %Transaction{
            type: :oracle,

--- a/test/archethic/replication_test.exs
+++ b/test/archethic/replication_test.exs
@@ -311,7 +311,7 @@ defmodule Archethic.ReplicationTest do
 
       MockDB
       |> expect(:get_genesis_address, fn _ -> "@Alice0" end)
-      |> expect(:get_transaction, fn _, _ ->
+      |> expect(:get_transaction, fn _, _, _ ->
         {:ok,
          %Transaction{
            validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()},
@@ -344,7 +344,7 @@ defmodule Archethic.ReplicationTest do
 
       MockDB
       |> expect(:get_genesis_address, fn _ -> "@Alice0" end)
-      |> expect(:get_transaction, fn _, _ ->
+      |> expect(:get_transaction, fn _, _, _ ->
         {:ok,
          %Transaction{
            validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()},

--- a/test/archethic/self_repair/self_repair_test.exs
+++ b/test/archethic/self_repair/self_repair_test.exs
@@ -39,7 +39,7 @@ defmodule Archethic.SelfRepairTest do
 
     MockDB
     |> expect(:get_last_chain_address, fn "Alice2" -> {"Alice2", ~U[2022-11-27 00:10:00Z]} end)
-    |> expect(:get_transaction, fn "Alice2", _ ->
+    |> expect(:get_transaction, fn "Alice2", _, _ ->
       {:ok, %Transaction{validation_stamp: %ValidationStamp{timestamp: ~U[2022-11-27 00:10:00Z]}}}
     end)
     |> expect(:get_genesis_address, 2, fn "Alice2" -> "Alice0" end)

--- a/test/archethic_web/live/rewards_live_test.exs
+++ b/test/archethic_web/live/rewards_live_test.exs
@@ -41,7 +41,7 @@ defmodule ArchethicWeb.RewardsLiveTest do
         {address, time}
       end)
     end)
-    |> stub(:get_transaction, fn _address, [:type] ->
+    |> stub(:get_transaction, fn _address, [:type], _ ->
       {:ok,
        %Transaction{
          type: :node_rewards

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -42,6 +42,7 @@ defmodule ArchethicCase do
     |> stub(:list_transactions, fn _ -> [] end)
     |> stub(:write_transaction, fn _, _ -> :ok end)
     |> stub(:get_transaction, fn _, _ -> {:error, :transaction_not_exists} end)
+    |> stub(:get_transaction, fn _, _, _ -> {:error, :transaction_not_exists} end)
     |> stub(:get_transaction_chain, fn _, _, _ -> {[], false, nil} end)
     |> stub(:list_last_transaction_addresses, fn -> [] end)
     |> stub(:add_last_transaction_address, fn _, _, _ -> :ok end)


### PR DESCRIPTION
# Description

This PR aims at adding a `get_calls/1` function to the smart contracts' actions. 
This function can be used to create aggregator contracts that do not do anything until some threshold.
I found few issues along the way that I will create and fix outside of this PR. 

- [x] Create a get_calls/0 that will automatically add the contract.address 
- [x] Update smart contract documentation

Should the get_calls/1 be available outside the action block?

Fixes #512

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have tested with this contract: 

```
condition inherit: [
	type: true,
	content: true,
	uco_transfers: true
]

condition transaction: [
	uco_transfers: size() > 0
]

actions triggered_by: transaction do
	transactions = get_calls(contract.address)
	set_content size(transactions)
	set_type transfer
	add_uco_transfer to: "000030831178cd6a49fe446778455a7a980729a293bfa16b0a1d2743935db210da76", amount: 1337
end
```

When I trigger this contract, a new transaction in the contract chain have the content updated to "1". 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
