### PR TITLE
SC: ActionInterpreter.execute might return nil to not create a next tx

### DIFF
--- a/lib/archethic/contracts/interpreter/action.ex
+++ b/lib/archethic/contracts/interpreter/action.ex
@@ -321,11 +321,11 @@ defmodule Archethic.Contracts.ActionInterpreter do
   end
 
   @doc """
-  Execute actions code and returns a transaction as result
+  Execute actions code and returns either the next transaction or nil
   """
-  @spec execute(Macro.t(), map()) :: Transaction.t()
+  @spec execute(Macro.t(), map()) :: Transaction.t() | nil
   def execute(code, constants \\ %{}) do
-    {%{"next_transaction" => next_transaction}, _} =
+    result =
       Code.eval_quoted(code,
         scope:
           Map.put(constants, "next_transaction", %Transaction{
@@ -333,6 +333,12 @@ defmodule Archethic.Contracts.ActionInterpreter do
           })
       )
 
-    next_transaction
+    case result do
+      {%{"next_transaction" => next_transaction}, _} ->
+        next_transaction
+
+      _ ->
+        nil
+    end
   end
 end

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -239,15 +239,13 @@ defmodule Archethic.Contracts.Worker do
         else
           nil ->
             # returned by ActionInterpreter.execute when contract did not create a next tx
-            Logger.error("Oracle contract did not trigger a new tx",
-              contract: Base.encode16(address)
-            )
+            :ok
 
           false ->
-            Logger.error("Invalid oracle conditions", contract: Base.encode16(address))
+            Logger.info("Invalid oracle conditions", contract: Base.encode16(address))
 
           {:error, e} ->
-            Logger.error("#{inspect(e)}", contract: Base.encode16(address))
+            Logger.info("#{inspect(e)}", contract: Base.encode16(address))
         end
       end
     end

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -103,14 +103,14 @@ defmodule Archethic.Contracts.Worker do
       contract_transaction = Constants.to_transaction(contract_constants)
 
       with true <- ConditionInterpreter.valid_conditions?(transaction_condition, constants),
-           next_tx when not is_nil(next_tx) <-
+           next_tx = %Transaction{} <-
              ActionInterpreter.execute(Map.fetch!(triggers, :transaction), constants),
            {:ok, next_tx} <- chain_transaction(next_tx, contract_transaction) do
         handle_new_transaction(next_tx)
         {:noreply, state}
       else
         nil ->
-          # contract did not create a next tx
+          # returned by ActionInterpreter.execute when contract did not create a next tx
           {:noreply, state}
 
         false ->
@@ -155,7 +155,7 @@ defmodule Archethic.Contracts.Worker do
 
     contract_tx = Constants.to_transaction(contract_constants)
 
-    with next_tx when not is_nil(next_tx) <-
+    with next_tx = %Transaction{} <-
            ActionInterpreter.execute(Map.fetch!(triggers, {:datetime, timestamp}), constants),
          {:ok, next_tx} <- chain_transaction(next_tx, contract_tx) do
       handle_new_transaction(next_tx)
@@ -189,7 +189,7 @@ defmodule Archethic.Contracts.Worker do
     contract_transaction = Constants.to_transaction(contract_constants)
 
     with true <- enough_funds?(address),
-         next_tx when not is_nil(next_tx) <-
+         next_tx = %Transaction{} <-
            ActionInterpreter.execute(Map.fetch!(triggers, {:interval, interval}), constants),
          {:ok, next_tx} <- chain_transaction(next_tx, contract_transaction),
          :ok <- ensure_enough_funds(next_tx, address) do
@@ -223,7 +223,7 @@ defmodule Archethic.Contracts.Worker do
       contract_transaction = Constants.to_transaction(contract_constants)
 
       if Conditions.empty?(oracle_condition) do
-        with next_tx when not is_nil(next_tx) <-
+        with next_tx = %Transaction{} <-
                ActionInterpreter.execute(Map.fetch!(triggers, :oracle), constants),
              {:ok, next_tx} <- chain_transaction(next_tx, contract_transaction),
              :ok <- ensure_enough_funds(next_tx, address) do
@@ -231,13 +231,14 @@ defmodule Archethic.Contracts.Worker do
         end
       else
         with true <- ConditionInterpreter.valid_conditions?(oracle_condition, constants),
-             next_tx when not is_nil(next_tx) <-
+             next_tx = %Transaction{} <-
                ActionInterpreter.execute(Map.fetch!(triggers, :oracle), constants),
              {:ok, next_tx} <- chain_transaction(next_tx, contract_transaction),
              :ok <- ensure_enough_funds(next_tx, address) do
           handle_new_transaction(next_tx)
         else
           nil ->
+            # returned by ActionInterpreter.execute when contract did not create a next tx
             Logger.error("Oracle contract did not trigger a new tx",
               contract: Base.encode16(address)
             )


### PR DESCRIPTION
# Description

This PRs allows smart contracts to end without a "next_transaction".
I know @Neylix wants to go one step further (allow contract to have a next transaction even when it ends on a non-transaction-statements) but I believe it should be done in a new issue. (CREATED: https://github.com/archethic-foundation/archethic-node/issues/870)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with a smart contract that use this code:

```
actions triggered_by: interval, at: "0 * * * *" do	
	calls = get_calls() 
	if calls != [] do 
		[...]
		add_uco_transfers(transfers)
	end
end
```

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
