### PR TITLE
Load all contract transaction

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -134,7 +134,7 @@ defmodule Archethic.Contracts do
   Load transaction into the Smart Contract context leveraging the interpreter
   """
   @spec load_transaction(Transaction.t(), list()) :: :ok
-  defdelegate load_transaction(tx, opts \\ []), to: Loader
+  defdelegate load_transaction(tx, opts), to: Loader
 
   @spec accept_new_contract?(Transaction.t() | nil, Transaction.t(), DateTime.t()) :: boolean()
   def accept_new_contract?(nil, _, _), do: true

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -572,7 +572,12 @@ defmodule Archethic.Replication do
     P2P.load_transaction(tx)
     SharedSecrets.load_transaction(tx)
     Account.load_transaction(tx, io_transaction?)
-    Contracts.load_transaction(tx, execute_contract?: not self_repair?)
+
+    Contracts.load_transaction(tx,
+      execute_contract?: not self_repair?,
+      io_transaction?: io_transaction?
+    )
+
     OracleChain.load_transaction(tx)
     Reward.load_transaction(tx)
     :ok

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -572,7 +572,7 @@ defmodule Archethic.Replication do
     P2P.load_transaction(tx)
     SharedSecrets.load_transaction(tx)
     Account.load_transaction(tx, io_transaction?)
-    Contracts.load_transaction(tx, from_self_repair: self_repair?)
+    Contracts.load_transaction(tx, execute_contract?: not self_repair?)
     OracleChain.load_transaction(tx)
     Reward.load_transaction(tx)
     :ok


### PR DESCRIPTION
# Description

Fix a bug where all the smart contract call where not reloaded when a node bootstrap.
Also start a Worker only if the node is storage node of the transaction

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
