### PR TITLE
Specify the hash algorithm in the sc library functions #610

### DIFF
--- a/lib/archethic/contracts/interpreter/library.ex
+++ b/lib/archethic/contracts/interpreter/library.ex
@@ -108,12 +108,38 @@ defmodule Archethic.Contracts.Interpreter.Library do
 
   ## Examples
 
+      iex> Library.hash("hello","sha256")
+      "2CF24DBA5FB0A30E26E83B2AC5B9E29E1B161E5C1FA7425E73043362938B9824"
+
       iex> Library.hash("hello")
       "2CF24DBA5FB0A30E26E83B2AC5B9E29E1B161E5C1FA7425E73043362938B9824"
   """
-  @spec hash(binary()) :: binary()
-  def hash(content) when is_binary(content) do
-    :crypto.hash(:sha256, decode_binary(content)) |> Base.encode16()
+  @spec hash(
+          content :: binary(),
+          algo :: binary()
+        ) ::
+          binary()
+  def hash(content, algo \\ "sha256") when is_binary(content) do
+    algo =
+      case algo do
+        "sha256" ->
+          :sha256
+
+        "sha512" ->
+          :sha512
+
+        "sha3_256" ->
+          :sha3_256
+
+        "sha3_512" ->
+          :sha3_512
+
+        "blake2b" ->
+          :blake2b
+      end
+
+    :crypto.hash(algo, decode_binary(content))
+    |> Base.encode16()
   end
 
   @doc """

--- a/lib/archethic/contracts/interpreter/utils.ex
+++ b/lib/archethic/contracts/interpreter/utils.ex
@@ -20,6 +20,8 @@ defmodule Archethic.Contracts.Interpreter.Utils do
                                                 )
                                                 |> Enum.into(%{})
 
+  @supported_hash Archethic.Crypto.list_supported_hash_functions(:string)
+
   @transaction_fields [
     "address",
     "type",
@@ -218,6 +220,11 @@ defmodule Archethic.Contracts.Interpreter.Utils do
   # Whitelist the hash/1 function
   def prewalk(node = {{:atom, "hash"}, _, [_data]}, acc = {:ok, %{scope: scope}})
       when scope != :root,
+      do: {node, acc}
+
+  # Whitelist the hash/2 function
+  def prewalk(node = {{:atom, "hash"}, _, [_data, algo]}, acc = {:ok, %{scope: scope}})
+      when scope != :root and algo in @supported_hash,
       do: {node, acc}
 
   # Whitelist the regex_match?/2 function

--- a/lib/archethic/crypto.ex
+++ b/lib/archethic/crypto.ex
@@ -1315,4 +1315,9 @@ defmodule Archethic.Crypto do
   def authorized_key_origin?(<<_::8, _::8, _::binary>>, []) do
     true
   end
+
+  @supported_hashes Application.compile_env(:archethic, [__MODULE__, :supported_hashes])
+  def list_supported_hash_functions(), do: @supported_hashes
+  @string_hashes Enum.map(@supported_hashes, &Atom.to_string/1)
+  def list_supported_hash_functions(:string), do: @string_hashes
 end

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -343,4 +343,44 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
              |> elem(2)
              |> ActionInterpreter.execute()
   end
+
+  describe "Hash in action" do
+    test "Hash/2 blake2b" do
+      assert %Transaction{data: %TransactionData{content: "yes"}} =
+               ~s"""
+               actions triggered_by: transaction do
+                 address = hash("hello darkness ","blake2b")
+                 if address == "CCFF7E67D673C76E3AAA242BF6B726DD75EF1C5AA201A527CFC76754B23AE0EAF83960DFC9377C4EDA7CF25EF3A9D0E66B54A3993F8AC2ECB5CA9CBDB79454F7" do
+                   set_content "yes"
+                 else
+                   set_content "no"
+                 end
+               end
+               """
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionInterpreter.parse()
+               |> elem(2)
+               |> ActionInterpreter.execute()
+    end
+
+    test "Hash/1" do
+      assert %Transaction{data: %TransactionData{content: "yes"}} =
+               ~s"""
+               actions triggered_by: transaction do
+                 address = hash("hello darkness ")
+                 if address == "E96FC07DD7B9EE9CDA01DF26DC9AFA78388EB33B12FDB8619C27BEAA3130CF18" do
+                   set_content "yes"
+                 else
+                   set_content "no"
+                 end
+               end
+               """
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionInterpreter.parse()
+               |> elem(2)
+               |> ActionInterpreter.execute()
+    end
+  end
 end

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -95,7 +95,7 @@ defmodule Archethic.ContractsTest do
       ]
 
       actions triggered_by: transaction do
-        add_uco_transfer to: "\3265CCD78CD74984FAB3CC6984D30C8C82044EBBAB1A4FFFB683BDB2D8C5BCF9", amount: 1000000000
+        add_uco_transfer to: \"3265CCD78CD74984FAB3CC6984D30C8C82044EBBAB1A4FFFB683BDB2D8C5BCF9\", amount: 1000000000
         set_content "hello"
         set_type transfer
       end


### PR DESCRIPTION
# Description
- This pr Updates the existing function in SC library `hash` to support multiple hash algos.
``` elixir
      hash("data","sha256")
      hash("data","sha512")   
      hash("data","sha3_256")
      hash("data","sha3_512")
      hash("data","blake2b")
```
- Also introduces an unused aehash function for ae padding

- [x] #610 

## Type of change

Please delete options that are not relevant.


- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

- Unit Tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
