### PR TITLE
plug governance flow with incoming transactions

### DIFF
--- a/lib/archethic/governance/code/CICD.ex
+++ b/lib/archethic/governance/code/CICD.ex
@@ -18,7 +18,7 @@ defmodule Archethic.Governance.Code.CICD do
 
   where
     * Code - a source code of archethic-node
-    * Propsal - a code proposal transaction
+    * Proposal - a code proposal transaction
     * Release - a release of archethic-node
     * Upgrade - an upgrade to a release of archethic-node
     * CiLog - unit tests and type checker logs

--- a/lib/archethic/governance/code/cicd/docker/cicd.ex
+++ b/lib/archethic/governance/code/cicd/docker/cicd.ex
@@ -1,6 +1,6 @@
 defmodule Archethic.Governance.Code.CICD.Docker do
   @moduledoc """
-  CICD service baked by docker.
+  CICD service backed by docker.
 
   The service relies on the `Dockerfile` with two targets: `archethic-ci` and
   `archethic-cd`.

--- a/lib/archethic/governance/pools/mem_table.ex
+++ b/lib/archethic/governance/pools/mem_table.ex
@@ -5,7 +5,7 @@ defmodule Archethic.Governance.Pools.MemTable do
   alias Archethic.Governance.Pools
 
   @doc """
-  Initialize an memory table for the governance pool member distribution
+  Initialize a memory table for the governance pool member distribution
 
   ## Examples
 

--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -502,6 +502,17 @@ defmodule Archethic.Mining.PendingTransactionValidation do
 
   defp do_accept_transaction(
          %Transaction{
+           type: :code_approval,
+           data: %TransactionData{
+             recipients: []
+           }
+         },
+         _
+       ),
+       do: {:error, "No recipient specified in code approval"}
+
+  defp do_accept_transaction(
+         %Transaction{
            type: :keychain,
            data: %TransactionData{content: "", ownerships: []}
          },
@@ -707,7 +718,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
         ) :: boolean
   defp validate_network_chain?(type, tx = %Transaction{})
        when type in [:oracle, :oracle_summary] do
-    # mulitpe txn chain based on summary date
+    # multipe txn chain based on summary date
 
     case OracleChain.genesis_address() do
       nil ->

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -31,6 +31,8 @@ defmodule Archethic.Replication do
 
   alias Archethic.Reward
 
+  alias Archethic.Governance
+
   alias __MODULE__.TransactionContext
   alias __MODULE__.TransactionPool
   alias __MODULE__.TransactionValidator
@@ -575,6 +577,7 @@ defmodule Archethic.Replication do
     Contracts.load_transaction(tx, from_self_repair: self_repair?)
     OracleChain.load_transaction(tx)
     Reward.load_transaction(tx)
+    Governance.load_transaction(tx)
     :ok
   end
 end

--- a/lib/archethic/transaction_chain/mem_tables_loader.ex
+++ b/lib/archethic/transaction_chain/mem_tables_loader.ex
@@ -19,7 +19,7 @@ defmodule Archethic.TransactionChain.MemTablesLoader do
     :address,
     :type,
     :previous_public_key,
-    data: [:code],
+    data: [:code, :recipients],
     validation_stamp: [:timestamp]
   ]
 


### PR DESCRIPTION
# Description

code_approval transactions weren't put in the corresponding ETS table, and coudn't be loaded properly when we fetched code_proposal transactions (in UI for example).

Also the governance flow wasn't plugged.
