### PR TITLE
DB: Nested fields behaviour change

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -388,11 +388,18 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
           read_transaction(fd, fields, limit, position, Map.put(acc, column_name, value))
         else
           # Check if we need to take this field based on the selection criteria
-          if column_name in fields do
-            read_transaction(fd, fields, limit, position, Map.put(acc, column_name, value))
-          else
-            # We continue to the next as the selection critieria didn't match
-            read_transaction(fd, fields, limit, position, acc)
+          cond do
+            column_name in fields ->
+              # match a field
+              read_transaction(fd, fields, limit, position, Map.put(acc, column_name, value))
+
+            Enum.any?(fields, &String.starts_with?(column_name, &1 <> ".")) ->
+              # match a nested field
+              read_transaction(fd, fields, limit, position, Map.put(acc, column_name, value))
+
+            true ->
+              # We continue to the next as the selection critieria didn't match
+              read_transaction(fd, fields, limit, position, acc)
           end
         end
 

--- a/test/archethic/db/embedded_impl_test.exs
+++ b/test/archethic/db/embedded_impl_test.exs
@@ -166,10 +166,23 @@ defmodule Archethic.DB.EmbeddedTest do
       tx1 = TransactionFactory.create_valid_transaction([], content: "Hello")
       :ok = EmbeddedImpl.write_transaction(tx1)
 
+      # data is a nested field
+      # ledger_operations is a nested field in a nested field
       assert {:ok,
               %Transaction{
-                data: %TransactionData{content: "Hello"}
-              }} = IO.inspect(EmbeddedImpl.get_transaction(tx1.address, [:data]))
+                address: nil,
+                data: %TransactionData{content: "Hello"},
+                validation_stamp: %ValidationStamp{
+                  timestamp: nil,
+                  ledger_operations: %LedgerOperations{fee: fee}
+                }
+              }} =
+               EmbeddedImpl.get_transaction(tx1.address, [
+                 :data,
+                 validation_stamp: [:ledger_operations]
+               ])
+
+      assert fee != 0.0
     end
 
     test "should filter with nested fields" do

--- a/test/archethic/db/embedded_impl_test.exs
+++ b/test/archethic/db/embedded_impl_test.exs
@@ -12,6 +12,7 @@ defmodule Archethic.DB.EmbeddedTest do
   alias Archethic.DB.EmbeddedImpl.ChainWriter
 
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionSummary
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
@@ -159,6 +160,16 @@ defmodule Archethic.DB.EmbeddedTest do
 
       assert {:ok, %Transaction{type: :transfer, address: nil}} =
                EmbeddedImpl.get_transaction(tx1.address, [:type])
+    end
+
+    test "should filter with the given field which is nested" do
+      tx1 = TransactionFactory.create_valid_transaction([], content: "Hello")
+      :ok = EmbeddedImpl.write_transaction(tx1)
+
+      assert {:ok,
+              %Transaction{
+                data: %TransactionData{content: "Hello"}
+              }} = IO.inspect(EmbeddedImpl.get_transaction(tx1.address, [:data]))
     end
 
     test "should filter with nested fields" do


### PR DESCRIPTION
# Description

DB will now fill the entire field if asked without specifiying nested fields. (See issue for example)
It should not break anything since we are more permissive than before.

Fixes #823

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests added

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
