### PR TITLE
fix previous on first page and next on last page of pagination component

### DIFF
--- a/lib/archethic_web/components/pagination.ex
+++ b/lib/archethic_web/components/pagination.ex
@@ -15,13 +15,13 @@ defmodule ArchethicWeb.Pagination do
       <%= if @current_page > 1 do %>
         <a class="pagination-previous" phx-value-page={@current_page - 1} phx-click="goto">Previous</a>
       <% else %>
-        <a class="pagination-previous is-disabled">Previous</a>
+        <a class="pagination-previous is-disabled" phx-click="first_page">Previous</a>
       <% end %>
 
       <%= if @current_page + 1 <= @total_pages do %>
         <a class="pagination-next" phx-value-page={@current_page + 1} phx-click="goto">Next page</a>
       <% else %>
-        <a class="pagination-next is-disabled">Next page</a>
+        <a class="pagination-next is-disabled" phx-click="last_page">Next page</a>
       <% end %>
 
       <p class="pagination-list has-text-white">

--- a/lib/archethic_web/live/chains/beacon_live.ex
+++ b/lib/archethic_web/live/chains/beacon_live.ex
@@ -95,6 +95,8 @@ defmodule ArchethicWeb.BeaconChainLive do
     {:noreply, push_patch(socket, to: Routes.live_path(socket, __MODULE__, %{"page" => page}))}
   end
 
+  def handle_event(_, _, socket), do: {:noreply, socket}
+
   def handle_info(
         :initial_load,
         socket

--- a/lib/archethic_web/live/chains/node_shared_secrets_live.ex
+++ b/lib/archethic_web/live/chains/node_shared_secrets_live.ex
@@ -94,6 +94,8 @@ defmodule ArchethicWeb.NodeSharedSecretsChainLive do
     {:noreply, push_patch(socket, to: Routes.live_path(socket, __MODULE__, %{"page" => page}))}
   end
 
+  def handle_event(_, _, socket), do: {:noreply, socket}
+
   @spec handle_info(
           _msg ::
             {:new_transaction, address :: binary(), :node_shared_secrets, DateTime.t()},

--- a/lib/archethic_web/live/chains/oracle_live.ex
+++ b/lib/archethic_web/live/chains/oracle_live.ex
@@ -103,6 +103,8 @@ defmodule ArchethicWeb.OracleChainLive do
     {:noreply, push_patch(socket, to: Routes.live_path(socket, __MODULE__, %{"page" => page}))}
   end
 
+  def handle_event(_, _, socket), do: {:noreply, socket}
+
   def handle_info(
         {:new_transaction, address, :oracle, timestamp},
         socket = %{assigns: assigns = %{current_date_page: current_page}}

--- a/lib/archethic_web/live/chains/reward_live.ex
+++ b/lib/archethic_web/live/chains/reward_live.ex
@@ -75,6 +75,8 @@ defmodule ArchethicWeb.RewardChainLive do
     {:noreply, push_patch(socket, to: Routes.live_path(socket, __MODULE__, %{"page" => page}))}
   end
 
+  def handle_event(_, _, socket), do: {:noreply, socket}
+
   @spec handle_info(
           {:new_transaction, binary(), :mint_rewards | :node_rewards, DateTime.t()},
           socket :: Phoenix.LiveView.Socket.t()


### PR DESCRIPTION
# Description

previous and next button breaks the liveview component in the pagination because the returned div didn't have any liveview action attached to it.

Fixes #818 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
