### PR TITLE
SC: change default contract type 

### DIFF
--- a/lib/archethic/contracts/interpreter/transaction_statements.ex
+++ b/lib/archethic/contracts/interpreter/transaction_statements.ex
@@ -15,7 +15,8 @@ defmodule Archethic.Contracts.Interpreter.TransactionStatements do
        %Transaction{ type: :transfer }
   """
   @spec set_type(Transaction.t(), binary()) :: Transaction.t()
-  def set_type(tx = %Transaction{}, type) when type in ["transfer", "token", "hosting"] do
+  def set_type(tx = %Transaction{}, type)
+      when type in ["transfer", "token", "hosting", "data", "contract"] do
     %{tx | type: String.to_existing_atom(type)}
   end
 

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -364,7 +364,7 @@ defmodule Archethic.Contracts.Worker do
            previous_transaction: _
          }
        ) do
-    put_in(acc, [:next_transaction, Access.key(:type)], :transfer)
+    put_in(acc, [:next_transaction, Access.key(:type)], :contract)
   end
 
   defp chain_type(acc), do: acc


### PR DESCRIPTION
# Description

Change default contract type from `transfer` to `contract`. We can now have contracts that don't necessarily have transfers. Plus added `data` & `contract` types as valid argument to the `set_type` action.

Fixes #844

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested this scenario via the transaction builder: 
```
condition inherit: [
	content: true
]

condition transaction: [
	uco_transfers: size() > 0
]

actions triggered_by: transaction do
	set_content "hello"
end
```

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
