### PR TITLE
Remove warnings about scope not used

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -39,49 +39,83 @@ defmodule Archethic.Contracts do
       ...>    end
       ...> "
       ...> |> Contracts.parse()
-      {:ok,
-        %Contract{
-          conditions: %{
-            inherit: %Conditions{
-              content: {:==, [line: 2], [
-                true,
-                {
-                  {:., [line: 2], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.Library], [:Library]}, :regex_match?]},
-                  [line: 2],
-                  [{:get_in, [line: 2], [{:scope, [line: 2], nil}, ["next", "content"]]}, "^(Mr.X: ){1}([0-9]+), (Mr.Y: ){1}([0-9])+$"]
-                }
-              ]},
-              origin_family: :biometric
-            },
-            transaction: %Conditions{},
-            oracle: %Conditions{}
-          },
-          constants: %Constants{
-            contract: nil,
-            transaction: nil
-          },
-          triggers: %{
-            {:datetime, ~U[2020-09-25 13:18:43Z]} => {:__block__, [], [
-                {
-                  :=,
-                  [line: 7],
-                  [
-                    {:scope, [line: 7], nil},
-                    {:update_in, [line: 7], [{:scope, [line: 7], nil}, ["next_transaction"], {:&, [line: 7], [{{:., [line: 7], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_type]}, [line: 7], [{:&, [line: 7], [1]}, "hosting"]}]}]}
-                  ]
+      {
+              :ok,
+              %Archethic.Contracts.Contract{
+                conditions: %{
+                  inherit: %Archethic.Contracts.ContractConditions{
+                    address: nil,
+                    authorized_keys: nil,
+                    code: nil,
+                    content: {
+                      :==,
+                      [line: 2],
+                      [true, {{:., [line: 2], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.Library], [:Library]}, :regex_match?]}, [line: 2], [{:get_in, [line: 2], [{:scope, [line: 2], nil}, ["next", "content"]]}, "^(Mr.X: ){1}([0-9]+), (Mr.Y: ){1}([0-9])+$"]}]
+                    },
+                    origin_family: :biometric,
+                    previous_public_key: nil,
+                    secrets: nil,
+                    timestamp: nil,
+                    token_transfers: nil,
+                    type: nil,
+                    uco_transfers: nil
+                  },
+                  oracle: %Archethic.Contracts.ContractConditions{address: nil, authorized_keys: nil, code: nil, content: nil, origin_family: :all, previous_public_key: nil, secrets: nil, timestamp: nil, token_transfers: nil, type: nil, uco_transfers: nil},
+                  transaction: %Archethic.Contracts.ContractConditions{address: nil, authorized_keys: nil, code: nil, content: nil, origin_family: :all, previous_public_key: nil, secrets: nil, timestamp: nil, token_transfers: nil, type: nil, uco_transfers: nil}
                 },
-                {
-                  :=,
-                  [line: 8],
-                  [
-                    {:scope, [line: 8], nil},
-                    {:update_in, [line: 8], [{:scope, [line: 8], nil}, ["next_transaction"], {:&, [line: 8], [{{:., [line: 8], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_content]}, [line: 8], [{:&, [line: 8], [1]}, "Mr.X: 10, Mr.Y: 8"]}]}]}
-                  ]
-                }
-              ]},
+                constants: %Archethic.Contracts.ContractConstants{contract: nil, transaction: nil},
+                next_transaction: %Archethic.TransactionChain.Transaction{
+                  address: nil,
+                  cross_validation_stamps: [],
+                  data: %Archethic.TransactionChain.TransactionData{
+                    code: "",
+                    content: "",
+                    ledger: %Archethic.TransactionChain.TransactionData.Ledger{token: %Archethic.TransactionChain.TransactionData.TokenLedger{transfers: []}, uco: %Archethic.TransactionChain.TransactionData.UCOLedger{transfers: []}},
+                    ownerships: [],
+                    recipients: []
+                  },
+                  origin_signature: nil,
+                  previous_public_key: nil,
+                  previous_signature: nil,
+                  type: nil,
+                  validation_stamp: nil,
+                  version: 1
+                },
+                triggers: %{
+                  {:datetime, ~U[2020-09-25 13:18:43Z]} => {
+                    :__block__,
+                    [],
+                    [
+                      {
+                        :__block__,
+                        [],
+                        [
+                          {
+                            :=,
+                            [line: 7],
+                            [{:scope, [line: 7], nil}, {:update_in, [line: 7], [{:scope, [line: 7], nil}, ["next_transaction"], {:&, [line: 7], [{{:., [line: 7], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_type]}, [line: 7], [{:&, [line: 7], [1]}, "hosting"]}]}]}]
+                          },
+                          {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [], [{:scope, [], nil}]}
+                        ]
+                      },
+                      {
+                        :__block__,
+                        [],
+                        [
+                          {
+                            :=,
+                            [line: 8],
+                            [{:scope, [line: 8], nil}, {:update_in, [line: 8], [{:scope, [line: 8], nil}, ["next_transaction"], {:&, [line: 8], [{{:., [line: 8], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_content]}, [line: 8], [{:&, [line: 8], [1]}, "Mr.X: 10, Mr.Y: 8"]}]}]}]
+                          },
+                          {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [], [{:scope, [], nil}]}
+                        ]
+                      }
+                    ]
+                  }
+                },
+                version: 0
+              }
             }
-          }
-        }
   """
   @spec parse(binary()) :: {:ok, Contract.t()} | {:error, binary()}
   def parse(contract_code) when is_binary(contract_code) do

--- a/lib/archethic/contracts/interpreter/legacy.ex
+++ b/lib/archethic/contracts/interpreter/legacy.ex
@@ -45,108 +45,144 @@ defmodule Archethic.Contracts.Interpreter.Legacy do
       ...>    end
       ...> ")
       ...> Legacy.parse(ast)
-      {:ok,
-        %Contract{
+      {
+        :ok,
+        %Archethic.Contracts.Contract{
           conditions: %{
-             inherit: %Archethic.Contracts.ContractConditions{
-                content: {
-                      :==,
-                      [line: 7],
-                      [
-                        true,
-                        {{:., [line: 7], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.Library], [:Library]}, :regex_match?]}, [line: 7], [{:get_in, [line: 7], [{:scope, [line: 7], nil}, ["next", "content"]]}, "hello"]}
-                      ]
-                },
-                authorized_keys: nil,
-                code: nil,
-                token_transfers: nil,
-                origin_family: :all,
-                previous_public_key: nil,
-                type: nil,
-                uco_transfers: nil
-             },
-            oracle: %Archethic.Contracts.ContractConditions{
-                 content: {
-                      :>,
-                      [line: 11],
-                      [
-                        {
-                          :==,
-                          [line: 11],
-                          [
-                            {:get_in, [line: 11], [{:scope, [line: 11], nil}, ["transaction", "content"]]},
-                            {{:., [line: 11], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.Library], [:Library]}, :json_path_extract]}, [line: 11], [{:get_in, [line: 11], [{:scope, [line: 11], nil}, ["transaction", "content"]]}, "$.uco.eur"]}
-                          ]
-                        },
-                        1
-                      ]
-                  },
-                 authorized_keys: nil,
+            inherit: %Archethic.Contracts.ContractConditions{
+              address: nil,
+              authorized_keys: nil,
               code: nil,
-                 token_transfers: nil,
-                 origin_family: :all,
-                 previous_public_key: nil,
-                 type: nil,
-                 uco_transfers: nil
-             },
-             transaction: %Archethic.Contracts.ContractConditions{
-                 content: {
-                      :==,
-                      [line: 2],
-                      [
-                        true,
-                        {{:., [line: 2], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.Library], [:Library]}, :regex_match?]}, [line: 2], [{:get_in, [line: 2], [{:scope, [line: 2], nil}, ["transaction", "content"]]}, "^Mr.Y|Mr.X{1}$"]}
-                      ]
-                 },
-                 origin_family: :biometric,
-                 authorized_keys: nil,
-                 code: nil,
-                 token_transfers: nil,
-                 previous_public_key: nil,
-                 type: nil,
-                 uco_transfers: nil
-             }
-         },
-         constants: %Archethic.Contracts.ContractConstants{},
-         next_transaction: %Transaction{ data: %TransactionData{}},
-         triggers: %{
-           {:datetime, ~U[2020-10-21 08:56:43Z]} => {:__block__, [],
+              content: {:==, [line: 7], [true, {{:., [line: 7], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.Library], [:Library]}, :regex_match?]}, [line: 7], [{:get_in, [line: 7], [{:scope, [line: 7], nil}, ["next", "content"]]}, "hello"]}]},
+              origin_family: :all,
+              previous_public_key: nil,
+              secrets: nil,
+              timestamp: nil,
+              token_transfers: nil,
+              type: nil,
+              uco_transfers: nil
+            },
+            oracle: %Archethic.Contracts.ContractConditions{
+              address: nil,
+              authorized_keys: nil,
+              code: nil,
+              content: {
+                :>,
+                [line: 11],
+                [
+                  {
+                    :==,
+                    [line: 11],
+                    [
+                      {:get_in, [line: 11], [{:scope, [line: 11], nil}, ["transaction", "content"]]},
+                      {{:., [line: 11], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.Library], [:Library]}, :json_path_extract]}, [line: 11], [{:get_in, [line: 11], [{:scope, [line: 11], nil}, ["transaction", "content"]]}, "$.uco.eur"]}
+                    ]
+                  },
+                  1
+                ]
+              },
+              origin_family: :all,
+              previous_public_key: nil,
+              secrets: nil,
+              timestamp: nil,
+              token_transfers: nil,
+              type: nil,
+              uco_transfers: nil
+            },
+            transaction: %Archethic.Contracts.ContractConditions{
+              address: nil,
+              authorized_keys: nil,
+              code: nil,
+              content: {
+                :==,
+                [line: 2],
+                [true, {{:., [line: 2], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.Library], [:Library]}, :regex_match?]}, [line: 2], [{:get_in, [line: 2], [{:scope, [line: 2], nil}, ["transaction", "content"]]}, "^Mr.Y|Mr.X{1}$"]}]
+              },
+              origin_family: :biometric,
+              previous_public_key: nil,
+              secrets: nil,
+              timestamp: nil,
+              token_transfers: nil,
+              type: nil,
+              uco_transfers: nil
+            }
+          },
+          constants: %Archethic.Contracts.ContractConstants{contract: nil, transaction: nil},
+          next_transaction: %Archethic.TransactionChain.Transaction{
+            address: nil,
+            cross_validation_stamps: [],
+            data: %Archethic.TransactionChain.TransactionData{
+              code: "",
+              content: "",
+              ledger: %Archethic.TransactionChain.TransactionData.Ledger{token: %Archethic.TransactionChain.TransactionData.TokenLedger{transfers: []}, uco: %Archethic.TransactionChain.TransactionData.UCOLedger{transfers: []}},
+              ownerships: [],
+              recipients: []
+            },
+            origin_signature: nil,
+            previous_public_key: nil,
+            previous_signature: nil,
+            type: nil,
+            validation_stamp: nil,
+            version: 1
+          },
+          triggers: %{
+            :oracle => {
+              :__block__,
+              [],
+              [
+                {
+                  :=,
+                  [line: 22],
+                  [{:scope, [line: 22], nil}, {:update_in, [line: 22], [{:scope, [line: 22], nil}, ["next_transaction"], {:&, [line: 22], [{{:., [line: 22], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_content]}, [line: 22], [{:&, [line: 22], [1]}, "uco price changed"]}]}]}]
+                },
+                {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [], [{:scope, [], nil}]}
+              ]
+            },
+            {:datetime, ~U[2020-10-21 08:56:43Z]} => {
+              :__block__,
+              [],
               [
                 {:=, [line: 15], [{:scope, [line: 15], nil}, {{:., [line: 15], [{:__aliases__, [line: 15], [:Map]}, :put]}, [line: 15], [{:scope, [line: 15], nil}, "new_content", "Sent 1040000000"]}]},
                 {
-                  :=,
-                  [line: 16],
+                  :__block__,
+                  [],
                   [
-                    {:scope, [line: 16], nil},
-                    {:update_in, [line: 16], [{:scope, [line: 16], nil}, ["next_transaction"], {:&, [line: 16], [{{:., [line: 16], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_type]}, [line: 16], [{:&, [line: 16], [1]}, "transfer"]}]}]}
+                    {
+                      :=,
+                      [line: 16],
+                      [{:scope, [line: 16], nil}, {:update_in, [line: 16], [{:scope, [line: 16], nil}, ["next_transaction"], {:&, [line: 16], [{{:., [line: 16], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_type]}, [line: 16], [{:&, [line: 16], [1]}, "transfer"]}]}]}]
+                    },
+                    {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [], [{:scope, [], nil}]}
                   ]
                 },
                 {
-                  :=,
-                  [line: 17],
+                  :__block__,
+                  [],
                   [
-                    {:scope, [line: 17], nil},
-                    {:update_in, [line: 17], [{:scope, [line: 17], nil}, ["next_transaction"], {:&, [line: 17], [{{:., [line: 17], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_content]}, [line: 17], [{:&, [line: 17], [1]}, {:get_in, [line: 17], [{:scope, [line: 17], nil}, ["new_content"]]}]}]}]}
+                    {
+                      :=,
+                      [line: 17],
+                      [{:scope, [line: 17], nil}, {:update_in, [line: 17], [{:scope, [line: 17], nil}, ["next_transaction"], {:&, [line: 17], [{{:., [line: 17], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_content]}, [line: 17], [{:&, [line: 17], [1]}, {:get_in, [line: 17], [{:scope, [line: 17], nil}, ["new_content"]]}]}]}]}]
+                    },
+                    {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [], [{:scope, [], nil}]}
                   ]
                 },
                 {
-                  :=,
-                  [line: 18],
+                  :__block__,
+                  [],
                   [
-                    {:scope, [line: 18], nil},
-                    {:update_in, [line: 18], [{:scope, [line: 18], nil}, ["next_transaction"], {:&, [line: 18], [{{:., [line: 18], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :add_uco_transfer]}, [line: 18], [{:&, [line: 18], [1]}, [{"to", "22368B50D3B2976787CFCC27508A8E8C67483219825F998FC9D6908D54D0FE10"}, {"amount", 1040000000}]]}]}]}
+                    {
+                      :=,
+                      [line: 18],
+                      [{:scope, [line: 18], nil}, {:update_in, [line: 18], [{:scope, [line: 18], nil}, ["next_transaction"], {:&, [line: 18], [{{:., [line: 18], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :add_uco_transfer]}, [line: 18], [{:&, [line: 18], [1]}, [{"to", "22368B50D3B2976787CFCC27508A8E8C67483219825F998FC9D6908D54D0FE10"}, {"amount", 1040000000}]]}]}]}]
+                    },
+                    {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [], [{:scope, [], nil}]}
                   ]
                 }
-              ]},
-           :oracle => {
-              :=,
-              [line: 22],
-              [
-                {:scope, [line: 22], nil},
-                {:update_in, [line: 22], [{:scope, [line: 22], nil}, ["next_transaction"], {:&, [line: 22], [{{:., [line: 22], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :set_content]}, [line: 22], [{:&, [line: 22], [1]}, "uco price changed"]}]}]}
               ]
-           }
-          }
+            }
+          },
+          version: 0
         }
       }
 

--- a/lib/archethic/contracts/interpreter/legacy/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/legacy/action_interpreter.ex
@@ -37,7 +37,7 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreter do
       ...>      ]}
       ...>   ]
       ...> ]})
-      {:ok, :transaction, {:=, [line: 2], [{:scope, [line: 2], nil}, {:update_in, [line: 2], [{:scope, [line: 2], nil}, ["next_transaction"], {:&, [line: 2], [{{:., [line: 2], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :add_uco_transfer]}, [line: 2], [{:&, [line: 2], [1]}, [{"to", "0000D574D171A484F8DEAC2D61FC3F7CC984BEB52465D69B3B5F670090742CBF5CC"}, {"amount", 2000000000}]]}]}]}]}}
+      { :ok, :transaction, { :__block__, [], [ { :=, [line: 2], [{:scope, [line: 2], nil}, {:update_in, [line: 2], [{:scope, [line: 2], nil}, ["next_transaction"], {:&, [line: 2], [{{:., [line: 2], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :add_uco_transfer]}, [line: 2], [{:&, [line: 2], [1]}, [{"to", "0000D574D171A484F8DEAC2D61FC3F7CC984BEB52465D69B3B5F670090742CBF5CC"}, {"amount", 2000000000}]]}]}]}] }, {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [], [{:scope, [], nil}]} ] }}
 
       Usage with trigger accepting parameters
 
@@ -53,7 +53,7 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreter do
       ...>      ["0000D574D171A484F8DEAC2D61FC3F7CC984BEB52465D69B3B5F670090742CBF5CC"]}
       ...>   ]
       ...> ]})
-      {:ok, {:datetime, ~U[2014-02-02 02:43:50Z]}, {:=, [line: 2], [{:scope, [line: 2], nil}, {:update_in, [line: 2], [{:scope, [line: 2], nil}, ["next_transaction"], {:&, [line: 2], [{{:., [line: 2], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :add_recipient]}, [line: 2], [{:&, [line: 2], [1]}, "0000D574D171A484F8DEAC2D61FC3F7CC984BEB52465D69B3B5F670090742CBF5CC"]}]}]}]}}
+      { :ok, {:datetime, ~U[2014-02-02 02:43:50Z]}, { :__block__, [], [ { :=, [line: 2], [{:scope, [line: 2], nil}, {:update_in, [line: 2], [{:scope, [line: 2], nil}, ["next_transaction"], {:&, [line: 2], [{{:., [line: 2], [{:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.TransactionStatements], [:TransactionStatements]}, :add_recipient]}, [line: 2], [{:&, [line: 2], [1]}, "0000D574D171A484F8DEAC2D61FC3F7CC984BEB52465D69B3B5F670090742CBF5CC"]}]}]}] }, {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [], [{:scope, [], nil}]} ] }}
 
 
       Prevent usage of not authorized functions

--- a/lib/archethic/contracts/interpreter/legacy/utils_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/legacy/utils_interpreter.ex
@@ -453,7 +453,14 @@ defmodule Archethic.Contracts.Interpreter.Legacy.UtilsInterpreter do
        ]}
 
     {
-      {:=, metadata, [{:scope, metadata, nil}, update_ast]},
+      {:__block__, [],
+       [
+         {:=, metadata, [{:scope, metadata, nil}, update_ast]},
+
+         # Remove warnings about unused scope by calling Function.identity(scope)
+         {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
+          [{:scope, [], nil}]}
+       ]},
       acc
     }
   end

--- a/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
@@ -23,236 +23,242 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
   import Mox
 
   test "should parse a contract with some standard functions" do
-    assert {:ok, :transaction,
-            {
-              :__block__,
-              [],
-              [
-                {
-                  :=,
-                  [line: 2],
-                  [
-                    {:scope, [line: 2], nil},
-                    {
-                      :update_in,
-                      [line: 2],
-                      [
-                        {:scope, [line: 2], nil},
-                        ["next_transaction"],
-                        {:&, [line: 2],
-                         [
-                           {{:., [line: 2],
+    assert {
+             :ok,
+             :transaction,
+             {
+               :__block__,
+               [],
+               [
+                 {
+                   :__block__,
+                   [],
+                   [
+                     {
+                       :=,
+                       [line: 2],
+                       [
+                         {:scope, [line: 2], nil},
+                         {:update_in, [line: 2],
+                          [
+                            {:scope, [line: 2], nil},
+                            ["next_transaction"],
+                            {:&, [line: 2],
                              [
-                               {:__aliases__,
-                                [
-                                  alias:
-                                    Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                ], [:TransactionStatements]},
-                               :set_type
-                             ]}, [line: 2], [{:&, [line: 2], [1]}, "transfer"]}
-                         ]}
-                      ]
-                    }
-                  ]
-                },
-                {
-                  :=,
-                  [line: 3],
-                  [
-                    {:scope, [line: 3], nil},
-                    {
-                      :update_in,
-                      [line: 3],
-                      [
-                        {:scope, [line: 3], nil},
-                        ["next_transaction"],
-                        {
-                          :&,
-                          [line: 3],
-                          [
-                            {
-                              {:., [line: 3],
-                               [
-                                 {:__aliases__,
-                                  [
-                                    alias:
-                                      Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                  ], [:TransactionStatements]},
-                                 :add_uco_transfer
-                               ]},
-                              [line: 3],
-                              [
-                                {:&, [line: 3], [1]},
-                                [
-                                  {"to",
-                                   "7F6661ACE282F947ACA2EF947D01BDDC90C65F09EE828BDADE2E3ED4258470B3"},
-                                  {"amount", 1_040_000_000}
-                                ]
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  :=,
-                  [line: 4],
-                  [
-                    {:scope, [line: 4], nil},
-                    {
-                      :update_in,
-                      [line: 4],
-                      [
-                        {:scope, [line: 4], nil},
-                        ["next_transaction"],
-                        {
-                          :&,
-                          [line: 4],
-                          [
-                            {
-                              {:., [line: 4],
-                               [
-                                 {:__aliases__,
-                                  [
-                                    alias:
-                                      Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                  ], [:TransactionStatements]},
-                                 :add_token_transfer
-                               ]},
-                              [line: 4],
-                              [
-                                {:&, [line: 4], [1]},
-                                [
-                                  {"to",
-                                   "30670455713E2CBECF94591226A903651ED8625635181DDA236FECC221D1E7E4"},
-                                  {"amount", 20_000_000_000},
-                                  {"token_address",
-                                   "AEB4A6F5AB6D82BE223C5867EBA5FE616F52F410DCF83B45AFF158DD40AE8AC3"},
-                                  {"token_id", 0}
-                                ]
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  :=,
-                  [line: 5],
-                  [
-                    {:scope, [line: 5], nil},
-                    {
-                      :update_in,
-                      [line: 5],
-                      [
-                        {:scope, [line: 5], nil},
-                        ["next_transaction"],
-                        {
-                          :&,
-                          [line: 5],
-                          [
-                            {{:., [line: 5],
-                              [
-                                {:__aliases__,
+                               {{:., [line: 2],
                                  [
-                                   alias:
-                                     Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                 ], [:TransactionStatements]},
-                                :set_content
-                              ]}, [line: 5], [{:&, [line: 5], [1]}, "Receipt"]}
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  :=,
-                  [line: 6],
-                  [
-                    {:scope, [line: 6], nil},
-                    {
-                      :update_in,
-                      [line: 6],
-                      [
-                        {:scope, [line: 6], nil},
-                        ["next_transaction"],
-                        {
-                          :&,
-                          [line: 6],
+                                   {:__aliases__,
+                                    [
+                                      alias:
+                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                    ], [:TransactionStatements]},
+                                   :set_type
+                                 ]}, [line: 2], [{:&, [line: 2], [1]}, "transfer"]}
+                             ]}
+                          ]}
+                       ]
+                     },
+                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
+                      [{:scope, [], nil}]}
+                   ]
+                 },
+                 {
+                   :__block__,
+                   [],
+                   [
+                     {
+                       :=,
+                       [line: 3],
+                       [
+                         {:scope, [line: 3], nil},
+                         {:update_in, [line: 3],
                           [
-                            {
-                              {:., [line: 6],
-                               [
-                                 {:__aliases__,
-                                  [
-                                    alias:
-                                      Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                  ], [:TransactionStatements]},
-                                 :add_ownership
-                               ]},
-                              [line: 6],
-                              [
-                                {:&, [line: 6], [1]},
+                            {:scope, [line: 3], nil},
+                            ["next_transaction"],
+                            {:&, [line: 3],
+                             [
+                               {{:., [line: 3],
+                                 [
+                                   {:__aliases__,
+                                    [
+                                      alias:
+                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                    ], [:TransactionStatements]},
+                                   :add_uco_transfer
+                                 ]}, [line: 3],
                                 [
-                                  {"secret", "MyEncryptedSecret"},
-                                  {"secret_key", "MySecretKey"},
-                                  {"authorized_public_keys",
-                                   [
-                                     "70C245E5D970B59DF65638BDD5D963EE22E6D892EA224D8809D0FB75D0B1907A"
-                                   ]}
-                                ]
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  :=,
-                  [line: 7],
-                  [
-                    {:scope, [line: 7], nil},
-                    {
-                      :update_in,
-                      [line: 7],
-                      [
-                        {:scope, [line: 7], nil},
-                        ["next_transaction"],
-                        {
-                          :&,
-                          [line: 7],
-                          [
-                            {
-                              {:., [line: 7],
-                               [
-                                 {:__aliases__,
+                                  {:&, [line: 3], [1]},
                                   [
-                                    alias:
-                                      Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                  ], [:TransactionStatements]},
-                                 :add_recipient
-                               ]},
-                              [line: 7],
-                              [
-                                {:&, [line: 7], [1]},
-                                "78273C5CBCEB8617F54380CC2F173DF2404DB676C9F10D546B6F395E6F3BDDEE"
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }} =
+                                    {"to",
+                                     "7F6661ACE282F947ACA2EF947D01BDDC90C65F09EE828BDADE2E3ED4258470B3"},
+                                    {"amount", 1_040_000_000}
+                                  ]
+                                ]}
+                             ]}
+                          ]}
+                       ]
+                     },
+                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
+                      [{:scope, [], nil}]}
+                   ]
+                 },
+                 {
+                   :__block__,
+                   [],
+                   [
+                     {
+                       :=,
+                       [line: 4],
+                       [
+                         {:scope, [line: 4], nil},
+                         {:update_in, [line: 4],
+                          [
+                            {:scope, [line: 4], nil},
+                            ["next_transaction"],
+                            {:&, [line: 4],
+                             [
+                               {{:., [line: 4],
+                                 [
+                                   {:__aliases__,
+                                    [
+                                      alias:
+                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                    ], [:TransactionStatements]},
+                                   :add_token_transfer
+                                 ]}, [line: 4],
+                                [
+                                  {:&, [line: 4], [1]},
+                                  [
+                                    {"to",
+                                     "30670455713E2CBECF94591226A903651ED8625635181DDA236FECC221D1E7E4"},
+                                    {"amount", 20_000_000_000},
+                                    {"token_address",
+                                     "AEB4A6F5AB6D82BE223C5867EBA5FE616F52F410DCF83B45AFF158DD40AE8AC3"},
+                                    {"token_id", 0}
+                                  ]
+                                ]}
+                             ]}
+                          ]}
+                       ]
+                     },
+                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
+                      [{:scope, [], nil}]}
+                   ]
+                 },
+                 {
+                   :__block__,
+                   [],
+                   [
+                     {
+                       :=,
+                       [line: 5],
+                       [
+                         {:scope, [line: 5], nil},
+                         {:update_in, [line: 5],
+                          [
+                            {:scope, [line: 5], nil},
+                            ["next_transaction"],
+                            {:&, [line: 5],
+                             [
+                               {{:., [line: 5],
+                                 [
+                                   {:__aliases__,
+                                    [
+                                      alias:
+                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                    ], [:TransactionStatements]},
+                                   :set_content
+                                 ]}, [line: 5], [{:&, [line: 5], [1]}, "Receipt"]}
+                             ]}
+                          ]}
+                       ]
+                     },
+                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
+                      [{:scope, [], nil}]}
+                   ]
+                 },
+                 {
+                   :__block__,
+                   [],
+                   [
+                     {
+                       :=,
+                       [line: 6],
+                       [
+                         {:scope, [line: 6], nil},
+                         {:update_in, [line: 6],
+                          [
+                            {:scope, [line: 6], nil},
+                            ["next_transaction"],
+                            {:&, [line: 6],
+                             [
+                               {{:., [line: 6],
+                                 [
+                                   {:__aliases__,
+                                    [
+                                      alias:
+                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                    ], [:TransactionStatements]},
+                                   :add_ownership
+                                 ]}, [line: 6],
+                                [
+                                  {:&, [line: 6], [1]},
+                                  [
+                                    {"secret", "MyEncryptedSecret"},
+                                    {"secret_key", "MySecretKey"},
+                                    {"authorized_public_keys",
+                                     [
+                                       "70C245E5D970B59DF65638BDD5D963EE22E6D892EA224D8809D0FB75D0B1907A"
+                                     ]}
+                                  ]
+                                ]}
+                             ]}
+                          ]}
+                       ]
+                     },
+                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
+                      [{:scope, [], nil}]}
+                   ]
+                 },
+                 {
+                   :__block__,
+                   [],
+                   [
+                     {
+                       :=,
+                       [line: 7],
+                       [
+                         {:scope, [line: 7], nil},
+                         {:update_in, [line: 7],
+                          [
+                            {:scope, [line: 7], nil},
+                            ["next_transaction"],
+                            {:&, [line: 7],
+                             [
+                               {{:., [line: 7],
+                                 [
+                                   {:__aliases__,
+                                    [
+                                      alias:
+                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                    ], [:TransactionStatements]},
+                                   :add_recipient
+                                 ]}, [line: 7],
+                                [
+                                  {:&, [line: 7], [1]},
+                                  "78273C5CBCEB8617F54380CC2F173DF2404DB676C9F10D546B6F395E6F3BDDEE"
+                                ]}
+                             ]}
+                          ]}
+                       ]
+                     },
+                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
+                      [{:scope, [], nil}]}
+                   ]
+                 }
+               ]
+             }
+           } =
              """
              actions triggered_by: transaction do
                set_type transfer

--- a/test/archethic/contracts/interpreter/legacy_test.exs
+++ b/test/archethic/contracts/interpreter/legacy_test.exs
@@ -2,13 +2,8 @@ defmodule Archethic.Contracts.Interpreter.LegacyTest do
   @moduledoc false
   use ArchethicCase
 
-  alias Archethic.Contracts.Contract
-
   alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.Legacy
-
-  alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.TransactionData
 
   doctest Legacy
 

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -3,10 +3,6 @@ defmodule Archethic.ContractsTest do
 
   alias Archethic.Contracts
 
-  alias Archethic.Contracts.Contract
-  alias Archethic.Contracts.ContractConditions, as: Conditions
-  alias Archethic.Contracts.ContractConstants, as: Constants
-
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Ledger


### PR DESCRIPTION
# Description

Remove these warnings by using Function.identify(scope): 

```
warning: variable "scope" is unused (there is a variable with the same name in the context, use the pin operator (^) to match on it or prefix this variable with underscore if it is not meant to be used)
  nofile:5
```

**THE ONLY RELEVANT CHANGE IS `lib/archethic/contracts/interpreter/legacy/utils_interpreter.ex`.** The rest is to adapt the tests.

## Type of change

cleanup

# How Has This Been Tested?

unit tests 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
