### PR TITLE
AEWeb: if url is a folder and there is an index.html inside, serve the index.html #874

### DIFF
--- a/lib/archethic_web/controllers/api/web_hosting_controller/resources.ex
+++ b/lib/archethic_web/controllers/api/web_hosting_controller/resources.ex
@@ -82,7 +82,15 @@ defmodule ArchethicWeb.API.WebHostingController.Resources do
     case Map.get(metadata, resource_path) do
       nil ->
         if is_a_directory?(metadata, resource_path) do
-          {:error, :is_a_directory}
+          index_path = resource_path <> "/index.html"
+
+          case Map.get(metadata, index_path) do
+            nil ->
+              {:error, :is_a_directory}
+
+            file ->
+              {:ok, file, MIME.from_path("index.html"), index_path}
+          end
         else
           # Handle JS History API by serving index.html instead of a 404
           # We loose the ability to return real 404 errors


### PR DESCRIPTION
# Description

If there is no index.html in the root folder , we host website as a navigation, but if we go inside any folder and if we encounter a index.html we should host it/ render it instead of rendering as navigation/explorer.


Fixes 
- [ ] #874
## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- manual testing 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
