### PR TITLE
Fix bootstrap node index

### DIFF
--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -15,6 +15,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
     P2P.Message.FirstPublicKey,
     P2P.Message.GetFirstPublicKey,
     P2P.Message.GetTransactionSummary,
+    P2P.Message.TransactionSummaryMessage,
     P2P.Message.NotFound,
     P2P.Node,
     Reward,
@@ -113,7 +114,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
 
     conflict_resolver = fn results ->
       # Prioritize transactions results over not found
-      case Enum.filter(results, &match?(%TransactionSummary{}, &1)) do
+      case Enum.filter(results, &match?(%TransactionSummaryMessage{}, &1)) do
         [] ->
           %NotFound{}
 
@@ -128,7 +129,8 @@ defmodule Archethic.Mining.PendingTransactionValidation do
            %GetTransactionSummary{address: address},
            conflict_resolver
          ) do
-      {:ok, %TransactionSummary{address: ^address}} ->
+      {:ok,
+       %TransactionSummaryMessage{transaction_summary: %TransactionSummary{address: ^address}}} ->
         {:error, "Transaction already exists"}
 
       {:ok, %NotFound{}} ->

--- a/lib/archethic/self_repair/sync/transaction_handler.ex
+++ b/lib/archethic/self_repair/sync/transaction_handler.ex
@@ -40,11 +40,9 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandler do
       true
     else
       Enum.any?(mvt_addresses, fn address ->
-        io_storage_nodes = Election.chain_storage_nodes(address, node_list)
-        node_pool_address = Crypto.hash(Crypto.last_node_public_key())
-
-        Utils.key_in_node_list?(io_storage_nodes, Crypto.first_node_public_key()) or
-          address == node_pool_address
+        address
+        |> Election.chain_storage_nodes(node_list)
+        |> Utils.key_in_node_list?(Crypto.first_node_public_key())
       end)
     end
   end

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -97,6 +97,9 @@ defmodule Archethic.BootstrapTest do
       ]
     end)
 
+    MockCrypto.NodeKeystore
+    |> stub(:set_node_key_index, fn _ -> :ok end)
+
     start_supervised!(RewardMemTable)
     start_supervised!(RewardTableLoader)
 


### PR DESCRIPTION
# Description

Fix a bug when a node goes in first_initialization during bootstrap while the node already exists on the network. The node was not able to correctly retrieve it's index to create the new node transaction in the chain.

Also fix an bug in pending transaction validation while verifying if the transaction already exists

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Start 2 nodes, stop 1 and delete it's DB, restart it
It should create a new node transaction in it's node chain.
Then wait for next self repair and try to update the node reward address (using endpoint/settings) and it should create a new transaction in the node chain.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
