### PR TITLE
Allow 10 seconds of drift between validators

### DIFF
--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1047,7 +1047,7 @@ defmodule Archethic.Mining.ValidationContext do
          validation_time: validation_time
        }) do
     diff = DateTime.diff(timestamp, validation_time)
-    diff <= 3 and diff > -10
+    diff <= 10 and diff > -10
   end
 
   defp valid_stamp_signature(stamp = %ValidationStamp{}, %__MODULE__{


### PR DESCRIPTION
# Description

In production, we have sometimes atomic commitment which is not reached because the timestamp validation is too strict.
This PR aims to increase the boundary of the validation time for 10s.
This number is significant in terms of latency and prevent too broad drift.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
