### PR TITLE
Fix previous chain stream

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -337,7 +337,9 @@ defmodule Archethic do
     case TransactionChain.get_genesis_address(address) do
       ^address ->
         # if returned address is same as given, it means the DB does not contain the value
-        TransactionChain.fetch_genesis_address_remotely(address)
+        nodes = Election.chain_storage_nodes(address, P2P.authorized_and_available_nodes())
+
+        TransactionChain.fetch_genesis_address_remotely(address, nodes)
 
       genesis_address ->
         {:ok, genesis_address}

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -741,10 +741,10 @@ defmodule Archethic.TransactionChain do
   defp do_stream_chain(nodes, address, paging_state, size) do
     case do_fetch_transaction_chain(nodes, address, paging_state) do
       {transactions, false, _} ->
-        {[transactions], {:end, size + length(transactions)}}
+        {transactions, {:end, size + length(transactions)}}
 
       {transactions, true, paging_state} ->
-        {[transactions], {address, paging_state, size + length(transactions)}}
+        {transactions, {address, paging_state, size + length(transactions)}}
     end
   end
 
@@ -970,24 +970,11 @@ defmodule Archethic.TransactionChain do
 
   @doc """
   Retrieve the last transaction address for a chain stored locally
-  It queries the the network for genesis address
   """
-  @spec get_last_local_address(address :: binary()) :: binary() | nil
-  def get_last_local_address(address) when is_binary(address) do
-    case fetch_genesis_address_remotely(address) do
-      {:ok, genesis_address} ->
-        last_stored_address = get_last_stored_address(genesis_address)
-
-        if last_stored_address == genesis_address, do: nil, else: last_stored_address
-
-      _ ->
-        nil
-    end
-  end
-
-  defp get_last_stored_address(genesis_address) do
+  @spec get_last_stored_address(genesis_address :: binary()) :: binary() | nil
+  def get_last_stored_address(genesis_address) do
     list_chain_addresses(genesis_address)
-    |> Enum.reduce_while(genesis_address, fn {address, _}, acc ->
+    |> Enum.reduce_while(nil, fn {address, _}, acc ->
       if transaction_exists?(address), do: {:cont, address}, else: {:halt, acc}
     end)
   end

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -996,11 +996,9 @@ defmodule Archethic.TransactionChain do
   Retrieve the genesis address for a chain from P2P Quorom
   It queries the the network for genesis address
   """
-  @spec fetch_genesis_address_remotely(address :: binary()) ::
+  @spec fetch_genesis_address_remotely(address :: binary(), list(Node.t())) ::
           {:ok, binary()} | {:error, :network_issue}
-  def fetch_genesis_address_remotely(address) when is_binary(address) do
-    nodes = Election.chain_storage_nodes(address, P2P.authorized_and_available_nodes())
-
+  def fetch_genesis_address_remotely(address, nodes) when is_binary(address) do
     case P2P.quorum_read(nodes, %GetGenesisAddress{address: address}) do
       {:ok, %GenesisAddress{address: genesis_address}} ->
         {:ok, genesis_address}

--- a/lib/archethic_web/faucet_rate_limiter.ex
+++ b/lib/archethic_web/faucet_rate_limiter.ex
@@ -4,8 +4,6 @@ defmodule ArchethicWeb.FaucetRateLimiter do
   use GenServer
   @vsn Mix.Project.config()[:version]
 
-  alias Archethic.TransactionChain
-
   @faucet_rate_limit Application.compile_env!(:archethic, :faucet_rate_limit)
   @faucet_rate_limit_expiry Application.compile_env!(:archethic, :faucet_rate_limit_expiry)
   @block_period_expiry @faucet_rate_limit_expiry
@@ -93,7 +91,7 @@ defmodule ArchethicWeb.FaucetRateLimiter do
     }
 
     address =
-      case TransactionChain.fetch_genesis_address_remotely(address) do
+      case Archethic.fetch_genesis_address_remotely(address) do
         {:ok, genesis_address} ->
           genesis_address
 

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -53,7 +53,7 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
   end
 
   def get_token(address) do
-    t1 = Task.async(fn -> TransactionChain.fetch_genesis_address_remotely(address) end)
+    t1 = Task.async(fn -> Archethic.fetch_genesis_address_remotely(address) end)
     t2 = Task.async(fn -> get_transaction_content(address) end)
 
     with {:ok, {:ok, genesis_address}} <- Task.yield(t1),

--- a/test/archethic/transaction_chain_test.exs
+++ b/test/archethic/transaction_chain_test.exs
@@ -233,15 +233,11 @@ defmodule Archethic.TransactionChainTest do
                %Transaction{}
              ]
            }}
-
-        _, %GetTransactionChainLength{}, _ ->
-          %TransactionChainLength{length: 1}
       end)
 
       assert 1 =
                TransactionChain.stream_remotely("Alice1", nodes)
                |> Enum.to_list()
-               |> List.first()
                |> length()
     end
 
@@ -314,7 +310,6 @@ defmodule Archethic.TransactionChainTest do
       assert 5 =
                TransactionChain.stream_remotely("Alice1", nodes)
                |> Enum.to_list()
-               |> List.first()
                |> length()
     end
   end


### PR DESCRIPTION
# Description

For the previous chain stream during replication, we don't fetch chain if the previous address of the transaction is the genesis address of the chain.
Also we stop the stream to the specified address to not crash during self repair

Fixes #835 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated unit test
Run 2 nodes, wait for some summaries
start a third node, the self repair should not crash for transaction_already_exists error

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
