### PR TITLE
Fix slot missing transaction

### DIFF
--- a/lib/archethic/beacon_chain/subset.ex
+++ b/lib/archethic/beacon_chain/subset.ex
@@ -411,4 +411,20 @@ defmodule Archethic.BeaconChain.Subset do
   end
 
   defp ensure_p2p_view(slot = %Slot{}, _), do: slot
+
+  def code_change(
+        "1.0.7",
+        state = %{postponed: %{transaction_attestations: postponed_attestations}},
+        _extra
+      ) do
+    new_state =
+      Enum.reduce(postponed_attestations, state, fn attestation, acc ->
+        Map.update!(acc, :current_slot, &Slot.add_transaction_attestation(&1, attestation))
+      end)
+      |> Map.delete(:postponed)
+
+    {:ok, new_state}
+  end
+
+  def code_change(_, state, _), do: {:ok, state}
 end

--- a/lib/archethic/beacon_chain/summary.ex
+++ b/lib/archethic/beacon_chain/summary.ex
@@ -205,11 +205,7 @@ defmodule Archethic.BeaconChain.Summary do
     transaction_attestations =
       slots
       |> Stream.flat_map(& &1.transaction_attestations)
-      |> Stream.uniq_by(fn %ReplicationAttestation{
-                             transaction_summary: %TransactionSummary{address: address}
-                           } ->
-        address
-      end)
+      |> ReplicationAttestation.reduce_confirmations()
       |> Enum.sort_by(
         fn %ReplicationAttestation{
              transaction_summary: %TransactionSummary{timestamp: timestamp}

--- a/lib/archethic_web/graphql_schema/resolver.ex
+++ b/lib/archethic_web/graphql_schema/resolver.ex
@@ -211,8 +211,15 @@ defmodule ArchethicWeb.GraphQLSchema.Resolver do
           end
 
         :eq ->
-          BeaconChain.fetch_and_aggregate_summaries(next_datetime_summary_time, authorized_nodes)
-          |> SummaryAggregate.aggregate()
+          {summary_aggregate, _} =
+            BeaconChain.fetch_and_aggregate_summaries(
+              next_datetime_summary_time,
+              authorized_nodes
+            )
+            |> SummaryAggregate.aggregate()
+            |> SummaryAggregate.filter_reached_threshold()
+
+          summary_aggregate
 
         :lt ->
           case BeaconChain.fetch_summaries_aggregate(next_datetime_summary_time, authorized_nodes) do

--- a/lib/archethic_web/live/chains/beacon_live.ex
+++ b/lib/archethic_web/live/chains/beacon_live.ex
@@ -222,8 +222,10 @@ defmodule ArchethicWeb.BeaconChainLive do
   end
 
   defp list_transactions_from_summaries(date = %DateTime{}) do
-    %SummaryAggregate{transaction_summaries: tx_summaries} =
+    {%SummaryAggregate{transaction_summaries: tx_summaries}, _} =
       Archethic.fetch_and_aggregate_summaries(date)
+      |> SummaryAggregate.aggregate()
+      |> SummaryAggregate.filter_reached_threshold()
 
     Enum.sort_by(tx_summaries, & &1.timestamp, {:desc, DateTime})
   end

--- a/test/archethic/beacon_chain/replication_attestation_test.exs
+++ b/test/archethic/beacon_chain/replication_attestation_test.exs
@@ -1,8 +1,104 @@
 defmodule Archethic.BeaconChain.ReplicationAttestationTest do
-  use ExUnit.Case
+  use ArchethicCase
 
   alias Archethic.BeaconChain.ReplicationAttestation
+  alias Archethic.BeaconChain.SummaryTimer
+
   alias Archethic.TransactionChain.TransactionSummary
 
+  alias Archethic.P2P
+  alias Archethic.P2P.Node
+
   doctest ReplicationAttestation
+
+  describe "reached_threshold?/1" do
+    setup do
+      # Summary timer each hour
+      start_supervised!({SummaryTimer, interval: "0 0 * * * *"})
+      # Create 10 nodes on last summary
+      Enum.each(0..9, fn i ->
+        P2P.add_and_connect_node(%Node{
+          ip: {88, 130, 19, i},
+          port: 3000 + i,
+          last_public_key: :crypto.strong_rand_bytes(32),
+          first_public_key: :crypto.strong_rand_bytes(32),
+          geo_patch: "AAA",
+          available?: true,
+          authorized?: true,
+          authorization_date: DateTime.utc_now() |> DateTime.add(-1, :hour),
+          enrollment_date: DateTime.utc_now() |> DateTime.add(-2, :hour)
+        })
+      end)
+
+      # Add two node in the current summary
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        last_public_key: :crypto.strong_rand_bytes(32),
+        first_public_key: :crypto.strong_rand_bytes(32),
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: true,
+        authorization_date: DateTime.utc_now(),
+        enrollment_date: DateTime.utc_now()
+      })
+
+      # Add two node in the current summary
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 2},
+        port: 3001,
+        last_public_key: :crypto.strong_rand_bytes(32),
+        first_public_key: :crypto.strong_rand_bytes(32),
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: true,
+        authorization_date: DateTime.utc_now(),
+        enrollment_date: DateTime.utc_now()
+      })
+    end
+
+    test "should return true if attestation reached threshold" do
+      # First Replication with enough threshold
+      attestation = %ReplicationAttestation{
+        transaction_summary: %TransactionSummary{
+          timestamp: DateTime.utc_now() |> DateTime.add(-1, :hour)
+        },
+        confirmations: Enum.map(0..9, &{&1, "signature#{&1}"})
+      }
+
+      assert ReplicationAttestation.reached_threshold?(attestation)
+
+      # Second Replication without enough threshold
+      attestation = %ReplicationAttestation{
+        transaction_summary: %TransactionSummary{
+          timestamp: DateTime.utc_now() |> DateTime.add(-1, :hour)
+        },
+        confirmations: Enum.map(0..2, &{&1, "signature#{&1}"})
+      }
+
+      assert ReplicationAttestation.reached_threshold?(attestation)
+    end
+
+    test "should return false if attestation do not reach threshold" do
+      # First Replication with enough threshold
+      attestation = %ReplicationAttestation{
+        transaction_summary: %TransactionSummary{
+          timestamp: DateTime.utc_now()
+        },
+        confirmations: Enum.map(0..9, &{&1, "signature#{&1}"})
+      }
+
+      assert ReplicationAttestation.reached_threshold?(attestation)
+
+      # Second Replication without enough threshold
+      attestation = %ReplicationAttestation{
+        transaction_summary: %TransactionSummary{
+          timestamp: DateTime.utc_now()
+        },
+        confirmations: Enum.map(0..2, &{&1, "signature#{&1}"})
+      }
+
+      refute ReplicationAttestation.reached_threshold?(attestation)
+    end
+  end
 end

--- a/test/archethic/beacon_chain/subset_test.exs
+++ b/test/archethic/beacon_chain/subset_test.exs
@@ -28,6 +28,18 @@ defmodule Archethic.BeaconChain.SubsetTest do
   import Mox
 
   setup do
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      first_public_key: Crypto.first_node_public_key(),
+      last_public_key: Crypto.first_node_public_key(),
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      available?: true,
+      authorized?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-1)
+    })
+
     {:ok, subset: <<0>>}
   end
 
@@ -237,18 +249,6 @@ defmodule Archethic.BeaconChain.SubsetTest do
       P2P.add_and_connect_node(%Node{
         ip: {127, 0, 0, 1},
         port: 3000,
-        first_public_key: Crypto.first_node_public_key(),
-        last_public_key: Crypto.first_node_public_key(),
-        geo_patch: "AAA",
-        network_patch: "AAA",
-        available?: true,
-        authorized?: true,
-        authorization_date: DateTime.utc_now() |> DateTime.add(-1)
-      })
-
-      P2P.add_and_connect_node(%Node{
-        ip: {127, 0, 0, 1},
-        port: 3000,
         first_public_key: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
         last_public_key: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
         geo_patch: "AAA",
@@ -346,19 +346,6 @@ defmodule Archethic.BeaconChain.SubsetTest do
           <<0::8, 0::8, subset::binary-size(1), :crypto.strong_rand_bytes(31)::binary>>,
         last_public_key:
           <<0::8, 0::8, subset::binary-size(1), :crypto.strong_rand_bytes(31)::binary>>,
-        geo_patch: "AAA",
-        network_patch: "AAA",
-        available?: true,
-        authorized?: true,
-        authorization_date: ~U[2020-09-01 00:00:00Z],
-        enrollment_date: ~U[2020-09-01 00:00:00Z]
-      })
-
-      P2P.add_and_connect_node(%Node{
-        ip: {127, 0, 0, 1},
-        port: 3000,
-        first_public_key: Crypto.first_node_public_key(),
-        last_public_key: Crypto.first_node_public_key(),
         geo_patch: "AAA",
         network_patch: "AAA",
         available?: true,

--- a/test/archethic/bootstrap/network_init_test.exs
+++ b/test/archethic/bootstrap/network_init_test.exs
@@ -8,6 +8,7 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
   alias Archethic.BeaconChain.ReplicationAttestation
   alias Archethic.BeaconChain.Slot, as: BeaconSlot
   alias Archethic.BeaconChain.SlotTimer, as: BeaconSlotTimer
+  alias Archethic.BeaconChain.SummaryTimer, as: BeaconSummaryTimer
   alias Archethic.BeaconChain.Subset, as: BeaconSubset
   alias Archethic.BeaconChain.SubsetRegistry, as: BeaconSubsetRegistry
 
@@ -62,6 +63,7 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
 
   setup do
     start_supervised!({BeaconSlotTimer, interval: "0 * * * * * *"})
+    start_supervised!({BeaconSummaryTimer, interval: "0 0 * * * * *"})
     Enum.each(BeaconChain.list_subsets(), &BeaconSubset.start_link(subset: &1))
     start_supervised!({NodeRenewalScheduler, interval: "*/2 * * * * * *"})
 

--- a/test/archethic/self_repair/sync_test.exs
+++ b/test/archethic/self_repair/sync_test.exs
@@ -24,7 +24,8 @@ defmodule Archethic.SelfRepair.SyncTest do
   alias Archethic.P2P.Message.TransactionList
   alias Archethic.P2P.Node
   alias Archethic.P2P.Message.GetGenesisAddress
-  # alias Archethic.P2P.Message.GenesisAddress
+
+  alias Archethic.PubSub
 
   alias Archethic.TransactionFactory
 
@@ -245,20 +246,8 @@ defmodule Archethic.SelfRepair.SyncTest do
         _, %GetTransaction{address: _}, _ ->
           {:ok, %NotFound{}}
 
-        _, %GetTransactionInputs{}, _ ->
-          {:ok,
-           %TransactionInputList{
-             inputs:
-               Enum.map(inputs, fn input ->
-                 %VersionedTransactionInput{input: input, protocol_version: 1}
-               end)
-           }}
-
         _, %GetTransactionChain{}, _ ->
           {:ok, %TransactionList{transactions: []}}
-
-        _, %GetTransactionChainLength{}, _ ->
-          %TransactionChainLength{length: 1}
 
         _, %GetGenesisAddress{}, _ ->
           {:ok, %NotFound{}}
@@ -271,6 +260,197 @@ defmodule Archethic.SelfRepair.SyncTest do
 
       assert_received :storage
     end
+  end
+
+  test "load_missed_transactions should postpone attestation if refused" do
+    Crypto.generate_deterministic_keypair("daily_nonce_seed")
+    |> elem(0)
+    |> NetworkLookup.set_daily_nonce_public_key(DateTime.utc_now() |> DateTime.add(-10))
+
+    # Summary timer each hour
+    start_supervised!({BeaconSummaryTimer, interval: "0 0 * * * *"})
+    start_supervised!({BeaconSlotTimer, interval: "0 */10 * * * *"})
+    # Create 11 nodes on last summary
+    nodes_keypair =
+      Enum.map(0..10, fn i ->
+        node_keypair = Crypto.derive_keypair("node_seed#{i}", 1)
+
+        P2P.add_and_connect_node(%Node{
+          ip: {88, 130, 19, i},
+          port: 3000 + i,
+          last_public_key: elem(node_keypair, 0),
+          first_public_key: elem(node_keypair, 0),
+          geo_patch: "BBB",
+          network_patch: "BBB",
+          available?: true,
+          authorized?: true,
+          authorization_date: DateTime.utc_now() |> DateTime.add(-1, :hour),
+          enrollment_date: DateTime.utc_now() |> DateTime.add(-2, :hour)
+        })
+
+        node_keypair
+      end)
+
+    P2P.add_and_connect_node(%Node{
+      first_public_key: Crypto.first_node_public_key(),
+      last_public_key: Crypto.last_node_public_key(),
+      authorized?: true,
+      available?: true,
+      geo_patch: "AAA",
+      network_patch: "AAA",
+      authorization_date: DateTime.utc_now() |> DateTime.add(-1, :hour),
+      enrollment_date: DateTime.utc_now() |> DateTime.add(-2, :hour)
+    })
+
+    tx_timestamp = DateTime.utc_now() |> DateTime.add(-59, :minute)
+
+    tx1 =
+      TransactionFactory.create_valid_transaction([],
+        timestamp: tx_timestamp
+      )
+
+    tx1_summary = TransactionSummary.from_transaction(tx1)
+
+    elected_storage_nodes =
+      Election.chain_storage_nodes_with_type(
+        tx1.address,
+        :transfer,
+        P2P.authorized_and_available_nodes(tx_timestamp)
+      )
+
+    # First Replication with enough threshold
+    attestation1 = %ReplicationAttestation{
+      transaction_summary: tx1_summary,
+      confirmations:
+        Enum.reduce_while(
+          elected_storage_nodes,
+          %{confirmations: [], index: 0},
+          fn node, acc = %{confirmations: confirmations, index: index} ->
+            if index >= 4 do
+              {:halt, confirmations}
+            else
+              signature =
+                if node.first_public_key == Crypto.first_node_public_key() do
+                  tx1_summary
+                  |> TransactionSummary.serialize()
+                  |> Crypto.sign_with_first_node_key()
+                else
+                  node_private_key =
+                    Enum.find_value(
+                      nodes_keypair,
+                      &if(elem(&1, 0) == node.first_public_key, do: elem(&1, 1))
+                    )
+
+                  tx1_summary |> TransactionSummary.serialize() |> Crypto.sign(node_private_key)
+                end
+
+              new_acc =
+                Map.update!(acc, :confirmations, &[{index, signature} | &1])
+                |> Map.update!(:index, &(&1 + 1))
+
+              {:cont, new_acc}
+            end
+          end
+        )
+    }
+
+    tx2 =
+      TransactionFactory.create_valid_transaction([],
+        index: 1,
+        timestamp: DateTime.utc_now() |> DateTime.add(-1, :hour)
+      )
+
+    tx2_summary = TransactionSummary.from_transaction(tx2)
+
+    elected_storage_nodes =
+      Election.chain_storage_nodes_with_type(
+        tx2.address,
+        :transfer,
+        P2P.authorized_and_available_nodes()
+      )
+
+    # Second Replication without enough threshold
+    attestation2 = %ReplicationAttestation{
+      transaction_summary: tx2_summary,
+      confirmations:
+        Enum.reduce_while(
+          elected_storage_nodes,
+          %{confirmations: [], index: 0},
+          fn node, acc = %{confirmations: confirmations, index: index} ->
+            if index >= 2 do
+              {:halt, confirmations}
+            else
+              node_private_key =
+                Enum.find_value(
+                  nodes_keypair,
+                  &if(elem(&1, 0) == node.first_public_key, do: elem(&1, 1))
+                )
+
+              signature =
+                if node_private_key != nil,
+                  do:
+                    tx2_summary |> TransactionSummary.serialize() |> Crypto.sign(node_private_key),
+                  else:
+                    tx2_summary
+                    |> TransactionSummary.serialize()
+                    |> Crypto.sign_with_first_node_key()
+
+              new_acc =
+                Map.update!(acc, :confirmations, &[{index, signature} | &1])
+                |> Map.update!(:index, &(&1 + 1))
+
+              {:cont, new_acc}
+            end
+          end
+        )
+    }
+
+    attestations = [attestation1, attestation2]
+
+    summary_time = DateTime.utc_now() |> BeaconSummaryTimer.previous_summary()
+
+    PubSub.register_to_new_replication_attestations()
+
+    summary = %BeaconSummary{
+      subset: <<0>>,
+      summary_time: summary_time,
+      transaction_attestations: attestations
+    }
+
+    tx1_address = tx1.address
+    tx2_address = tx2.address
+
+    me = self()
+
+    MockClient
+    |> stub(:send_message, fn
+      _, %GetBeaconSummaries{}, _ ->
+        {:ok, %BeaconSummaryList{summaries: [summary]}}
+
+      _, %GetTransaction{address: ^tx1_address}, _ ->
+        send(me, :should_request)
+        {:ok, tx1}
+
+      _, %GetTransaction{address: ^tx2_address}, _ ->
+        send(me, :should_not_request)
+        {:ok, tx2}
+
+      _, %GetTransaction{address: _}, _ ->
+        {:ok, %NotFound{}}
+
+      _, %GetTransactionChain{}, _ ->
+        {:ok, %TransactionList{transactions: []}}
+
+      _, %GetGenesisAddress{}, _ ->
+        {:ok, %NotFound{}}
+    end)
+
+    Sync.load_missed_transactions(DateTime.utc_now() |> DateTime.add(-1, :hour))
+
+    assert_receive {:new_replication_attestation, ^attestation2}
+    assert_receive :should_request
+    refute_receive {:new_replication_attestation, ^attestation1}
+    refute_receive :should_not_request
   end
 
   describe "process_summary_aggregate/2" do


### PR DESCRIPTION
# Description

Actually, when it's the time for a new slot, the slot timer send a event to all the subset to process the slot creation.
But due to some latency for a slot node to receive the ReplicationAttestation message or simply the latency for a transaction to be replicated, the slot node may have build and sent the slot before receiving all the slot transaction.

For example:
![image](https://user-images.githubusercontent.com/26260538/221901673-2cc77429-6a77-431c-91ef-22ca31d8a65f.png)

To solve this problem, here is the new workflow: 
- We don't verify that a replication attestation is in the right slot time. Any attestation can be in any slot.
- When building the summary, we control that the number of confirmations of an attestation reach a certain threshold (35%) of the expected confirmations number. If it not reaches the threshold, the attestation is postponed to the next summary.
- As we can have postponed attestation in a next summary, we ensure the attestation is between 2 previous summary and current summary.

Here is an example:

![image](https://user-images.githubusercontent.com/26260538/222735623-8b1ab2e7-9e5d-4f7d-ba8e-a2b4bd5307fb.png)


## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
