### PR TITLE
Replace Flow with Tasks & Streams in Beacon Summaries

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -7,8 +7,8 @@ defmodule Archethic do
   alias __MODULE__.{Account, BeaconChain, Crypto, Election, P2P, P2P.Node, P2P.Message}
   alias __MODULE__.{SelfRepair, TransactionChain}
 
-  alias Message.{NewTransaction, NotFound, StartMining, TransactionSummaryList}
-  alias Message.{Balance, GetBalance, GetCurrentSummaries, GetTransactionSummary}
+  alias Message.{NewTransaction, NotFound, StartMining}
+  alias Message.{Balance, GetBalance, GetTransactionSummary}
   alias Message.{StartMining, Ok, TransactionSummaryMessage}
 
   alias TransactionChain.{Transaction, TransactionInput, TransactionSummary}
@@ -359,43 +359,11 @@ defmodule Archethic do
     end
   end
 
-  @doc """
-  Slots which are already has been added
-  Real time transaction can be get from pubsub
-  """
-  @spec list_transactions_summaries_from_current_slot(DateTime.t()) ::
-          list(TransactionSummary.t())
-  def list_transactions_summaries_from_current_slot(date = %DateTime{} \\ DateTime.utc_now()) do
-    authorized_nodes = P2P.authorized_and_available_nodes()
+  defdelegate list_transactions_summaries_from_current_slot(),
+    to: BeaconChain
 
-    ref_time = DateTime.truncate(date, :millisecond)
-
-    next_summary_date = BeaconChain.next_summary_date(ref_time)
-
-    BeaconChain.list_subsets()
-    |> Flow.from_enumerable(stages: 256)
-    |> Flow.flat_map(fn subset ->
-      # Foreach subset and date we compute concurrently the node election
-      subset
-      |> Election.beacon_storage_nodes(next_summary_date, authorized_nodes)
-      |> Enum.filter(&Node.locally_available?/1)
-      |> P2P.nearest_nodes()
-      |> Enum.take(3)
-      |> Enum.map(&{&1, subset})
-    end)
-    # We partition by node
-    |> Flow.partition(key: {:elem, 0})
-    |> Flow.reduce(fn -> %{} end, fn {node, subset}, acc ->
-      # We aggregate the subsets for a given node
-      Map.update(acc, node, [subset], &[subset | &1])
-    end)
-    |> Flow.flat_map(fn {node, subsets} ->
-      # For this node we fetch the summaries
-      fetch_summaries(node, subsets)
-    end)
-    |> Stream.uniq_by(& &1.address)
-    |> Enum.sort_by(& &1.timestamp, {:desc, DateTime})
-  end
+  defdelegate list_transactions_summaries_from_current_slot(date),
+    to: BeaconChain
 
   @doc """
   Check if a transaction exists at address
@@ -435,22 +403,5 @@ defmodule Archethic do
           raise e
       end
     end
-  end
-
-  defp fetch_summaries(node, subsets) do
-    subsets
-    |> Stream.chunk_every(10)
-    |> Task.async_stream(fn subsets ->
-      case P2P.send_message(node, %GetCurrentSummaries{subsets: subsets}) do
-        {:ok, %TransactionSummaryList{transaction_summaries: transaction_summaries}} ->
-          transaction_summaries
-
-        _ ->
-          []
-      end
-    end)
-    |> Stream.filter(&match?({:ok, _}, &1))
-    |> Stream.flat_map(&elem(&1, 1))
-    |> Enum.to_list()
   end
 end

--- a/test/archethic/beacon_chain_test.exs
+++ b/test/archethic/beacon_chain_test.exs
@@ -21,6 +21,8 @@ defmodule Archethic.BeaconChainTest do
   alias Archethic.P2P.Message.GetBeaconSummaries
   alias Archethic.P2P.Message.GetTransactionSummary
   alias Archethic.P2P.Message.BeaconSummaryList
+  alias Archethic.P2P.Message.GetCurrentSummaries
+  alias Archethic.P2P.Message.TransactionSummaryList
   alias Archethic.P2P.Node
 
   alias Archethic.TransactionChain.TransactionSummary
@@ -525,6 +527,46 @@ defmodule Archethic.BeaconChainTest do
              |> Enum.flat_map(& &1)
              |> Enum.sort() ==
                expected_average_availabilities
+    end
+  end
+
+  describe "list_transactions_summaries_from_current_slot/0" do
+    test "should work" do
+      SummaryTimer.start_link([interval: "0 0 * * * * *"], [])
+      now = DateTime.utc_now()
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3000,
+        first_public_key: <<0::8, :crypto.strong_rand_bytes(32)::binary>>,
+        last_public_key: <<0::8, :crypto.strong_rand_bytes(32)::binary>>,
+        available?: true,
+        geo_patch: "AAA",
+        network_patch: "AAA",
+        authorized?: true,
+        authorization_date: now |> DateTime.add(-10)
+      })
+
+      MockClient
+      |> stub(:send_message, fn
+        _, %GetCurrentSummaries{}, _ ->
+          {:ok,
+           %TransactionSummaryList{
+             transaction_summaries: [
+               %TransactionSummary{
+                 address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+                 timestamp: now
+               }
+             ]
+           }}
+      end)
+
+      summaries = BeaconChain.list_transactions_summaries_from_current_slot()
+
+      # there are 256 subsets, and we query the summaries 10 by 10
+      # so we call the GetCurrentSummaries 26 times
+      # each call to GetCurrentSummaries return a list of 1 transactionSummary (mock above)
+      assert length(summaries) == 26
     end
   end
 end


### PR DESCRIPTION
# Description

This used to be a PR to remove the Flow warnings, but I got sidetracked. 
We did plenty of benchmarks to conclude that the functions that fetch the summaries are slow &  have a huge memory footprint. By replacing Flow with Streams & Tasks, we manage to have much faster result with almost no memory usage.

## Type of change

Performance

# How Has This Been Tested?

- [x] Automated tests
- [ ] Manual tests with many nodes

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
