### PR TITLE
quorum during self repair should fetch from all nodes

### DIFF
--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -741,7 +741,7 @@ defmodule Archethic.P2P do
             message,
             conflict_resolver,
             acceptance_resolver,
-            consistency_level - 1,
+            consistency_level,
             timeout,
             quorum_result
           )

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -710,7 +710,7 @@ defmodule Archethic.P2P do
               message,
               conflict_resolver,
               acceptance_resolver,
-              consistency_level - 1,
+              consistency_level,
               timeout,
               quorum_result
             )
@@ -723,7 +723,7 @@ defmodule Archethic.P2P do
             message,
             conflict_resolver,
             acceptance_resolver,
-            consistency_level - 1,
+            consistency_level,
             timeout,
             result
           )
@@ -758,9 +758,7 @@ defmodule Archethic.P2P do
     else
       # If the results differ, we can apply a conflict resolver to merge the result into
       # a consistent response
-      resolved_result = conflict_resolver.(distinct_elems)
-
-      resolved_result
+      conflict_resolver.(distinct_elems)
     end
   end
 end

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -633,10 +633,19 @@ defmodule Archethic.P2P do
 
   def quorum_read(nodes, message, conflict_resolver, timeout, consistency_level) do
     nodes
+    |> filter_and_prioritize_nodes_for_quorum_read()
+    |> do_quorum_read(message, conflict_resolver, timeout, consistency_level, nil)
+  end
+
+  @doc """
+  Filter and prioritize nodes to be used in quorum read
+  """
+  @spec filter_and_prioritize_nodes_for_quorum_read(list(Node.t())) :: list(Node.t())
+  def filter_and_prioritize_nodes_for_quorum_read(nodes) do
+    nodes
     |> Enum.filter(&Node.locally_available?/1)
     |> nearest_nodes()
     |> unprioritize_node(Crypto.first_node_public_key())
-    |> do_quorum_read(message, conflict_resolver, timeout, consistency_level, nil)
   end
 
   defp do_quorum_read([], _, _, _, _, nil), do: {:error, :network_issue}

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -620,6 +620,7 @@ defmodule Archethic.P2P do
           message :: Message.t(),
           conflict_resolver :: (list(Message.t()) -> Message.t()),
           timeout :: non_neg_integer(),
+          acceptance_resolver :: (Message.t() -> boolean()),
           consistency_level :: pos_integer()
         ) ::
           {:ok, Message.t()} | {:error, :network_issue}
@@ -628,33 +629,40 @@ defmodule Archethic.P2P do
         message,
         conflict_resolver \\ fn results -> List.first(results) end,
         timeout \\ 0,
+        acceptance_resolver \\ fn _ -> true end,
         consistency_level \\ 3
       )
 
-  def quorum_read(nodes, message, conflict_resolver, timeout, consistency_level) do
-    nodes
-    |> filter_and_prioritize_nodes_for_quorum_read()
-    |> do_quorum_read(message, conflict_resolver, timeout, consistency_level, nil)
-  end
-
-  @doc """
-  Filter and prioritize nodes to be used in quorum read
-  """
-  @spec filter_and_prioritize_nodes_for_quorum_read(list(Node.t())) :: list(Node.t())
-  def filter_and_prioritize_nodes_for_quorum_read(nodes) do
+  def quorum_read(
+        nodes,
+        message,
+        conflict_resolver,
+        timeout,
+        acceptance_resolver,
+        consistency_level
+      ) do
     nodes
     |> Enum.filter(&Node.locally_available?/1)
     |> nearest_nodes()
     |> unprioritize_node(Crypto.first_node_public_key())
+    |> do_quorum_read(
+      message,
+      conflict_resolver,
+      acceptance_resolver,
+      timeout,
+      consistency_level,
+      nil
+    )
   end
 
-  defp do_quorum_read([], _, _, _, _, nil), do: {:error, :network_issue}
-  defp do_quorum_read([], _, _, _, _, previous_result), do: {:ok, previous_result}
+  defp do_quorum_read([], _, _, _, _, _, nil), do: {:error, :network_issue}
+  defp do_quorum_read([], _, _, _, _, _, previous_result), do: {:ok, previous_result}
 
   defp do_quorum_read(
          nodes,
          message,
          conflict_resolver,
+         acceptance_resolver,
          timeout,
          consistency_level,
          previous_result
@@ -684,6 +692,7 @@ defmodule Archethic.P2P do
           rest,
           message,
           conflict_resolver,
+          acceptance_resolver,
           consistency_level,
           timeout,
           previous_result
@@ -691,15 +700,52 @@ defmodule Archethic.P2P do
 
       1 ->
         if previous_result != nil do
-          do_quorum([previous_result | results], conflict_resolver)
+          quorum_result = do_quorum([previous_result | results], conflict_resolver)
+
+          if acceptance_resolver.(quorum_result) do
+            {:ok, quorum_result}
+          else
+            do_quorum_read(
+              rest,
+              message,
+              conflict_resolver,
+              acceptance_resolver,
+              consistency_level - 1,
+              timeout,
+              quorum_result
+            )
+          end
         else
           result = List.first(results)
-          do_quorum_read(rest, message, conflict_resolver, consistency_level - 1, timeout, result)
+
+          do_quorum_read(
+            rest,
+            message,
+            conflict_resolver,
+            acceptance_resolver,
+            consistency_level - 1,
+            timeout,
+            result
+          )
         end
 
       _ ->
         results = if previous_result != nil, do: [previous_result | results], else: results
-        do_quorum(results, conflict_resolver)
+        quorum_result = do_quorum(results, conflict_resolver)
+
+        if acceptance_resolver.(quorum_result) do
+          {:ok, quorum_result}
+        else
+          do_quorum_read(
+            rest,
+            message,
+            conflict_resolver,
+            acceptance_resolver,
+            consistency_level - 1,
+            timeout,
+            quorum_result
+          )
+        end
     end
   end
 
@@ -708,12 +754,13 @@ defmodule Archethic.P2P do
 
     # If the results are the same, then we reached consistency
     if length(distinct_elems) == 1 do
-      {:ok, List.first(distinct_elems)}
+      List.first(distinct_elems)
     else
       # If the results differ, we can apply a conflict resolver to merge the result into
       # a consistent response
       resolved_result = conflict_resolver.(distinct_elems)
-      {:ok, resolved_result}
+
+      resolved_result
     end
   end
 end

--- a/lib/archethic/self_repair/sync/transaction_handler.ex
+++ b/lib/archethic/self_repair/sync/transaction_handler.ex
@@ -66,61 +66,25 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandler do
       |> Election.chain_storage_nodes_with_type(type, node_list)
       |> Enum.reject(&(&1.first_public_key == Crypto.first_node_public_key()))
 
-    download_nodes =
-      storage_nodes
-      |> P2P.filter_and_prioritize_nodes_for_quorum_read()
-
     case TransactionChain.fetch_transaction_remotely(address, storage_nodes) do
       {:ok, tx = %Transaction{}} ->
         tx
 
-      {:error, error} ->
-        do_retry_download_transaction(address, type, download_nodes, error)
-    end
-  end
+      {:error, :transaction_not_exists} ->
+        Logger.error("Cannot fetch the transaction to sync",
+          transaction_address: Base.encode16(address),
+          transaction_type: type
+        )
 
-  defp do_retry_download_transaction(address, type, download_nodes, intial_error) do
-    %{errors: errors, transaction: tx} =
-      download_nodes
-      |> Enum.chunk_every(3)
-      |> Enum.reduce_while(
-        %{
-          errors: [intial_error],
-          transaction: nil
-        },
-        fn nodes, acc ->
-          case TransactionChain.fetch_transaction_remotely(address, nodes) do
-            {:ok, tx = %Transaction{}} ->
-              {:halt, %{acc | transaction: tx}}
+        raise "Transaction doesn't exist"
 
-            {:error, error} ->
-              {:cont, %{acc | errors: [error | acc.errors]}}
-          end
-        end
-      )
+      {:error, :network_issue} ->
+        Logger.error("Cannot fetch the transaction to sync",
+          transaction_address: Base.encode16(address),
+          transaction_type: type
+        )
 
-    if is_nil(tx) do
-      errors
-      |> Enum.uniq()
-      |> Enum.each(fn
-        :network_issue ->
-          Logger.error("Cannot fetch the transaction to sync",
-            transaction_address: Base.encode16(address),
-            transaction_type: type
-          )
-
-          raise "Network issue during during self repair"
-
-        :transaction_not_exists ->
-          Logger.error("Cannot fetch the transaction to sync",
-            transaction_address: Base.encode16(address),
-            transaction_type: type
-          )
-
-          raise "Transaction doesn't exist"
-      end)
-    else
-      tx
+        raise "Network issue during during self repair"
     end
   end
 

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -691,11 +691,17 @@ defmodule Archethic.TransactionChain do
       end
     end
 
+    acceptance_resolver = fn
+      {:ok, %Transaction{}} -> true
+      _ -> false
+    end
+
     case P2P.quorum_read(
            nodes,
            %GetTransaction{address: address},
            conflict_resolver,
-           timeout
+           timeout,
+           acceptance_resolver
          ) do
       {:ok, %NotFound{}} ->
         {:error, :transaction_not_exists}

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -692,7 +692,7 @@ defmodule Archethic.TransactionChain do
     end
 
     acceptance_resolver = fn
-      {:ok, %Transaction{}} -> true
+      {:ok, %Transaction{address: ^address}} -> true
       _ -> false
     end
 

--- a/test/archethic/p2p_test.exs
+++ b/test/archethic/p2p_test.exs
@@ -259,4 +259,54 @@ defmodule Archethic.P2PTest do
                P2P.authorized_and_available_nodes(~U[2022-09-11 01:05:00Z])
     end
   end
+
+  describe "filter_and_prioritize_nodes_for_quorum_read/1" do
+    setup do
+      pub1 = Crypto.generate_deterministic_keypair("node1") |> elem(0)
+      pub2 = Crypto.generate_deterministic_keypair("node2") |> elem(0)
+      pub3 = Crypto.generate_deterministic_keypair("node3") |> elem(0)
+
+      node_1 = %Node{
+        ip: {127, 0, 0, 1},
+        port: 3002,
+        first_public_key: pub1,
+        last_public_key: pub1,
+        available?: false,
+        availability_history: <<1::1>>,
+        network_patch: "CCC",
+        geo_patch: "CCC"
+      }
+
+      node_2 = %Node{
+        ip: {127, 0, 0, 1},
+        port: 3003,
+        first_public_key: pub2,
+        last_public_key: pub2,
+        available?: true,
+        availability_history: <<0::1>>,
+        network_patch: "BBB",
+        geo_patch: "BBB"
+      }
+
+      node_3 = %Node{
+        ip: {127, 0, 0, 1},
+        port: 3004,
+        first_public_key: pub3,
+        last_public_key: pub3,
+        available?: true,
+        availability_history: <<1::1>>,
+        network_patch: "AAA",
+        geo_patch: "AAA"
+      }
+
+      nodes = [node_1, node_2, node_3]
+
+      Enum.each(nodes, &P2P.add_and_connect_node/1)
+      {:ok, %{nodes: nodes, result: [node_1, node_3]}}
+    end
+
+    test "should return locally available and nearest nodes", %{nodes: nodes, result: result} do
+      assert P2P.filter_and_prioritize_nodes_for_quorum_read(nodes) == result
+    end
+  end
 end

--- a/test/archethic/p2p_test.exs
+++ b/test/archethic/p2p_test.exs
@@ -152,6 +152,7 @@ defmodule Archethic.P2PTest do
         :send_message,
         1,
         fn _node, _message, _timeout ->
+          :timer.sleep(200)
           {:ok, %NotFound{}}
         end
       )

--- a/test/archethic/self_repair/sync/transaction_handler_test.exs
+++ b/test/archethic/self_repair/sync/transaction_handler_test.exs
@@ -142,8 +142,50 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
 
     tx = TransactionFactory.create_valid_transaction(inputs)
 
+    pb_key1 = Crypto.derive_keypair("key101", 0) |> elem(0)
+    pb_key2 = Crypto.derive_keypair("key202", 0) |> elem(0)
+    pb_key3 = Crypto.derive_keypair("key303", 0) |> elem(0)
+
+    nodes = [
+      %Node{
+        first_public_key: pb_key1,
+        last_public_key: pb_key1,
+        authorized?: true,
+        available?: true,
+        authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+        geo_patch: "AAA",
+        network_patch: "AAA",
+        reward_address: :crypto.strong_rand_bytes(32),
+        enrollment_date: DateTime.utc_now()
+      },
+      %Node{
+        first_public_key: pb_key2,
+        last_public_key: pb_key2,
+        authorized?: true,
+        available?: true,
+        authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+        geo_patch: "AAA",
+        network_patch: "AAA",
+        reward_address: :crypto.strong_rand_bytes(32),
+        enrollment_date: DateTime.utc_now()
+      },
+      %Node{
+        first_public_key: pb_key3,
+        last_public_key: pb_key3,
+        authorized?: true,
+        available?: true,
+        authorization_date: DateTime.utc_now() |> DateTime.add(-10),
+        geo_patch: "AAA",
+        network_patch: "AAA",
+        reward_address: :crypto.strong_rand_bytes(32),
+        enrollment_date: DateTime.utc_now()
+      }
+    ]
+
+    Enum.each(nodes, &P2P.add_and_connect_node(&1))
+
     MockClient
-    |> expect(:send_message, fn
+    |> expect(:send_message, 4, fn
       _, %GetTransaction{}, _ ->
         {:error, :network_issue}
     end)


### PR DESCRIPTION
# Description

During the self repair, we use the quorum read to fetch the missed transactions and the previous summary aggregate.
But if there is some synchronization error, the 3 requested node from the quorum may return that the transaction does not exist and so the self repair crashes.
If the transaction is in the beacon summary it means that it exists and so it should be fetched during self repair.

If the quorum read return an unexpected response (transaction does not exists, transaction invalid ...), we remove from the node list the previously requested nodes, and retry the quorum until we get the expected response or the node list is empty

Fixes #856 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
