### PR TITLE
Improve balance api

### DIFF
--- a/lib/archethic_web/graphql_schema.ex
+++ b/lib/archethic_web/graphql_schema.ex
@@ -101,7 +101,7 @@ defmodule ArchethicWeb.GraphQLSchema do
     end
 
     @desc """
-    Query the network to find a balance from an address
+    Query the network to find a balance from an address coming from the latest transaction on the chain
     """
     field :balance, :balance do
       arg(:address, non_null(:address))

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -476,8 +476,12 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
       addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
 
       MockClient
-      |> stub(:send_message, fn _, %GetBalance{}, _ ->
-        {:ok, %Balance{uco: 218_000_000}}
+      |> stub(:send_message, fn
+        _, %GetBalance{}, _ ->
+          {:ok, %Balance{uco: 218_000_000}}
+
+        _, %GetLastTransactionAddress{address: address}, _ ->
+          {:ok, %LastTransactionAddress{address: address}}
       end)
 
       conn =
@@ -492,15 +496,19 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
       addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
 
       MockClient
-      |> stub(:send_message, fn _, %GetBalance{}, _ ->
-        {:ok,
-         %Balance{
-           token: %{
-             {"@Token1", 0} => 200_000_000,
-             {"@Token2", 0} => 500_000_000,
-             {"@Token3", 0} => 1_000_000_000
-           }
-         }}
+      |> stub(:send_message, fn
+        _, %GetBalance{}, _ ->
+          {:ok,
+           %Balance{
+             token: %{
+               {"@Token1", 0} => 200_000_000,
+               {"@Token2", 0} => 500_000_000,
+               {"@Token3", 0} => 1_000_000_000
+             }
+           }}
+
+        _, %GetLastTransactionAddress{address: address}, _ ->
+          {:ok, %LastTransactionAddress{address: address}}
       end)
 
       conn =


### PR DESCRIPTION
# Description

Add the resolution of the last address in the get_balance api

Fixes #875 

## Type of change

Please delete options that are not relevant.

- Enhancement

# How Has This Been Tested?

The API should fetch the balance from:
- a genesis address
- a transaction
- the latest transaction of a chain

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
