### PR TITLE
Create appup transform to set post_purge to soft

### DIFF
--- a/lib/release/transform_purge.ex
+++ b/lib/release/transform_purge.ex
@@ -1,0 +1,60 @@
+defmodule Archethic.Release.TransformPurge do
+  @moduledoc false
+
+  use Distillery.Releases.Appup.Transform
+
+  @default_change {:advanced, []}
+
+  def up(:archethic, _v1, _v2, instructions, _opts), do: transform(instructions, [])
+
+  def up(_, _, _, instructions, _), do: instructions
+
+  def down(:archethic, _v1, _v2, instructions, _opts), do: transform(instructions, [])
+
+  def down(_, _, _, instructions, _), do: instructions
+
+  defp transform([], acc), do: Enum.reverse(acc)
+
+  defp transform([instruction | rest], acc) do
+    call = elem(instruction, 0)
+
+    new_instruction =
+      case call do
+        :update ->
+          handle_update(instruction)
+
+        call when call in [:load, :load_module] ->
+          handle_load(instruction)
+
+        _ ->
+          instruction
+      end
+
+    transform(rest, [new_instruction | acc])
+  end
+
+  defp handle_update(instruction = {_call, _module, :supervisor}), do: instruction
+
+  defp handle_update({call, module}),
+    do: {call, module, @default_change, :brutal_purge, :soft_purge}
+
+  defp handle_update({call, module, change}) when is_tuple(change),
+    do: {call, module, change, :brutal_purge, :soft_purge}
+
+  defp handle_update({call, module, deps}) when is_list(deps),
+    do: {call, module, @default_change, :brutal_purge, :soft_purge, deps}
+
+  defp handle_update({call, module, change, deps}),
+    do: {call, module, change, :brutal_purge, :soft_purge, deps}
+
+  # Other change already contain purge so we don't overwrite them
+  defp handle_update(instruction), do: instruction
+
+  defp handle_load({call, module}), do: {call, module, :brutal_purge, :soft_purge, []}
+
+  defp handle_load({call, module, deps}),
+    do: {call, module, :brutal_purge, :soft_purge, deps}
+
+  # Other change already contain purge so we don't overwrite them
+  defp handle_load(instruction), do: instruction
+end

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -56,4 +56,8 @@ release :archethic_node do
     :observer_cli,
     archethic: :permanent
   ]
+
+  set appup_transforms: [
+    {Archethic.Release.TransformPurge, []}
+  ]
 end


### PR DESCRIPTION
# Description

Create new module `Archethic.Release.TransformPurge`.
This module is called during the creation of an appup from distillery.
It is configured in `rel/config.exs`

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Create a release on testnet branch using `./script/test-script.sh -i`
Switch to PR branch, change mix.exs version and generate an appup using `mix distillery.gen.appup --app archethic`
The generated appup should have brutal_purge and soft_purge in each load_module or update instructions.
Generate the upgrade release using `./script/test-release.sh -p` it should take the generated appup as it valid (not create a new one, visible in log)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
