### PR TITLE
Welcome node should forward tx if not synced#872

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,15 +7,14 @@ config :git_hooks,
     pre_push: [
       tasks: [
         {:cmd, "mix clean"},
-        {:cmd, "mix git_hooks.install"},
-        {:cmd, "mix hex.outdated --within-requirements"},
         {:cmd, "mix format --check-formatted"},
         {:cmd, "mix compile --warnings-as-errors"},
         {:cmd, "mix credo"},
         {:cmd, "mix sobelow"},
         {:cmd, "mix knigge.verify"},
         {:cmd, "mix test --trace"},
-        {:cmd, "mix dialyzer"}
+        {:cmd, "mix dialyzer"},
+        {:cmd, "mix check.updates"}
       ]
     ]
   ]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -117,8 +117,9 @@ config :archethic, Archethic.SelfRepair.Scheduler,
   availability_application: 10
 
 config :archethic, Archethic.SharedSecrets.NodeRenewalScheduler,
-  # At 40th second
+  # At 40th second Create a new node renewal tx
   interval: "40 * * * * * *",
+  # At every minute, Make use of the new node renewal tx
   application_interval: "0 * * * * * *"
 
 config :archethic, Archethic.P2P.Listener,

--- a/lib/archethic/bootstrap/transaction_handler.ex
+++ b/lib/archethic/bootstrap/transaction_handler.ex
@@ -36,7 +36,10 @@ defmodule Archethic.Bootstrap.TransactionHandler do
   @spec do_send_transaction(list(Node.t()), Transaction.t()) ::
           :ok
   defp do_send_transaction([node | rest], tx) do
-    case P2P.send_message(node, %NewTransaction{transaction: tx}) do
+    case P2P.send_message(node, %NewTransaction{
+           transaction: tx,
+           welcome_node: node.first_public_key
+         }) do
       {:ok, %Ok{}} ->
         Logger.info("Waiting transaction validation",
           transaction_address: Base.encode16(tx.address),

--- a/lib/archethic/crypto.ex
+++ b/lib/archethic/crypto.ex
@@ -30,21 +30,11 @@ defmodule Archethic.Crypto do
   According to the implementation, keys can be stored and regenerated on the fly
   """
 
-  alias __MODULE__.ECDSA
-  alias __MODULE__.Ed25519
-  alias __MODULE__.ID
-  alias __MODULE__.NodeKeystore
-  alias __MODULE__.SharedSecretsKeystore
+  alias __MODULE__.{ECDSA, Ed25519, ID, NodeKeystore, SharedSecretsKeystore}
 
-  alias Archethic.SharedSecrets
-
-  alias Archethic.TransactionChain
-  alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.Transaction.ValidationStamp
-  alias Archethic.TransactionChain.TransactionData
-  alias Archethic.TransactionChain.TransactionData.Ownership
-
-  alias Archethic.Utils
+  alias Archethic.{SharedSecrets, Utils, TransactionChain}
+  alias Archethic.TransactionChain.{Transaction, Transaction.ValidationStamp}
+  alias Archethic.TransactionChain.{TransactionData, TransactionData.Ownership}
 
   require Logger
 

--- a/lib/archethic/oracle_chain/scheduler.ex
+++ b/lib/archethic/oracle_chain/scheduler.ex
@@ -2,26 +2,11 @@ defmodule Archethic.OracleChain.Scheduler do
   @moduledoc """
   Manage the scheduling of the oracle transactions
   """
-
-  alias Archethic.Crypto
-
-  alias Archethic.Election
-
-  alias Archethic.P2P
-  alias Archethic.P2P.Node
-
-  alias Archethic.PubSub
-
-  alias Archethic.OracleChain
-  alias Archethic.OracleChain.Services
-  alias Archethic.OracleChain.Summary
-
-  alias Archethic.TransactionChain
-  alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.TransactionData
-
-  alias Archethic.Utils
-  alias Archethic.Utils.DetectNodeResponsiveness
+  alias Archethic
+  alias Archethic.{Crypto, Election, P2P, P2P.Node, PubSub, Utils}
+  alias Archethic.{OracleChain, TransactionChain, Utils.DetectNodeResponsiveness}
+  alias OracleChain.{Services, Summary}
+  alias TransactionChain.{Transaction, TransactionData}
 
   alias Crontab.CronExpression.Parser, as: CronParser
 

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -2,22 +2,11 @@ defmodule Archethic.P2P do
   @moduledoc """
   Handle P2P node discovery and messaging
   """
-  alias Archethic.Crypto
+  alias Archethic.{Crypto, TaskSupervisor, TransactionChain}
 
-  alias __MODULE__.BootstrappingSeeds
-  alias __MODULE__.Client
-  alias __MODULE__.GeoPatch
-  alias __MODULE__.MemTable
-  alias __MODULE__.MemTableLoader
-  alias __MODULE__.Message
-  alias __MODULE__.Node
+  alias Archethic.{TransactionChain.Transaction, Utils}
 
-  alias Archethic.TaskSupervisor
-
-  alias Archethic.TransactionChain
-  alias Archethic.TransactionChain.Transaction
-
-  alias Archethic.Utils
+  alias __MODULE__.{BootstrappingSeeds, Client, GeoPatch, MemTable, MemTableLoader, Message, Node}
 
   require Logger
 

--- a/lib/archethic/reward/scheduler.ex
+++ b/lib/archethic/reward/scheduler.ex
@@ -4,17 +4,10 @@ defmodule Archethic.Reward.Scheduler do
   use GenStateMachine, callback_mode: [:handle_event_function]
   @vsn Mix.Project.config()[:version]
 
-  alias Archethic.{
-    Crypto,
-    PubSub,
-    DB,
-    P2P,
-    P2P.Node,
-    Reward,
-    Election,
-    Utils,
-    Utils.DetectNodeResponsiveness
-  }
+  alias Archethic
+
+  alias Archethic.{Crypto, PubSub, DB, P2P, P2P.Node}
+  alias Archethic.{Reward, Election, Utils, Utils.DetectNodeResponsiveness}
 
   require Logger
 

--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -4,23 +4,11 @@ defmodule Archethic.SelfRepair do
   the bootstrapping phase and stores last synchronization date after each cycle.
   """
 
-  alias __MODULE__.Notifier
-  alias __MODULE__.NotifierSupervisor
-  alias __MODULE__.RepairRegistry
-  alias __MODULE__.RepairWorker
-  alias __MODULE__.Scheduler
-  alias __MODULE__.Sync
+  alias __MODULE__.{Notifier, NotifierSupervisor, RepairRegistry, RepairWorker}
+  alias __MODULE__.{Scheduler, Sync}
 
-  alias Archethic.{
-    BeaconChain,
-    Crypto,
-    Utils,
-    Contracts,
-    TransactionChain,
-    Election
-  }
-
-  alias Archethic.P2P.Node
+  alias Archethic.{BeaconChain, Crypto, Utils, Contracts, TransactionChain, Election}
+  alias Archethic.{P2P.Node, SharedSecrets, OracleChain, Reward, Replication}
 
   alias Crontab.CronExpression.Parser, as: CronParser
   alias Crontab.Scheduler, as: CronScheduler
@@ -217,4 +205,55 @@ defmodule Archethic.SelfRepair do
         :ok
     end
   end
+
+  def resync(last_address) do
+    first_address = get_genesis_address(:node_shared_secrets)
+
+    case repair_in_progress?(first_address) do
+      false ->
+        start_worker(
+          first_address: first_address,
+          storage_address: last_address,
+          io_addresses: []
+        )
+
+      pid ->
+        add_repair_addresses(pid, first_address, [])
+    end
+
+    :ok
+  end
+
+  @spec resync_network_chain(atom(), list(Node.t()) | []) :: :ok | :error
+  def resync_network_chain(_, []),
+    do: Logger.notice("Enforce Resync of Network Txs: No-Nodes")
+
+  def resync_network_chain(type, nodes) do
+    with addr when is_binary(addr) <- get_genesis_address(type),
+         {:ok, rem_last_addr} <- TransactionChain.resolve_last_address(addr),
+         {local_last_addr, _} <- TransactionChain.get_last_address(addr),
+         false <- rem_last_addr == local_last_addr,
+         {:ok, tx} <- TransactionChain.fetch_transaction_remotely(rem_last_addr, nodes),
+         :ok <- Replication.validate_and_store_transaction_chain(tx) do
+      Logger.info("Enforced Resync: Success", transaction_type: type)
+      :ok
+    else
+      nil ->
+        Logger.warning("Node is out of sync, wait for self repair to complete succesfully.")
+
+      true ->
+        Logger.info("Enforced Resync: No new transaction to sync", transaction_type: type)
+        :ok
+
+      e ->
+        Logger.debug("Enforced Resync: Error #{inspect(e)}", transaction_type: type)
+    end
+  end
+
+  defp get_genesis_address(:node_shared_secrets),
+    do: SharedSecrets.genesis_address(:node_shared_secrets)
+
+  defp get_genesis_address(:oracle), do: OracleChain.genesis_address()
+
+  defp get_genesis_address(:reward), do: Reward.genesis_address()
 end

--- a/lib/archethic/self_repair/scheduler.ex
+++ b/lib/archethic/self_repair/scheduler.ex
@@ -5,16 +5,8 @@ defmodule Archethic.SelfRepair.Scheduler do
   """
   use GenServer
   @vsn Mix.Project.config()[:version]
-
-  alias Archethic.P2P
-
-  alias Archethic.SelfRepair.Sync
-
-  alias Archethic.TaskSupervisor
-
-  alias Archethic.Utils
-
-  alias Archethic.PubSub
+  alias Archethic
+  alias Archethic.{P2P, SelfRepair.Sync, TaskSupervisor, Utils, PubSub}
 
   alias Archethic.Bootstrap.Sync, as: BootstrapSync
 

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -1,33 +1,14 @@
 defmodule Archethic.SelfRepair.Sync do
   @moduledoc false
+  alias Archethic
 
-  alias Archethic.BeaconChain
-  alias Archethic.BeaconChain.Subset.P2PSampling
-  alias Archethic.BeaconChain.Summary
-  alias Archethic.BeaconChain.SummaryAggregate
+  alias Archethic.{BeaconChain, Crypto, DB, Election, P2P, P2P.Node, P2P.Message}
+  alias Archethic.{SelfRepair, TaskSupervisor, TransactionChain, Utils, PubSub}
+  alias Archethic.{TaskSupervisor, TransactionChain.TransactionSummary}
 
-  alias Archethic.Crypto
-
-  alias Archethic.DB
-
-  alias Archethic.Election
-
-  alias Archethic.PubSub
-
-  alias Archethic.P2P
-  alias Archethic.P2P.Node
-  alias Archethic.P2P.Message
+  alias BeaconChain.{Subset.P2PSampling, Summary, SummaryAggregate}
 
   alias __MODULE__.TransactionHandler
-
-  alias Archethic.TaskSupervisor
-  alias Archethic.TransactionChain
-
-  alias Archethic.TransactionChain.TransactionSummary
-
-  alias Archethic.SelfRepair
-
-  alias Archethic.Utils
 
   require Logger
 

--- a/lib/archethic_web/channels/user_socket.ex
+++ b/lib/archethic_web/channels/user_socket.ex
@@ -8,6 +8,7 @@ defmodule ArchethicWeb.UserSocket do
 
   require Logger
 
+  alias Archethic
   ## Channels
   # channel "room:*", ArchethicWeb.RoomChannel
 

--- a/mix.exs
+++ b/mix.exs
@@ -131,6 +131,16 @@ defmodule Archethic.MixProject do
 
   defp aliases do
     [
+      "check.updates": ["cmd mix hex.outdated --within-requirements || echo 'Updates available!'"],
+      compile: ["git_hooks.install", "compile"],
+      "dev.update_deps": [
+        "hex.outdated --within-requirements",
+        "deps.update --all --only",
+        "deps.clean --all --only",
+        "deps.get",
+        "deps.compile",
+        "hex.outdated --within-requirements"
+      ],
       # Intial developer Setup
       "dev.setup": ["deps.get", "cmd npm install --prefix assets"],
       # When Changes are not registered by compiler | any()

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -1,52 +1,19 @@
 defmodule Archethic.BootstrapTest do
   use ArchethicCase
 
-  alias Archethic.{
-    Bootstrap,
-    Crypto,
-    P2P,
-    P2P.BootstrappingSeeds,
-    P2P.Node,
-    Replication,
-    SharedSecrets,
-    TransactionChain,
-    TransactionFactory
-  }
+  alias Archethic.{Bootstrap, Crypto, Replication, SharedSecrets, TransactionChain}
+  alias Archethic.{P2P, P2P.BootstrappingSeeds, P2P.Node, TransactionChain, P2P.Message}
+  alias Archethic.{TransactionFactory, SelfRepair}
 
-  alias Archethic.P2P.Message.{
-    GetTransactionChainLength,
-    TransactionChainLength,
-    BootstrappingNodes,
-    EncryptedStorageNonce,
-    GetBootstrappingNodes,
-    GetLastTransactionAddress,
-    GetStorageNonce,
-    GetTransaction,
-    GetTransactionChain,
-    GetTransactionSummary,
-    GetTransactionInputs,
-    GetGenesisAddress,
-    GenesisAddress,
-    LastTransactionAddress,
-    ListNodes,
-    NewTransaction,
-    NodeList,
-    NotFound,
-    NotifyEndOfNodeSync,
-    TransactionList,
-    TransactionInputList,
-    TransactionSummaryMessage,
-    Ok,
-    GetGenesisAddress,
-    NotFound
-  }
+  alias Message.{GetGenesisAddress, GetTransactionChainLength, GetBootstrappingNodes, Ok}
+  alias Message.{GetTransactionSummary, GetTransactionInputs, GetGenesisAddress, GetStorageNonce}
+  alias Message.{GetLastTransactionAddress, GetTransactionChain, GetTransaction, NotFound}
+  alias Message.{GenesisAddress, LastTransactionAddress, NewTransaction, NotifyEndOfNodeSync}
+  alias Message.{TransactionList, TransactionInputList, TransactionSummaryMessage, NodeList}
+  alias Message.{TransactionChainLength, BootstrappingNodes, EncryptedStorageNonce, ListNodes}
 
-  alias TransactionChain.{
-    Transaction,
-    TransactionSummary,
-    Transaction.ValidationStamp,
-    Transaction.ValidationStamp.LedgerOperations
-  }
+  alias TransactionChain.{Transaction, TransactionSummary}
+  alias Transaction.{ValidationStamp, ValidationStamp.LedgerOperations}
 
   alias Archethic.BeaconChain.SlotTimer, as: BeaconSlotTimer
   alias Archethic.BeaconChain.SummaryTimer, as: BeaconSummaryTimer
@@ -501,7 +468,7 @@ defmodule Archethic.BootstrapTest do
       :persistent_term.put(:node_shared_secrets_gen_addr, nil)
 
       assert :ok =
-               Bootstrap.do_resync_network_chain(
+               SelfRepair.resync_network_chain(
                  :node_shared_secrets,
                  _nodes = P2P.authorized_and_available_nodes()
                )
@@ -529,7 +496,7 @@ defmodule Archethic.BootstrapTest do
       end)
 
       assert :ok =
-               Bootstrap.do_resync_network_chain(
+               SelfRepair.resync_network_chain(
                  :node_shared_secrets,
                  _nodes = P2P.authorized_and_available_nodes()
                )
@@ -600,7 +567,7 @@ defmodule Archethic.BootstrapTest do
       end)
 
       assert :ok =
-               Bootstrap.do_resync_network_chain(
+               SelfRepair.resync_network_chain(
                  :node_shared_secrets,
                  _nodes = P2P.authorized_and_available_nodes()
                )

--- a/test/archethic/oracle_chain/scheduler_test.exs
+++ b/test/archethic/oracle_chain/scheduler_test.exs
@@ -383,6 +383,8 @@ defmodule Archethic.OracleChain.SchedulerTest do
     end
 
     test "should wait for node up message to start the scheduler and node_down to stop the scheduler, node: authorized and available" do
+      :persistent_term.put(:archethic_up, nil)
+
       P2P.add_and_connect_node(%Node{
         ip: {127, 0, 0, 1},
         port: 3002,

--- a/test/archethic/oracle_chain/scheduler_test.exs
+++ b/test/archethic/oracle_chain/scheduler_test.exs
@@ -18,10 +18,15 @@ defmodule Archethic.OracleChain.SchedulerTest do
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.TransactionData
 
+  import ArchethicCase, only: [setup_before_send_tx: 0]
+
   import Mox
 
   setup do
     SelfRepairScheduler.start_link([interval: "0 0 * * *"], [])
+
+    setup_before_send_tx()
+
     :ok
   end
 

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -145,8 +145,8 @@ defmodule Archethic.P2P.MessageTest do
     test "NewTransaction message" do
       tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
 
-      assert %NewTransaction{transaction: tx} ==
-               %NewTransaction{transaction: tx}
+      assert %NewTransaction{transaction: tx, welcome_node: Crypto.first_node_public_key()} ==
+               %NewTransaction{transaction: tx, welcome_node: Crypto.first_node_public_key()}
                |> Message.encode()
                |> Message.decode()
                |> elem(0)

--- a/test/archethic/reward/scheduler_test.exs
+++ b/test/archethic/reward/scheduler_test.exs
@@ -1,19 +1,23 @@
 defmodule Archethic.Reward.SchedulerTest do
   use ArchethicCase, async: false
 
-  alias Archethic.{
-    Crypto,
-    P2P,
-    P2P.Node,
-    P2P.Message.StartMining,
-    Reward.Scheduler,
-    TransactionChain.Transaction
-  }
+  alias Archethic.{Crypto, P2P, P2P.Node, P2P.Message.StartMining}
+  alias Archethic.{Reward.Scheduler, TransactionChain.Transaction}
+
+  import ArchethicCase, only: [setup_before_send_tx: 0]
 
   import Mox
 
+  setup do
+    setup_before_send_tx()
+
+    :ok
+  end
+
   describe "Trigger mint Reward" do
     test "should initiate the reward scheduler and trigger mint reward" do
+      :persistent_term.put(:archethic_up, nil)
+
       P2P.add_and_connect_node(%Node{
         first_public_key: Crypto.first_node_public_key(),
         last_public_key: Crypto.last_node_public_key(),
@@ -52,6 +56,8 @@ defmodule Archethic.Reward.SchedulerTest do
 
   describe "Scheduler" do
     setup do
+      :persistent_term.put(:archethic_up, nil)
+
       P2P.add_and_connect_node(%Node{
         first_public_key: Crypto.first_node_public_key(),
         last_public_key: Crypto.last_node_public_key(),

--- a/test/archethic/reward/scheduler_test.exs
+++ b/test/archethic/reward/scheduler_test.exs
@@ -138,6 +138,8 @@ defmodule Archethic.Reward.SchedulerTest do
     end
 
     test "should wait for :node_up message to start the scheduler, when node is authorized and available" do
+      :persistent_term.put(:archethic_up, nil)
+
       P2P.add_and_connect_node(%Node{
         ip: {127, 0, 0, 1},
         port: 3002,

--- a/test/archethic/shared_secrets/node_renewal_scheduler_test.exs
+++ b/test/archethic/shared_secrets/node_renewal_scheduler_test.exs
@@ -18,12 +18,17 @@ defmodule Archethic.SharedSecrets.NodeRenewalSchedulerTest do
 
   alias Archethic.TransactionChain.Transaction
 
+  import ArchethicCase, only: [setup_before_send_tx: 0]
+
   import Mox
 
   setup do
     SelfRepairScheduler.start_link([interval: "0 0 0 * *"], [])
     start_supervised!({BeaconSlotTimer, interval: "0 * * * * *"})
     Enum.each(BeaconChain.list_subsets(), &Registry.register(SubsetRegistry, &1, []))
+
+    setup_before_send_tx()
+
     :ok
   end
 
@@ -160,6 +165,8 @@ defmodule Archethic.SharedSecrets.NodeRenewalSchedulerTest do
     end
 
     test "should wait for node down message to stop the scheduler" do
+      :persistent_term.put(:archethic_up, nil)
+
       P2P.add_and_connect_node(%Node{
         ip: {127, 0, 0, 1},
         port: 3002,

--- a/test/archethic/shared_secrets_test.exs
+++ b/test/archethic/shared_secrets_test.exs
@@ -1,13 +1,15 @@
 defmodule Archethic.SharedSecretsTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
-  alias Archethic.{
-    Crypto,
-    SharedSecrets,
-    SharedSecrets.MemTables.OriginKeyLookup
-  }
+  alias Archethic.{Crypto, SharedSecrets, SharedSecrets.MemTables.OriginKeyLookup, P2P}
+  alias Archethic.{TransactionChain.Transaction, TransactionChain.MemTables.KOLedger}
+  alias Archethic.{Election, TransactionChain.Transaction.ValidationStamp}
+
+  alias P2P.Message.{GetLastTransactionAddress, LastTransactionAddress}
 
   doctest SharedSecrets
+
+  import Mox
 
   describe "has_origin_public_key?/1" do
     setup do
@@ -24,6 +26,111 @@ defmodule Archethic.SharedSecretsTest do
       {pb_key, _} = Crypto.derive_keypair("has_origin_public_key", 0)
       OriginKeyLookup.add_public_key(:software, pb_key)
       assert SharedSecrets.has_origin_public_key?(pb_key)
+    end
+  end
+
+  describe "verify_synchronization" do
+    setup do
+      MockCrypto.NodeKeystore
+      |> stub(:first_public_key, fn ->
+        {pub, _} = Crypto.derive_keypair("seed", 0, :secp256r1)
+        pub
+      end)
+      |> stub(:last_public_key, fn ->
+        {pub, _} = Crypto.derive_keypair("seed", 0, :secp256r1)
+        pub
+      end)
+
+      MockCrypto.SharedSecretsKeystore
+      |> stub(:get_storage_nonce, fn -> "nonce" end)
+
+      MockClient
+      |> stub(:new_connection, fn _, _, _, public_key ->
+        P2P.MemTable.increase_node_availability(public_key)
+        {:ok, make_ref()}
+      end)
+
+      start_supervised!({KOLedger, []})
+      start_supervised!({P2P.MemTable, []})
+      start_supervised!(Election.Constraints)
+
+      allow(MockCrypto.NodeKeystore, self(), P2P.MemTable)
+
+      P2P.add_and_connect_node(%P2P.Node{
+        first_public_key: Crypto.derive_keypair("seed", 0, :secp256r1) |> elem(0),
+        last_public_key: Crypto.derive_keypair("seed", 0, :secp256r1) |> elem(0),
+        authorized?: true,
+        available?: true,
+        authorization_date: DateTime.add(DateTime.utc_now(), -86_400, :second),
+        geo_patch: "AAA",
+        network_patch: "AAA",
+        enrollment_date: DateTime.add(DateTime.utc_now(), -86_400, :second),
+        reward_address: "Crypto.derive_address(Crypto.last_node_public_key())"
+      })
+
+      Process.sleep(50)
+      :ok
+    end
+
+    test "validate_scheduling_time()" do
+      keys = SharedSecrets.genesis_address_keys()
+
+      :persistent_term.put(keys.nss, nil)
+      refute SharedSecrets.validate_scheduling_time()
+
+      nss_genesis_address = "nss_genesis_address"
+      nss_last_address = "nss_last_address"
+      :persistent_term.put(Map.get(keys, :nss), "nss_genesis_address")
+
+      MockDB
+      |> expect(:get_last_chain_address, 1, fn ^nss_genesis_address ->
+        {nss_last_address, DateTime.utc_now()}
+      end)
+      |> expect(:get_transaction, 1, fn ^nss_last_address,
+                                        [validation_stamp: [:timestamp]],
+                                        :chain ->
+        {:ok,
+         %Transaction{
+           validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+         }}
+      end)
+
+      assert SharedSecrets.validate_scheduling_time()
+
+      MockDB
+      |> expect(:get_last_chain_address, 1, fn ^nss_genesis_address ->
+        {nss_last_address, DateTime.utc_now()}
+      end)
+      |> expect(:get_transaction, 1, fn ^nss_last_address,
+                                        [validation_stamp: [:timestamp]],
+                                        :chain ->
+        {:ok, :error}
+      end)
+
+      refute SharedSecrets.validate_scheduling_time()
+    end
+
+    test "validate_last_address()" do
+      keys = SharedSecrets.genesis_address_keys()
+
+      :persistent_term.put(keys.nss, nil)
+      assert :error == SharedSecrets.validate_last_address()
+
+      nss_genesis_address = "nss_genesis_address"
+      nss_last_address = "nss_last_address"
+      :persistent_term.put(Map.get(keys, :nss), "nss_genesis_address")
+
+      MockClient
+      |> stub(:send_message, fn _, %GetLastTransactionAddress{}, _ ->
+        {:ok, %LastTransactionAddress{address: nss_last_address}}
+      end)
+
+      MockDB
+      |> stub(:get_last_chain_address, fn ^nss_genesis_address ->
+        {nss_last_address, DateTime.utc_now()}
+      end)
+
+      assert :ok == SharedSecrets.validate_last_address()
     end
   end
 end

--- a/test/archethic_test.exs
+++ b/test/archethic_test.exs
@@ -1,32 +1,136 @@
 defmodule ArchethicTest do
   use ArchethicCase
 
-  alias Archethic.Crypto
+  alias Archethic.{Crypto, PubSub, P2P, P2P.Message, P2P.Node, TransactionChain, SelfRepair}
+  alias Archethic.{BeaconChain.SummaryTimer, SharedSecrets}
 
-  alias Archethic.PubSub
+  alias Message.{Balance, GetBalance, GetLastTransactionAddress, GetTransaction, Ok}
+  alias Message.{GetTransactionChainLength, GetTransactionInputs, LastTransactionAddress}
+  alias Message.{NotFound, StartMining, TransactionChainLength, TransactionInputList}
+  alias Message.{NewTransaction}
 
-  alias Archethic.P2P
-  alias Archethic.P2P.Message.Balance
-  alias Archethic.P2P.Message.GetBalance
-  alias Archethic.P2P.Message.GetLastTransactionAddress
-  alias Archethic.P2P.Message.GetTransaction
-  alias Archethic.P2P.Message.GetTransactionChainLength
-  alias Archethic.P2P.Message.GetTransactionInputs
+  alias TransactionChain.{Transaction, TransactionData}
+  alias TransactionChain.{TransactionInput, VersionedTransactionInput}
 
-  alias Archethic.P2P.Message.LastTransactionAddress
-  alias Archethic.P2P.Message.NotFound
-  alias Archethic.P2P.Message.Ok
-  alias Archethic.P2P.Message.StartMining
-  alias Archethic.P2P.Message.TransactionChainLength
-  alias Archethic.P2P.Message.TransactionInputList
-  alias Archethic.P2P.Node
-
-  alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.TransactionData
-  alias Archethic.TransactionChain.TransactionInput
-  alias Archethic.TransactionChain.VersionedTransactionInput
+  import ArchethicCase, only: [setup_before_send_tx: 0]
 
   import Mox
+
+  setup do
+    setup_before_send_tx()
+    :ok
+  end
+
+  describe "should validate NSS Chain before sending a tx" do
+    test "When NOT authorized & available should forward the tx " do
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
+        network_patch: "AAA",
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: false,
+        authorization_date: DateTime.utc_now() |> DateTime.add(-1)
+      })
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: "node2",
+        last_public_key: "node2",
+        network_patch: "AAA",
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: true,
+        authorization_date: DateTime.utc_now() |> DateTime.add(-1)
+      })
+
+      MockClient
+      |> expect(:send_message, 1, fn
+        _, %NewTransaction{}, _ ->
+          {:ok, %Ok{}}
+      end)
+
+      tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
+
+      assert :ok = Archethic.send_new_transaction(tx)
+    end
+
+    test "When NOT synced should forward the tx and start repair " do
+      nss_genesis_address = "nss_genesis_address"
+      nss_last_address = "nss_last_address"
+      :persistent_term.put(:node_shared_secrets_gen_addr, nss_genesis_address)
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.first_node_public_key(),
+        network_patch: "AAA",
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: true,
+        authorization_date: DateTime.utc_now() |> DateTime.add(-20_000)
+      })
+
+      start_supervised!({SummaryTimer, Application.get_env(:archethic, SummaryTimer)})
+
+      MockDB
+      |> stub(:get_last_chain_address, fn ^nss_genesis_address ->
+        {nss_last_address, DateTime.utc_now()}
+      end)
+      |> stub(
+        :get_transaction,
+        fn
+          ^nss_last_address, [validation_stamp: [:timestamp]], :chain ->
+            {:ok,
+             %Transaction{
+               validation_stamp: %{
+                 __struct__: :ValidationStamp,
+                 # fail mathematical check with irregular timestamp
+                 # causes validate_scheduling_time() to fail
+                 timestamp: DateTime.utc_now() |> DateTime.add(-86_400)
+               }
+             }}
+
+          _, _, _ ->
+            {:error, :transaction_not_exists}
+        end
+      )
+
+      MockClient
+      |> expect(:send_message, 4, fn
+        # validate nss chain from network
+        # anticippated to be failed
+        _, %GetLastTransactionAddress{}, _ ->
+          {:ok, %LastTransactionAddress{address: "willnotmatchaddress"}}
+
+        _, %NewTransaction{transaction: _, welcome_node: _}, _ ->
+          # forward the tx
+          {:ok, %Ok{}}
+
+        _, %GetTransaction{address: _}, _ ->
+          {:ok, %NotFound{}}
+
+        _, _, _ ->
+          {:ok, %Ok{}}
+      end)
+
+      # last address is d/f it returns last address from quorum
+      assert {:error, "willnotmatchaddress"} = SharedSecrets.verify_synchronization()
+
+      # trying to ssend a tx when NSS chain not synced
+      tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
+      assert :ok = Archethic.send_new_transaction(tx)
+
+      # start repair and should bottleneck requests
+      pid = SelfRepair.repair_in_progress?(nss_genesis_address)
+      Process.sleep(150)
+      assert pid != nil
+    end
+  end
 
   describe "search_transaction/1" do
     test "should request storage nodes and return the transaction" do
@@ -108,7 +212,7 @@ defmodule ArchethicTest do
 
       MockClient
       |> expect(:send_message, fn _, %StartMining{}, _ ->
-        Process.sleep(1_000)
+        Process.sleep(20)
         PubSub.notify_new_transaction(tx.address)
         {:ok, %Ok{}}
       end)

--- a/test/archethic_web/controllers/api/origin_key_controller_test.exs
+++ b/test/archethic_web/controllers/api/origin_key_controller_test.exs
@@ -2,14 +2,10 @@ defmodule ArchethicWeb.API.OriginKeyControllerTest do
   use ArchethicCase
   use ArchethicWeb.ConnCase
 
-  alias Archethic.{
-    Crypto,
-    P2P,
-    P2P.Node,
-    SharedSecrets,
-    SharedSecrets.MemTables.OriginKeyLookup,
-    P2P.Message.Ok
-  }
+  alias Archethic.{Crypto, P2P, P2P.Node, SharedSecrets}
+  alias Archethic.{SharedSecrets.MemTables.OriginKeyLookup, P2P.Message.Ok}
+
+  import ArchethicCase, only: [setup_before_send_tx: 0]
 
   import Mox
 
@@ -28,6 +24,7 @@ defmodule ArchethicWeb.API.OriginKeyControllerTest do
 
     OriginKeyLookup.start_link()
 
+    setup_before_send_tx()
     :ok
   end
 

--- a/test/archethic_web/controllers/faucet_controller_test.exs
+++ b/test/archethic_web/controllers/faucet_controller_test.exs
@@ -2,36 +2,18 @@ defmodule ArchethicWeb.FaucetControllerTest do
   use ArchethicCase, async: false
   use ArchethicWeb.ConnCase
 
-  alias Archethic.{
-    Crypto,
-    P2P,
-    P2P.Node,
-    PubSub
-  }
+  alias Archethic.{Crypto, P2P, P2P.Node, PubSub, P2P.Message, TransactionChain}
+  alias Archethic.{BeaconChain.ReplicationAttestation, TransactionChain.TransactionData}
 
-  alias Archethic.BeaconChain.ReplicationAttestation
+  alias Message.{GetLastTransactionAddress, GetTransactionChainLength, LastTransactionAddress, Ok}
+  alias Message.{StartMining, TransactionChainLength, GetGenesisAddress, GenesisAddress}
 
-  alias Archethic.P2P.Message.{
-    GetLastTransactionAddress,
-    GetTransactionChainLength,
-    LastTransactionAddress,
-    Ok,
-    StartMining,
-    TransactionChainLength,
-    GetGenesisAddress,
-    GenesisAddress
-  }
-
-  alias Archethic.TransactionChain.{
-    Transaction,
-    TransactionData,
-    TransactionData.Ledger,
-    TransactionData.UCOLedger,
-    TransactionSummary
-  }
+  alias TransactionData.{Ledger, UCOLedger}
+  alias TransactionChain.{Transaction, TransactionSummary}
 
   alias ArchethicWeb.FaucetRateLimiter
 
+  import ArchethicCase, only: [setup_before_send_tx: 0]
   import Mox
 
   @pool_seed Application.compile_env(:archethic, [ArchethicWeb.FaucetController, :seed])
@@ -49,6 +31,7 @@ defmodule ArchethicWeb.FaucetControllerTest do
       authorization_date: DateTime.utc_now()
     })
 
+    setup_before_send_tx()
     :ok
   end
 

--- a/test/archethic_web/graphql_schema_test.exs
+++ b/test/archethic_web/graphql_schema_test.exs
@@ -865,6 +865,9 @@ defmodule ArchethicWeb.GraphQLSchemaTest do
       |> stub(:send_message, fn
         _, %GetCurrentSummaries{}, _ ->
           {:ok, []}
+
+        _, %GetBeaconSummariesAggregate{}, _ ->
+          {:ok, %SummaryAggregate{version: version}}
       end)
 
       conn =


### PR DESCRIPTION
# Description

When it is the time for protocol to create a new node renewal transaction, there exist a time window where new transactions arrive and election results with anomaly due to missing latest Node shared secret transaction.

###  Solutions and  Further improvements
 - Check for whether a node is synced for every transaction
 - If not schedule a request for resync.
 - Last nss transaction validation stamp and last scheduling date to determine node status.
 
 Drawbacks
 - NSS chain has to be checked for each transaction

 Solution

- [ ] #872 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- manual 


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
