### PR TITLE
Forward http port at application startup

### DIFF
--- a/lib/archethic/application.ex
+++ b/lib/archethic/application.ex
@@ -59,6 +59,9 @@ defmodule Archethic.Application do
 
     port = Keyword.fetch!(p2p_endpoint_conf, :port)
     {:ok, port} = Networking.try_open_port(port, true)
+    try_open_port(Keyword.get(web_endpoint_conf, :http))
+    try_open_port(Keyword.get(web_endpoint_conf, :https))
+
     http = Keyword.fetch!(web_endpoint_conf, :http)
     http_port = Keyword.fetch!(http, :port)
 
@@ -97,6 +100,13 @@ defmodule Archethic.Application do
 
     opts = [strategy: :rest_for_one, name: Archethic.Supervisor]
     Supervisor.start_link(Utils.configurable_children(children), opts)
+  end
+
+  defp try_open_port(nil), do: :ok
+
+  defp try_open_port(conf) do
+    port = Keyword.get(conf, :port)
+    Networking.try_open_port(port, false)
   end
 
   def config_change(changed, _new, removed) do

--- a/lib/archethic_web/supervisor.ex
+++ b/lib/archethic_web/supervisor.ex
@@ -3,7 +3,6 @@ defmodule ArchethicWeb.Supervisor do
 
   use Supervisor
 
-  alias Archethic.Networking
   alias Archethic.Utils
 
   alias ArchethicCache.LRU
@@ -19,12 +18,6 @@ defmodule ArchethicWeb.Supervisor do
   end
 
   def init(_) do
-    # Try to open the HTTP port
-    endpoint_conf = Application.get_env(:archethic, ArchethicWeb.Endpoint)
-
-    try_open_port(Keyword.get(endpoint_conf, :http))
-    try_open_port(Keyword.get(endpoint_conf, :https))
-
     children =
       [
         TransactionCache,
@@ -41,13 +34,6 @@ defmodule ArchethicWeb.Supervisor do
 
     opts = [strategy: :one_for_one]
     Supervisor.init(children, opts)
-  end
-
-  defp try_open_port(nil), do: :ok
-
-  defp try_open_port(conf) do
-    port = Keyword.get(conf, :port)
-    Networking.try_open_port(port, false)
   end
 
   defp add_faucet_rate_limit_child(children) do


### PR DESCRIPTION
# Description

Http port are forwarded while starting `ArchethicWeb.Supervisor` in init function.
While performing a hot reload, the supervisor init function are called to update the supervisor child and strategy. But because of the http forwarding in init function that can take some times, the hot reload may fall in timeout.

To avoid this, the http port forwarding are moved to application start.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
