### PR TITLE
SC: add reduce/3 action

### DIFF
--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -184,6 +184,8 @@ defmodule Archethic.Contracts.Interpreter do
     end
   end
 
+  # We do not want user-code to generate atoms because it can exhaust the atom table
+  # https://hexdocs.pm/elixir/1.14.2/Code.html#string_to_quoted/2-the-static_atoms_encoder-function
   defp atom_encoder(atom, _) do
     if atom in ["if"] do
       {:ok, String.to_atom(atom)}

--- a/lib/archethic/contracts/interpreter/action.ex
+++ b/lib/archethic/contracts/interpreter/action.ex
@@ -70,6 +70,7 @@ defmodule Archethic.Contracts.ActionInterpreter do
       {:error, "unexpected term - System - L2"}
 
   """
+
   @spec parse(any()) :: {:ok, trigger(), Macro.t()} | {:error, String.t()}
   def parse(ast) do
     case Macro.traverse(
@@ -89,6 +90,7 @@ defmodule Archethic.Contracts.ActionInterpreter do
       {:error, InterpreterUtils.format_error_reason(node, reason)}
 
     {:error, node} ->
+      IO.inspect(node, label: "err")
       {:error, InterpreterUtils.format_error_reason(node, "unexpected term")}
   end
 
@@ -280,21 +282,29 @@ defmodule Archethic.Contracts.ActionInterpreter do
     throw({:error, reason, node})
   end
 
-  # Whitelist the reduce/3 and enter the reduce scope
-  defp prewalk(
-         node = {{:atom, "reduce"}, _, [_, _, _]},
-         _acc = {:ok, %{scope: parent_scope}}
-       ) do
-    {node, {:ok, %{scope: {:reduce, parent_scope}}}}
-  end
+  # # Whitelist the reduce/3 and enter the reduce scope
+  # defp prewalk(
+  #        node = {{:atom, "reduce"}, _, [_, _, _]},
+  #        _acc = {:ok, %{scope: parent_scope}}
+  #      ) do
+  #   # {:reduce, [],
+  #   #  [
+  #   #    {{:., [], [{:list, [], Elixir}, :x]}, [no_parens: true], []},
+  #   #    [as: {:item, [], Elixir}, with: [count: 0]],
+  #   #    [
+  #   #      do: {:+, [context: Elixir, imports: [{1, Kernel}, {2, Kernel}]],
+  #   #       [{:count, [], Elixir}, {:item, [], Elixir}]}
+  #   #    ]
+  #   #  ]}
+  # end
 
-  # Delegate all nodes inside the reduce
-  defp prewalk(
-         node,
-         acc = {:ok, %{scope: {:reduce, _}}}
-       ) do
-    Archethic.Contracts.Interpreter.ActionReduce.prewalk(node, acc)
-  end
+  # # Delegate all nodes inside the reduce
+  # defp prewalk(
+  #        node,
+  #        acc = {:ok, %{scope: {:reduce, _}}}
+  #      ) do
+  #   Archethic.Contracts.Interpreter.ActionReduce.prewalk(node, acc)
+  # end
 
   defp prewalk(node, acc) do
     InterpreterUtils.prewalk(node, acc)
@@ -352,13 +362,13 @@ defmodule Archethic.Contracts.ActionInterpreter do
     {node, acc}
   end
 
-  # Exit the reduce scope
-  defp postwalk(
-         node = {{:atom, "reduce"}, _, [_, _, _]},
-         _acc = {:ok, %{scope: {:reduce, parent_scope}}}
-       ) do
-    {node, {:ok, %{scope: parent_scope}}}
-  end
+  # # Exit the reduce scope
+  # defp postwalk(
+  #        node = {{:atom, "reduce"}, _, [_, _, _]},
+  #        _acc = {:ok, %{scope: {:reduce, parent_scope}}}
+  #      ) do
+  #   {node, {:ok, %{scope: parent_scope}}}
+  # end
 
   defp postwalk(node, acc) do
     InterpreterUtils.postwalk(node, acc)

--- a/lib/archethic/contracts/interpreter/action_reduce.ex
+++ b/lib/archethic/contracts/interpreter/action_reduce.ex
@@ -72,6 +72,14 @@ defmodule Archethic.Contracts.Interpreter.ActionReduce do
     {node, acc}
   end
 
+  # Whitelist variable assignation inside the reduce
+  def prewalk(
+        node = {:=, _, _},
+        acc
+      ) do
+    {node, acc}
+  end
+
   # Whitelist every utils function inside the reducer
   def prewalk(node, acc) do
     Archethic.Contracts.Interpreter.Utils.prewalk(node, acc)

--- a/lib/archethic/contracts/interpreter/action_reduce.ex
+++ b/lib/archethic/contracts/interpreter/action_reduce.ex
@@ -1,0 +1,79 @@
+defmodule Archethic.Contracts.Interpreter.ActionReduce do
+  @moduledoc """
+  AST manipulation related to the reduce/3
+  """
+
+  @reduce_item_atom :ae_sc_reduce_item__
+  @reduce_acc_atom :ae_sc_reduce_acc__
+
+  # Whitelist the lambdas
+  def prewalk(
+        node = {:fn, _, [_]},
+        acc
+      ) do
+    {node, acc}
+  end
+
+  # Whitelist the lambdas
+  # Transforms the lambda args into hardcoded atoms in the entire context
+  #
+  # we do this because we don't want user to be able to create atoms (prevent atoms' table exhaustion)
+  def prewalk(
+        _node = {:->, meta, [args, body]},
+        acc
+      ) do
+    # we know the lambda of a reduce has 2 arguments
+    [
+      {reduce_item_atom, reduce_item_meta, reduce_item_ctx},
+      {reduce_acc_atom, reduce_acc_meta, reduce_acc_ctx}
+    ] = args
+
+    # replace them on the args node
+    args_sanified = [
+      {@reduce_item_atom, reduce_item_meta, reduce_item_ctx},
+      {@reduce_acc_atom, reduce_acc_meta, reduce_acc_ctx}
+    ]
+
+    # replace them on the body node
+    body_sanified =
+      Macro.prewalk(body, fn
+        body_node = {atom_name = {:atom, _}, meta, context} ->
+          cond do
+            atom_name == reduce_item_atom ->
+              {@reduce_item_atom, meta, context}
+
+            atom_name == reduce_acc_atom ->
+              {@reduce_acc_atom, meta, context}
+
+            true ->
+              body_node
+          end
+
+        body_node ->
+          body_node
+      end)
+
+    {{:->, meta, [args_sanified, body_sanified]}, acc}
+  end
+
+  # Whitelist the lambda 1st argument
+  def prewalk(
+        node = {@reduce_item_atom, _, _},
+        acc
+      ) do
+    {node, acc}
+  end
+
+  # Whitelist the lambda 2nd argument
+  def prewalk(
+        node = {@reduce_acc_atom, _, _},
+        acc
+      ) do
+    {node, acc}
+  end
+
+  # Whitelist every utils function inside the reducer
+  def prewalk(node, acc) do
+    Archethic.Contracts.Interpreter.Utils.prewalk(node, acc)
+  end
+end

--- a/lib/archethic/contracts/interpreter/action_reduce.ex
+++ b/lib/archethic/contracts/interpreter/action_reduce.ex
@@ -80,6 +80,30 @@ defmodule Archethic.Contracts.Interpreter.ActionReduce do
     {node, acc}
   end
 
+  # Dot access to item
+  def prewalk(
+        _node = {{:., meta, [{@reduce_item_atom, _, _}, {:atom, atom_name}]}, _, _},
+        acc
+      ) do
+    node =
+      {:get_in, [context: Elixir, imports: [{2, Kernel}]],
+       [{@reduce_item_atom, meta, nil}, [atom_name]]}
+
+    {node, acc}
+  end
+
+  # Dot access to acc
+  def prewalk(
+        _node = {{:., meta, [{@reduce_acc_atom, _, _}, {:atom, atom_name}]}, _, _},
+        acc
+      ) do
+    node =
+      {:get_in, [context: Elixir, imports: [{2, Kernel}]],
+       [{@reduce_acc_atom, meta, nil}, [atom_name]]}
+
+    {node, acc}
+  end
+
   # Whitelist every utils function inside the reducer
   def prewalk(node, acc) do
     Archethic.Contracts.Interpreter.Utils.prewalk(node, acc)

--- a/lib/archethic/contracts/interpreter/action_reduce.ex
+++ b/lib/archethic/contracts/interpreter/action_reduce.ex
@@ -3,109 +3,301 @@ defmodule Archethic.Contracts.Interpreter.ActionReduce do
   AST manipulation related to the reduce/3
   """
 
-  @reduce_item_atom :ae_sc_reduce_item__
-  @reduce_acc_atom :ae_sc_reduce_acc__
+  alias Archethic.Contracts.Interpreter.Utils
+  alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
 
-  # Whitelist the lambdas
-  def prewalk(
-        node = {:fn, _, [_]},
+  @reduce_item :sc_reduce_item
+  @reduce_acc :sc_reduce_acc
+  @reduce_scope :sc_reduce_scope
+
+  @spec parse(any()) :: {:ok, Macro.t()} | {:error, term()}
+  def parse(ast) do
+    case Macro.traverse(
+           ast,
+           {:ok, %{scope: :root}},
+           fn a, b ->
+             # IO.inspect({a, b}, label: "prewalk")
+             prewalk(a, b)
+           end,
+           fn a, b ->
+             # IO.inspect({a, b}, label: "postwalk")
+             postwalk(a, b)
+           end
+         ) do
+      {node, {:ok, _}} ->
+        {:ok, node}
+    end
+  catch
+    {:error, reason, node} ->
+      {:error, Utils.format_error_reason(node, reason)}
+
+    {:error, node} ->
+      {:error, Utils.format_error_reason(node, "unexpected term")}
+  end
+
+  @doc """
+  Execute the code
+  """
+  @spec execute(Macro.t(), map()) :: Transaction.t()
+  def execute(code, constants \\ %{}) do
+    case Code.eval_quoted(code, scope: constants) do
+      {acc, _ctx} ->
+        # IO.inspect({acc, ctx}, label: "execute result")
         acc
-      ) do
+    end
+  end
+
+  # ----------------------------------------------------------------------
+  #
+  #                      _ __  _ __ ___
+  #                     | '_ \| '__/ _ \
+  #                     | |_) | | |  __/
+  #                     | .__/|_|  \___|
+  #                     |_|
+  #
+  # ----------------------------------------------------------------------
+  # ------- root ------------
+  # enter in reduce_definition
+  defp prewalk(
+         node =
+           {{:atom, "reduce"}, _,
+            [
+              firstArg,
+              [
+                {{:atom, "as"}, asVariable},
+                {{:atom, "with"}, keywordList}
+              ],
+              [do: _]
+            ]},
+         {:ok, %{scope: :root}}
+       ) do
+    with true <-
+           AST.is_variable?(firstArg) or
+             AST.is_function_call?(firstArg) or
+             AST.is_list?(firstArg),
+         true <- AST.is_keyword_list?(keywordList),
+         true <- AST.is_variable?(asVariable) do
+      {node, {:ok, %{scope: :reduce_definition, parent_scope: :root}}}
+    else
+      false ->
+        throw({:error, "invalid reduce syntax", node})
+    end
+  end
+
+  # ------- reduce_definition ------------
+
+  # ASK SAM TO PUT KEYWORD IN UTILS AND NOT IN ACTION
+  # allow pairs
+  defp prewalk(
+         node = {{:atom, _}, _},
+         acc = {:ok, %{scope: :reduce_definition}}
+       ) do
     {node, acc}
   end
 
-  # Whitelist the lambdas
-  # Transforms the lambda args into hardcoded atoms in the entire context
+  defp prewalk(
+         node = [do: _],
+         _acc = {:ok, %{scope: :reduce_definition}}
+       ) do
+    {node, {:ok, %{scope: :reduce_block, parent_scope: :reduce_definition}}}
+  end
+
+  # pass through utils
+  defp prewalk(
+         node,
+         acc = {:ok, %{scope: :reduce_definition}}
+       ) do
+    Utils.prewalk(node, acc)
+  end
+
+  # ------- reduce_block ------------
+  # explicit forbid a reduce inside a reduce
+  # this is already not allowed with scope, but this provide a helpful message to the user
+  defp prewalk(
+         node = {{:atom, "reduce"}, _, [_, _, _]},
+         {:ok, %{scope: :reduce_block}}
+       ) do
+    throw({:error, "Nested reduce are forbidden", node})
+  end
+
+  # ASK SAM TO PUT ASSIGN IN UTILS AND NOT IN ACTION
+  # allow pairs
+  defp prewalk(
+         node = {:=, _, _},
+         acc = {:ok, %{scope: :reduce_block}}
+       ) do
+    {node, acc}
+  end
+
+  # pass through utils
+  defp prewalk(
+         node,
+         acc = {:ok, %{scope: :reduce_block}}
+       ) do
+    Utils.prewalk(node, acc)
+  end
+
+  # ----------------------------------------------------------------------
+  #                                      _
+  #                      _ __   ___  ___| |_
+  #                     | '_ \ / _ \/ __| __|
+  #                     | |_) | (_) \__ | |_
+  #                     | .__/ \___/|___/\__|
+  #                     |_|
   #
-  # we do this because we don't want user to be able to create atoms (prevent atoms' table exhaustion)
-  def prewalk(
-        _node = {:->, meta, [args, body]},
-        acc
-      ) do
-    # we know the lambda of a reduce has 2 arguments
-    [
-      {reduce_item_atom, reduce_item_meta, reduce_item_ctx},
-      {reduce_acc_atom, reduce_acc_meta, reduce_acc_ctx}
-    ] = args
-
-    # replace them on the args node
-    args_sanified = [
-      {@reduce_item_atom, reduce_item_meta, reduce_item_ctx},
-      {@reduce_acc_atom, reduce_acc_meta, reduce_acc_ctx}
-    ]
-
-    # replace them on the body node
-    body_sanified =
-      Macro.prewalk(body, fn
-        body_node = {atom_name = {:atom, _}, meta, context} ->
-          cond do
-            atom_name == reduce_item_atom ->
-              {@reduce_item_atom, meta, context}
-
-            atom_name == reduce_acc_atom ->
-              {@reduce_acc_atom, meta, context}
-
-            true ->
-              body_node
-          end
-
-        body_node ->
-          body_node
+  # ----------------------------------------------------------------------
+  # Transform reduce into a list comprehension
+  defp postwalk(
+         _node =
+           {{:atom, "reduce"}, _,
+            [
+              enumerable,
+              [
+                {{:atom, "as"}, {{:atom, itemName}, _, nil}},
+                {{:atom, "with"}, withPropList}
+              ],
+              [do: block]
+            ]},
+         acc = {:ok, %{scope: :reduce_definition}}
+       ) do
+    # unwrap the {:atom, _} from the with proplist
+    withPropList =
+      withPropList
+      |> Enum.map(fn {{:atom, atomName}, value} ->
+        {atomName, value}
       end)
 
-    {{:->, meta, [args_sanified, body_sanified]}, acc}
-  end
+    # acc variables
+    accVariables = withPropList |> Enum.map(&elem(&1, 0))
 
-  # Whitelist the lambda 1st argument
-  def prewalk(
-        node = {@reduce_item_atom, _, _},
-        acc
-      ) do
-    {node, acc}
-  end
+    # The block which is the content of the reduce is now going to be traversed
+    # The prewalk is used to whitelist what is possible to do in a reduce
+    # the postwalk is used to transform variable into the proper accessor
+    {block, _} =
+      Macro.traverse(
+        block,
+        :no_acc,
+        fn
+          # assignation
+          node =
+              {:=, meta,
+               [
+                 {{:atom, atomName}, _, nil},
+                 content
+               ]},
+          acc0 ->
+            cond do
+              atomName == itemName ->
+                throw({:error, ~s(Rebinding the "#{itemName}" variable is forbidden), node})
 
-  # Whitelist the lambda 2nd argument
-  def prewalk(
-        node = {@reduce_acc_atom, _, _},
-        acc
-      ) do
-    {node, acc}
-  end
+              atomName in accVariables ->
+                # variable is in the "with"
+                node =
+                  {:=, meta,
+                   [
+                     {@reduce_acc, meta, nil},
+                     {{:., meta, [{:__aliases__, meta, [:Map]}, :put]}, meta,
+                      [{@reduce_acc, meta, nil}, atomName, content]}
+                   ]}
 
-  # Whitelist variable assignation inside the reduce
-  def prewalk(
-        node = {:=, _, _},
-        acc
-      ) do
-    {node, acc}
-  end
+                {node, acc0}
 
-  # Dot access to item
-  def prewalk(
-        _node = {{:., meta, [{@reduce_item_atom, _, _}, {:atom, atom_name}]}, _, _},
-        acc
-      ) do
+              true ->
+                # variable is in the scope
+                node =
+                  {:=, meta,
+                   [
+                     {@reduce_scope, meta, nil},
+                     {{:., meta, [{:__aliases__, meta, [:Map]}, :put]}, meta,
+                      [{@reduce_scope, meta, nil}, atomName, content]}
+                   ]}
+
+                {node, acc0}
+            end
+
+          # pass through
+          node, acc0 ->
+            {node, acc0}
+        end,
+        fn
+          # read variable
+          {{:atom, atomName}, meta, nil}, acc0 ->
+            node =
+              cond do
+                atomName == itemName ->
+                  # variable is the "as"
+                  {@reduce_item, meta, nil}
+
+                atomName in accVariables ->
+                  # variable is in the "with"
+                  {{:., meta, [Access, :get]}, meta, [{@reduce_acc, meta, nil}, atomName]}
+
+                true ->
+                  # variable is in the scope
+                  {{:., meta, [{:__aliases__, meta, [:Map]}, :get]}, meta,
+                   [{@reduce_scope, meta, nil}, atomName]}
+              end
+
+            {node, acc0}
+
+          # pass through
+          node, acc0 ->
+            {node, acc0}
+        end
+      )
+
+    # Transform to an Enum.reduce
     node =
-      {:get_in, [context: Elixir, imports: [{2, Kernel}]],
-       [{@reduce_item_atom, meta, nil}, [atom_name]]}
+      {{:., [], [{:__aliases__, [alias: false], [:Enum]}, :reduce]}, [],
+       [
+         enumerable,
+         {:%{}, [], withPropList},
+         {:fn, [],
+          [
+            {:->, [],
+             [
+               [{@reduce_item, [], nil}, {@reduce_acc, [], nil}],
+               {:__block__, [],
+                [
+                  # initiate a scope for the variables assigned within the reduce
+                  {:=, [], [{@reduce_scope, [], nil}, {:%{}, [], []}]},
+
+                  # user code
+                  block,
+
+                  # call the identity function on reduce_scope
+                  # to avoid compilation warning if user do not use it
+                  {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
+                   [{@reduce_scope, [], nil}]},
+
+                  # return the accumulator
+                  {@reduce_acc, [], nil}
+                ]}
+             ]}
+          ]}
+       ]}
 
     {node, acc}
   end
 
-  # Dot access to acc
-  def prewalk(
-        _node = {{:., meta, [{@reduce_acc_atom, _, _}, {:atom, atom_name}]}, _, _},
-        acc
-      ) do
-    node =
-      {:get_in, [context: Elixir, imports: [{2, Kernel}]],
-       [{@reduce_acc_atom, meta, nil}, [atom_name]]}
-
-    {node, acc}
+  # exit the reduce scope
+  defp postwalk(
+         node = {{:atom, "reduce"}, _, [_, _, _]},
+         {:ok, %{scope: :reduce_definition}}
+       ) do
+    {node, {:ok, %{scope: :root}}}
   end
 
-  # Whitelist every utils function inside the reducer
-  def prewalk(node, acc) do
-    Archethic.Contracts.Interpreter.Utils.prewalk(node, acc)
+  # exit the reduce block scope
+  defp postwalk(
+         node = [do: _],
+         _acc = {:ok, %{scope: :reduce_block, parent_scope: parent_scope}}
+       ) do
+    {node, {:ok, %{scope: parent_scope}}}
+  end
+
+  # pass through
+  defp postwalk(node, acc) do
+    {node, acc}
   end
 end

--- a/lib/archethic/contracts/interpreter/ast_helper.ex
+++ b/lib/archethic/contracts/interpreter/ast_helper.ex
@@ -2,6 +2,22 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
   @moduledoc """
   Helper functions to manipulate AST
   """
+
+  @doc """
+  Return wether the given ast is a keyword list
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("[]")
+    iex> ASTHelper.is_keyword_list?(ast)
+    true
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("[sum: 1, product: 10]")
+    iex> ASTHelper.is_keyword_list?(ast)
+    true
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("[1,2,3]")
+    iex> ASTHelper.is_keyword_list?(ast)
+    false
+  """
   @spec is_keyword_list?(Macro.t()) :: boolean()
   def is_keyword_list?(ast) when is_list(ast) do
     Enum.all?(ast, fn
@@ -15,16 +31,58 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
 
   def is_keyword_list?(_), do: false
 
+  @doc """
+  Return wether the given ast is a variable
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("hello")
+    iex> ASTHelper.is_variable?(ast)
+    true
+  """
   @spec is_variable?(Macro.t()) :: boolean()
   def is_variable?({{:atom, _}, _, nil}), do: true
   def is_variable?(_), do: false
 
+  @doc """
+  Return wether the given ast is a function call or not
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("hello(12)")
+    iex> ASTHelper.is_function_call?(ast)
+    true
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("hello()")
+    iex> ASTHelper.is_function_call?(ast)
+    true
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("hello")
+    iex> ASTHelper.is_function_call?(ast)
+    false
+  """
   @spec is_function_call?(Macro.t()) :: boolean()
   def is_function_call?({{:atom, _}, _, list}) when is_list(list), do: true
   def is_function_call?(_), do: false
 
-  @spec is_list?(Macro.t()) :: boolean()
-  def is_list?(ast), do: is_list(ast)
+  @doc """
+  Transform an ast that is a keyword list in a proplist
+  (because we don't allow atom from user-code)
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("[]")
+    iex> ASTHelper.keyword_to_proplist(ast)
+    []
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("[sum: 1]")
+    iex> ASTHelper.keyword_to_proplist(ast)
+    [{"sum", 1}]
+
+    iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("[sum: 1, product: 10]")
+    iex> ASTHelper.keyword_to_proplist(ast)
+    [{"sum", 1}, {"product", 10}]
+  """
+  @spec keyword_to_proplist(Macro.t()) :: :proplists.proplist()
+  def keyword_to_proplist(ast) do
+    Enum.map(ast, fn {{:atom, atomName}, value} ->
+      {atomName, value}
+    end)
+  end
 
   # --------------
   # DEBUG
@@ -35,7 +93,7 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
   """
   @spec io_inspect(Macro.t()) :: Macro.t()
   def io_inspect(var) do
-    {{:., [], [{:__aliases__, [alias: false], [:IO]}, :inspect]}, [], [var]}
+    quote do: IO.inspect(unquote(var))
   end
 
   @doc """
@@ -43,6 +101,6 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
   """
   @spec io_inspect(Macro.t(), binary()) :: Macro.t()
   def io_inspect(var, label) do
-    {{:., [], [{:__aliases__, [alias: false], [:IO]}, :inspect]}, [], [var, [label: label]]}
+    quote do: IO.inspect(unquote(var), label: unquote(label))
   end
 end

--- a/lib/archethic/contracts/interpreter/ast_helper.ex
+++ b/lib/archethic/contracts/interpreter/ast_helper.ex
@@ -1,0 +1,48 @@
+defmodule Archethic.Contracts.Interpreter.ASTHelper do
+  @moduledoc """
+  Helper functions to manipulate AST
+  """
+  @spec is_keyword_list?(Macro.t()) :: boolean()
+  def is_keyword_list?(ast) when is_list(ast) do
+    Enum.all?(ast, fn
+      {{:atom, bin}, _value} when is_binary(bin) ->
+        true
+
+      _ ->
+        false
+    end)
+  end
+
+  def is_keyword_list?(_), do: false
+
+  @spec is_variable?(Macro.t()) :: boolean()
+  def is_variable?({{:atom, _}, _, nil}), do: true
+  def is_variable?(_), do: false
+
+  @spec is_function_call?(Macro.t()) :: boolean()
+  def is_function_call?({{:atom, _}, _, list}) when is_list(list), do: true
+  def is_function_call?(_), do: false
+
+  @spec is_list?(Macro.t()) :: boolean()
+  def is_list?(ast), do: is_list(ast)
+
+  # --------------
+  # DEBUG
+  # --------------
+
+  @doc """
+  Return the AST of IO.inspect(var)
+  """
+  @spec io_inspect(Macro.t()) :: Macro.t()
+  def io_inspect(var) do
+    {{:., [], [{:__aliases__, [alias: false], [:IO]}, :inspect]}, [], [var]}
+  end
+
+  @doc """
+  Return the AST of IO.inspect(var, label: label)
+  """
+  @spec io_inspect(Macro.t(), binary()) :: Macro.t()
+  def io_inspect(var, label) do
+    {{:., [], [{:__aliases__, [alias: false], [:IO]}, :inspect]}, [], [var, [label: label]]}
+  end
+end

--- a/lib/archethic/contracts/interpreter/library.ex
+++ b/lib/archethic/contracts/interpreter/library.ex
@@ -193,6 +193,51 @@ defmodule Archethic.Contracts.Interpreter.Library do
   def size(map) when is_map(map), do: map_size(map)
 
   @doc """
+  Append item to the list (slow)
+
+  ## Examples
+    iex> Library.append([], 1)
+    [1]
+
+    iex> Library.append([1], [2])
+    [1, [2]]
+  """
+  @spec append(list(any()), any()) :: list(any())
+  def append(list, item) do
+    list ++ [item]
+  end
+
+  @doc """
+  Prepend item to the list (fast)
+
+  ## Examples
+    iex> Library.prepend([], 1)
+    [1]
+
+    iex> Library.prepend([1], [2])
+    [[2], 1]
+  """
+  @spec prepend(list(any()), any()) :: list(any())
+  def prepend(list, item) do
+    [item | list]
+  end
+
+  @doc """
+  Concat both list
+
+  ## Examples
+  iex> Library.concat([], [])
+  []
+
+  iex> Library.concat([1,2], [3,4])
+  [1,2,3,4]
+  """
+  @spec concat(list(), list()) :: list()
+  def concat(list1, list2) do
+    list1 ++ list2
+  end
+
+  @doc """
   Get the inputs(type= :call) of the given transaction
 
   This is useful for contracts that want to throttle their calls

--- a/lib/archethic/contracts/interpreter/library.ex
+++ b/lib/archethic/contracts/interpreter/library.ex
@@ -226,15 +226,26 @@ defmodule Archethic.Contracts.Interpreter.Library do
   Concat both list
 
   ## Examples
-  iex> Library.concat([], [])
-  []
 
-  iex> Library.concat([1,2], [3,4])
-  [1,2,3,4]
+    iex> Library.concat([], [])
+    []
+
+    iex> Library.concat("", "")
+    ""
+
+    iex> Library.concat("hello", " world")
+    "hello world"
+
+    iex> Library.concat([1,2], [3,4])
+    [1,2,3,4]
   """
-  @spec concat(list(), list()) :: list()
-  def concat(list1, list2) do
+  @spec concat(list() | String.t(), list() | String.t()) :: list() | String.t()
+  def concat(list1, list2) when is_list(list1) and is_list(list2) do
     list1 ++ list2
+  end
+
+  def concat(str1, str2) when is_binary(str1) and is_binary(str2) do
+    str1 <> str2
   end
 
   @doc """

--- a/lib/archethic/contracts/interpreter/library.ex
+++ b/lib/archethic/contracts/interpreter/library.ex
@@ -166,6 +166,14 @@ defmodule Archethic.Contracts.Interpreter.Library do
   end
 
   @doc """
+  Invokes fun for each element in the enumerable with the accumulator.
+  """
+  @spec reduce(Enumerable.t(), any(), (any(), any() -> any())) :: any()
+  def reduce(list, acc, func) do
+    Enum.reduce(list, acc, func)
+  end
+
+  @doc """
   Determines the size  of the input
 
   ## Examples

--- a/lib/archethic/contracts/interpreter/library.ex
+++ b/lib/archethic/contracts/interpreter/library.ex
@@ -145,6 +145,10 @@ defmodule Archethic.Contracts.Interpreter.Library do
     |> Base.encode16()
   end
 
+  def debug(var, label) do
+    IO.inspect(var, label: label)
+  end
+
   @doc """
   Determines if the value is inside the list
 
@@ -163,14 +167,6 @@ defmodule Archethic.Contracts.Interpreter.Library do
 
   def in?(val, list) when is_list(list) do
     val in list
-  end
-
-  @doc """
-  Invokes fun for each element in the enumerable with the accumulator.
-  """
-  @spec reduce(Enumerable.t(), any(), (any(), any() -> any())) :: any()
-  def reduce(list, acc, func) do
-    Enum.reduce(list, acc, func)
   end
 
   @doc """

--- a/lib/archethic/contracts/interpreter/transaction_statements.ex
+++ b/lib/archethic/contracts/interpreter/transaction_statements.ex
@@ -129,6 +129,10 @@ defmodule Archethic.Contracts.Interpreter.TransactionStatements do
     put_in(tx, [Access.key(:data), Access.key(:content)], Float.to_string(content))
   end
 
+  def set_content(tx = %Transaction{}, content) when is_list(content) do
+    put_in(tx, [Access.key(:data), Access.key(:content)], Jason.encode!(content))
+  end
+
   @doc """
   Set transaction smart contract code
 

--- a/lib/archethic/contracts/interpreter/utils.ex
+++ b/lib/archethic/contracts/interpreter/utils.ex
@@ -581,7 +581,21 @@ defmodule Archethic.Contracts.Interpreter.Utils do
   end
 
   def format_error_reason(ast_node = {_, metadata, _}, reason) do
-    do_format_error_reason(reason, Macro.to_string(ast_node), metadata)
+    # we can't rely on Macro.to_string because it may fail because of our {:atom, ""} format
+    # since we can't transform them into atom, there's no way to display it correctly
+    #
+    # Example of unparseable node:
+    #   {:=, [line: 2], [{{:atom, "item"}, [line: 2], nil}, {{:atom, "item"}, [line: 2], nil}]}
+
+    cause =
+      try do
+        Macro.to_string(ast_node)
+      rescue
+        ArgumentError ->
+          "N/A"
+      end
+
+    do_format_error_reason(reason, cause, metadata)
   end
 
   def format_error_reason({{:atom, _}, {_, metadata, _}}, reason) do

--- a/lib/archethic/contracts/interpreter/utils.ex
+++ b/lib/archethic/contracts/interpreter/utils.ex
@@ -84,6 +84,9 @@ defmodule Archethic.Contracts.Interpreter.Utils do
   def prewalk(node = {:==, _, _}, acc = {:ok, %{scope: scope}}) when scope != :root,
     do: {node, acc}
 
+  def prewalk(node = {:++, _, _}, acc = {:ok, %{scope: scope}}) when scope != :root,
+    do: {node, acc}
+
   # Whitelist the use of doted statement
   def prewalk(node = {{:., _, [{_, _, _}, _]}, _, []}, acc = {:ok, %{scope: scope}})
       when scope != :root,
@@ -215,6 +218,15 @@ defmodule Archethic.Contracts.Interpreter.Utils do
       )
       when scope != :root do
     {node, acc}
+  end
+
+  # Whitelist and delegate the rem/2 function to Kernel
+  def prewalk(
+        _node = {{:atom, "rem"}, meta, ctx = [_, _]},
+        acc = {:ok, %{scope: scope}}
+      )
+      when scope != :root do
+    {{:rem, Keyword.put(meta, :context, Kernel), ctx}, acc}
   end
 
   # Whitelist the hash/1 function

--- a/lib/archethic/contracts/interpreter/utils.ex
+++ b/lib/archethic/contracts/interpreter/utils.ex
@@ -189,13 +189,12 @@ defmodule Archethic.Contracts.Interpreter.Utils do
   def prewalk(node = Access, acc), do: {node, acc}
   def prewalk(node = :get, acc), do: {node, acc}
 
-  # Whitelist the usage of transaction fields in references: "transaction/contract/previous/next"
+  # Whitelist the usage of dot statement (maps)
   def prewalk(
-        node = {:., _, [{{:atom, transaction_ref}, _, nil}, {:atom, transaction_field}]},
+        node = {:., _, [{{:atom, _}, _, nil}, {:atom, _}]},
         acc = {:ok, %{scope: scope}}
       )
-      when scope != :root and transaction_ref in ["next", "previous", "transaction", "contract"] and
-             transaction_field in @transaction_fields do
+      when scope != :root do
     {node, acc}
   end
 

--- a/lib/archethic/contracts/interpreter/utils.ex
+++ b/lib/archethic/contracts/interpreter/utils.ex
@@ -84,9 +84,6 @@ defmodule Archethic.Contracts.Interpreter.Utils do
   def prewalk(node = {:==, _, _}, acc = {:ok, %{scope: scope}}) when scope != :root,
     do: {node, acc}
 
-  def prewalk(node = {:++, _, _}, acc = {:ok, %{scope: scope}}) when scope != :root,
-    do: {node, acc}
-
   # Whitelist the use of doted statement
   def prewalk(node = {{:., _, [{_, _, _}, _]}, _, []}, acc = {:ok, %{scope: scope}})
       when scope != :root,
@@ -211,9 +208,36 @@ defmodule Archethic.Contracts.Interpreter.Utils do
     {node, acc}
   end
 
-  # Whitelist the size/1 function
+  # Whitelist the size/1 library function
   def prewalk(
         node = {{:atom, "size"}, _, [_data]},
+        acc = {:ok, %{scope: scope}}
+      )
+      when scope != :root do
+    {node, acc}
+  end
+
+  # Whitelist the append/2 library function
+  def prewalk(
+        node = {{:atom, "append"}, _, [_, _]},
+        acc = {:ok, %{scope: scope}}
+      )
+      when scope != :root do
+    {node, acc}
+  end
+
+  # Whitelist the prepend/2 library function
+  def prewalk(
+        node = {{:atom, "prepend"}, _, [_, _]},
+        acc = {:ok, %{scope: scope}}
+      )
+      when scope != :root do
+    {node, acc}
+  end
+
+  # Whitelist the concat/2 library function
+  def prewalk(
+        node = {{:atom, "concat"}, _, [_, _]},
         acc = {:ok, %{scope: scope}}
       )
       when scope != :root do

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -853,16 +853,19 @@ defmodule Archethic.Utils do
     months = normal_year ++ [leap_year_february]
 
     months
-    |> Task.async_stream(fn date ->
-      key =
-        if Date.leap_year?(date) do
-          0
-        else
-          date.month
-        end
+    |> Task.async_stream(
+      fn date ->
+        key =
+          if Date.leap_year?(date) do
+            0
+          else
+            date.month
+          end
 
-      {key, number_of_reward_occurences_per_month(interval, date)}
-    end)
+        {key, number_of_reward_occurences_per_month(interval, date)}
+      end,
+      timeout: 10000
+    )
     |> Stream.map(fn {:ok, v} -> v end)
     |> Map.new()
   end

--- a/test/archethic/contracts/interpreter/action_reduce_test.exs
+++ b/test/archethic/contracts/interpreter/action_reduce_test.exs
@@ -1,0 +1,195 @@
+defmodule Archethic.Contracts.Interpreter.ActionReduceTest do
+  use ArchethicCase
+
+  alias Archethic.Contracts.Interpreter
+  alias Archethic.Contracts.Interpreter.ActionReduce
+
+  describe "parse/1" do
+    test "should parse if list is a variable" do
+      code = """
+      reduce list, [as: item, with: [count: 0]] do
+        count = count + item
+      end
+      """
+
+      assert {:ok, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+    end
+
+    test "should parse a list" do
+      code = """
+      reduce [1,2,3], as: item, with: [count: 0] do
+        count = count + item
+      end
+      """
+
+      assert {:ok, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+    end
+
+    # test "should parse a function" do
+    # # Impossible right now because I need to whitelist a function
+    #   code = """
+    #   reduce get_calls(), as: item, with: [count: 0] do
+    #     count = count + item
+    #   end
+    #   """
+
+    #   assert {:ok, _} =
+    #            code
+    #            |> Interpreter.sanitize_code()
+    #            |> elem(1)
+    #            |> ActionReduce.parse()
+    # end
+
+    test "should not parse nested reduce" do
+      code = """
+      reduce [], as: i, with: [acc0: 0] do
+        reduce [], as: j, with: [acc1: 1] do
+          acc1 = 1
+        end
+      end
+      """
+
+      assert {:error, "Nested reduce are forbidden - reduce - L2"} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+    end
+
+    test "should not parse if rebinding the as" do
+      code = """
+      reduce [], as: item, with: [count: 0] do
+        item = item
+        count = count + item
+      end
+      """
+
+      assert {:error, "Rebinding the \"item\" variable is forbidden - N/A - L2"} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+    end
+
+    test "should not parse if first argument is invalid" do
+      code = """
+      reduce 1, as: item, with: [count: 0] do
+        count = count + item
+      end
+      """
+
+      assert {:error, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+    end
+
+    test "should not parse if second argument is invalid" do
+      code = """
+      reduce [], as: 42, with: [count: 0] do
+        count = count + item
+      end
+      """
+
+      assert {:error, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+    end
+
+    test "should not parse if third argument is invalid" do
+      code = """
+      reduce [], as: i, with: acc do
+        count = count + item
+      end
+      """
+
+      assert {:error, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+    end
+
+    # test "should parse a with value is a variable" do
+    #   # might be impossible at the moment cause it's in parent scope
+    #   code = """
+    #   initial_count = 0
+    #   reduce list, as: item, with: [count: initial_count] do
+    #     count = count + item
+    #   end
+    #   """
+
+    #   assert {:ok, _} =
+    #            code
+    #            |> Interpreter.sanitize_code()
+    #            |> elem(1)
+    #            |> ActionReduce.parse()
+    # end
+  end
+
+  describe "execute/2" do
+    test "should be able to use 1 acc variable" do
+      code = """
+      reduce [1,2,3], as: item, with: [count: 0] do
+        count = count + item
+      end
+      """
+
+      assert %{"count" => 6} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+               |> elem(1)
+               |> ActionReduce.execute()
+    end
+
+    test "should be able to use multiple acc variable" do
+      code = """
+      reduce [1,2,3], as: item, with: [sum: 0, product: 1] do
+        sum = sum + item
+        product = product * item
+      end
+      """
+
+      assert %{"sum" => 6, "product" => 6} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+               |> elem(1)
+               |> ActionReduce.execute()
+    end
+
+    test "should be able to use new variable" do
+      code = """
+      reduce [1,2,3], as: item, with: [count: 0] do
+        other = 10
+        count = count + item + other
+      end
+      """
+
+      assert %{"count" => 36} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionReduce.parse()
+               |> elem(1)
+               |> ActionReduce.execute()
+    end
+
+    # access scope parent
+    # access contract/transaction
+  end
+end

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -497,7 +497,7 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
         list = [1,2,3,4]
         even_numbers = reduce(list, [], fn number, acc ->
           if rem(number, 2) == 0 do
-            acc ++ [number]
+            append(acc, number)
           else
             acc
           end
@@ -514,7 +514,7 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
       actions triggered_by: transaction do
         list = [1,2,3]
         double = reduce(list, [], fn number, accu ->
-            accu ++ [number * 2]
+            append(accu, number * 2)
         end)
 
         set_content double

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -594,6 +594,43 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
         }
       })
     end
+
+    test "should be able to modify acc if it is an object" do
+      ~S"""
+      actions triggered_by: transaction do
+        list = ["X"]
+        transaction2 = reduce(list, transaction, fn item, acc ->
+            set(acc, address, item)
+        end)
+        set_content transaction2.address
+      end
+      """
+      |> assert_content_after_execute("X", %{
+        "transaction" => %{
+          "address" => "@addr"
+        }
+      })
+    end
+
+    test "should be able to reduce in a reduce" do
+      ~S"""
+      actions triggered_by: transaction do
+        list = [[1,2,3], [10,11,12]]
+        content = reduce(list, [], fn item, acc ->
+          sum = reduce(item, 0, fn item2, acc2 ->
+              item2 + acc2
+            end)
+          append(acc, sum)
+        end)
+        set_content content
+      end
+      """
+      |> assert_content_after_execute("[6,33]", %{
+        "transaction" => %{
+          "address" => "@addr"
+        }
+      })
+    end
   end
 
   test "shall use get_calls/1 in actions" do

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -483,154 +483,156 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
     test "should be able to reduce" do
       ~S"""
       actions triggered_by: transaction do
-        list = [1337,2551,563]
-        sum = reduce(list, 49, fn item, acc -> 0 + item + acc end)
+        list = [49,1337,2551,563]
+        sum = reduce list, as: item, with: [count: 0] do
+          count + item
+        end
         set_content sum
       end
       """
       |> assert_content_after_execute("4500")
     end
 
-    test "should be able to filter" do
-      ~S"""
-      actions triggered_by: transaction do
-        list = [1,2,3,4]
-        even_numbers = reduce(list, [], fn number, acc ->
-          if rem(number, 2) == 0 do
-            append(acc, number)
-          else
-            acc
-          end
-        end)
+    # test "should be able to filter" do
+    #   ~S"""
+    #   actions triggered_by: transaction do
+    #     list = [1,2,3,4]
+    #     even_numbers = reduce(list, [], fn number, acc ->
+    #       if rem(number, 2) == 0 do
+    #         append(acc, number)
+    #       else
+    #         acc
+    #       end
+    #     end)
 
-        set_content even_numbers
-      end
-      """
-      |> assert_content_after_execute("[2,4]")
-    end
+    #     set_content even_numbers
+    #   end
+    #   """
+    #   |> assert_content_after_execute("[2,4]")
+    # end
 
-    test "should be able to map" do
-      ~S"""
-      actions triggered_by: transaction do
-        list = [1,2,3]
-        double = reduce(list, [], fn number, accu ->
-            append(accu, number * 2)
-        end)
+    # test "should be able to map" do
+    #   ~S"""
+    #   actions triggered_by: transaction do
+    #     list = [1,2,3]
+    #     double = reduce(list, [], fn number, accu ->
+    #         append(accu, number * 2)
+    #     end)
 
-        set_content double
-      end
-      """
-      |> assert_content_after_execute("[2,4,6]")
-    end
+    #     set_content double
+    #   end
+    #   """
+    #   |> assert_content_after_execute("[2,4,6]")
+    # end
 
-    test "should be able to use = in a reduce" do
-      ~S"""
-      actions triggered_by: transaction do
-        list = [1,2,3]
-        double = reduce(list, [], fn number, acc ->
-            x = 2
-            append(acc, number * x)
-        end)
+    # test "should be able to use = in a reduce" do
+    #   ~S"""
+    #   actions triggered_by: transaction do
+    #     list = [1,2,3]
+    #     double = reduce(list, [], fn number, acc ->
+    #         x = 2
+    #         append(acc, number * x)
+    #     end)
 
-        set_content double
-      end
-      """
-      |> assert_content_after_execute("[2,4,6]")
-    end
+    #     set_content double
+    #   end
+    #   """
+    #   |> assert_content_after_execute("[2,4,6]")
+    # end
 
-    test "should be able to use . in a reduce" do
-      ~S"""
-      actions triggered_by: transaction do
-        list = ["X", "Y"]
-        content = reduce(list, [], fn unused, acc ->
-          # unused assignment just to remove compilation warning
-          x = unused
+    # test "should be able to use . in a reduce" do
+    #   ~S"""
+    #   actions triggered_by: transaction do
+    #     list = ["X", "Y"]
+    #     content = reduce(list, [], fn unused, acc ->
+    #       # unused assignment just to remove compilation warning
+    #       x = unused
 
-          append(acc, transaction.address)
-        end)
-        set_content content
-      end
-      """
-      |> assert_content_after_execute("[\"@addr\",\"@addr\"]", %{
-        "transaction" => %{
-          "address" => "@addr"
-        }
-      })
-    end
+    #       append(acc, transaction.address)
+    #     end)
+    #     set_content content
+    #   end
+    #   """
+    #   |> assert_content_after_execute("[\"@addr\",\"@addr\"]", %{
+    #     "transaction" => %{
+    #       "address" => "@addr"
+    #     }
+    #   })
+    # end
 
-    test "should be able to use an object as 1st arg in a reduce" do
-      ~S"""
-      actions triggered_by: transaction do
-        list = [transaction, transaction]
-        content = reduce(list, [], fn tx, acc ->
-            append(acc, tx.address)
-        end)
-        set_content content
-      end
-      """
-      |> assert_content_after_execute("[\"@addr\",\"@addr\"]", %{
-        "transaction" => %{
-          "address" => "@addr"
-        }
-      })
-    end
+    # test "should be able to use an object as 1st arg in a reduce" do
+    #   ~S"""
+    #   actions triggered_by: transaction do
+    #     list = [transaction, transaction]
+    #     content = reduce(list, [], fn tx, acc ->
+    #         append(acc, tx.address)
+    #     end)
+    #     set_content content
+    #   end
+    #   """
+    #   |> assert_content_after_execute("[\"@addr\",\"@addr\"]", %{
+    #     "transaction" => %{
+    #       "address" => "@addr"
+    #     }
+    #   })
+    # end
 
-    test "should be able to use an object as 2nd arg in a reduce" do
-      ~S"""
-      actions triggered_by: transaction do
-        list = ["X"]
-        content = reduce(list, transaction, fn unused, acc ->
-            # unused assignment just to remove compilation warning
-            x = unused
+    # test "should be able to use an object as 2nd arg in a reduce" do
+    #   ~S"""
+    #   actions triggered_by: transaction do
+    #     list = ["X"]
+    #     content = reduce(list, transaction, fn unused, acc ->
+    #         # unused assignment just to remove compilation warning
+    #         x = unused
 
-            acc.address
-        end)
-        set_content content
-      end
-      """
-      |> assert_content_after_execute("@addr", %{
-        "transaction" => %{
-          "address" => "@addr"
-        }
-      })
-    end
+    #         acc.address
+    #     end)
+    #     set_content content
+    #   end
+    #   """
+    #   |> assert_content_after_execute("@addr", %{
+    #     "transaction" => %{
+    #       "address" => "@addr"
+    #     }
+    #   })
+    # end
 
-    test "should be able to modify acc if it is an object" do
-      ~S"""
-      actions triggered_by: transaction do
-        list = ["X"]
-        transaction2 = reduce(list, transaction, fn item, acc ->
-            set(acc, address, item)
-        end)
-        set_content transaction2.address
-      end
-      """
-      |> assert_content_after_execute("X", %{
-        "transaction" => %{
-          "address" => "@addr"
-        }
-      })
-    end
+    # test "should be able to modify acc if it is an object" do
+    #   ~S"""
+    #   actions triggered_by: transaction do
+    #     list = ["X"]
+    #     transaction2 = reduce(list, transaction, fn item, acc ->
+    #         set(acc, address, item)
+    #     end)
+    #     set_content transaction2.address
+    #   end
+    #   """
+    #   |> assert_content_after_execute("X", %{
+    #     "transaction" => %{
+    #       "address" => "@addr"
+    #     }
+    #   })
+    # end
 
-    test "should be able to reduce in a reduce" do
-      ~S"""
-      actions triggered_by: transaction do
-        list = [[1,2,3], [10,11,12]]
-        content = reduce(list, [], fn item, acc ->
-          sum = reduce(item, 0, fn item2, acc2 ->
-              item2 + acc2
-            end)
-          append(acc, sum)
-        end)
-        set_content content
-      end
-      """
-      |> assert_content_after_execute("[6,33]", %{
-        "transaction" => %{
-          "address" => "@addr"
-        }
-      })
-    end
+    # test "should be able to reduce in a reduce" do
+    #   ~S"""
+    #   actions triggered_by: transaction do
+    #     list = [[1,2,3], [10,11,12]]
+    #     content = reduce(list, [], fn item, acc ->
+    #       sum = reduce(item, 0, fn item2, acc2 ->
+    #           item2 + acc2
+    #         end)
+    #       append(acc, sum)
+    #     end)
+    #     set_content content
+    #   end
+    #   """
+    #   |> assert_content_after_execute("[6,33]", %{
+    #     "transaction" => %{
+    #       "address" => "@addr"
+    #     }
+    #   })
+    # end
   end
 
   test "shall use get_calls/1 in actions" do

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -522,6 +522,21 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
       """
       |> assert_content_after_execute("[2,4,6]")
     end
+
+    test "should be able to use = in a reduce" do
+      ~S"""
+      actions triggered_by: transaction do
+        list = [1,2,3]
+        double = reduce(list, [], fn number, accu ->
+            x = 2
+            append(accu, number * x)
+        end)
+
+        set_content double
+      end
+      """
+      |> assert_content_after_execute("[2,4,6]")
+    end
   end
 
   test "shall use get_calls/1 in actions" do

--- a/test/archethic/contracts/interpreter/action_test.exs
+++ b/test/archethic/contracts/interpreter/action_test.exs
@@ -579,16 +579,16 @@ defmodule Archethic.Contracts.ActionInterpreterTest do
       ~S"""
       actions triggered_by: transaction do
         list = ["X"]
-        content = reduce(list, transaction, fn letter, acc ->
+        content = reduce(list, transaction, fn unused, acc ->
             # unused assignment just to remove compilation warning
             x = unused
 
-            concat(acc.address, letter)
+            acc.address
         end)
         set_content content
       end
       """
-      |> assert_content_after_execute("@addrX", %{
+      |> assert_content_after_execute("@addr", %{
         "transaction" => %{
           "address" => "@addr"
         }

--- a/test/archethic/contracts/interpreter/ast_helper_test.exs
+++ b/test/archethic/contracts/interpreter/ast_helper_test.exs
@@ -1,0 +1,6 @@
+defmodule Archethic.Contracts.Interpreter.ASTHelperTest do
+  use ArchethicCase
+  alias Archethic.Contracts.Interpreter.ASTHelper
+
+  doctest ASTHelper
+end


### PR DESCRIPTION
# Description

Implement a reduce/3 action in the smart contracts. 
With the reduce alone we can do all the list manipulation we need. 
We could add more convenience functions later such as map/filter.

Syntax: 

```
list = [1,2,3]
sum = reduce(list, 0, fn item, acc ->  
    item + acc
end)
```
Fixes #826

# Current limitation to discuss

- [ ] Impossible to call actions from within the reduce (set_content/add_uco_transfer etc.)
- [ ] Impossible to have a reduce in a reduce 
- [ ] Is the elixir lambda syntax good?

# Type of change


- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests added to the suite

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
