### PR TITLE
Initialize migration workflow

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -192,6 +192,8 @@ config :ex_cldr,
   default_backend: Archethic.Cldr,
   json_library: Jason
 
+config :archethic, env: config_env()
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config("#{Mix.env()}.exs")

--- a/lib/archethic/application.ex
+++ b/lib/archethic/application.ex
@@ -51,6 +51,8 @@ defmodule Archethic.Application do
 
   alias Archethic.Metrics.MetricSupervisor, as: MetricSupervisor
 
+  alias Mix.Tasks.Archethic.Migrate
+
   require Logger
 
   def start(_type, _args) do
@@ -100,6 +102,10 @@ defmodule Archethic.Application do
 
     opts = [strategy: :rest_for_one, name: Archethic.Supervisor]
     Supervisor.start_link(Utils.configurable_children(children), opts)
+  end
+
+  def start_phase(:migrate, :normal, _options) do
+    Application.spec(:archethic, :vsn) |> Migrate.run()
   end
 
   defp try_open_port(nil), do: :ok

--- a/lib/release/call_migrate_script.ex
+++ b/lib/release/call_migrate_script.ex
@@ -1,0 +1,20 @@
+defmodule Archethic.Release.CallMigrateScript do
+  @moduledoc false
+
+  alias Mix.Tasks.Archethic.Migrate
+
+  use Distillery.Releases.Appup.Transform
+
+  def up(:archethic, _v1, v2, instructions, _opts),
+    do: add_migrate_script_call(v2, instructions)
+
+  def up(_, _, _, instructions, _), do: instructions
+
+  def down(_, _, _, instructions, _), do: instructions
+
+  defp add_migrate_script_call(new_version, instructions) do
+    call_instruction = {:apply, {Migrate, :run, [new_version]}}
+
+    instructions ++ [call_instruction]
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,8 @@ defmodule Archethic.MixProject do
         :xmerl,
         :crypto
       ],
-      mod: {Archethic.Application, []}
+      mod: {Archethic.Application, []},
+      start_phases: [migrate: []]
     ]
   end
 

--- a/priv/migration_tasks/test/0.0.1-migration_test.exs
+++ b/priv/migration_tasks/test/0.0.1-migration_test.exs
@@ -1,0 +1,9 @@
+defmodule Migration_0_0_1 do
+  @moduledoc "DB.transaction_exists? used to catch it in MigrateTest mock"
+
+  alias Archethic.DB
+
+  def run() do
+    DB.transaction_exists?("0.0.1", :storage)
+  end
+end

--- a/priv/migration_tasks/test/0.0.2-migration_test.exs
+++ b/priv/migration_tasks/test/0.0.2-migration_test.exs
@@ -1,0 +1,9 @@
+defmodule Migration_0_0_2 do
+  @moduledoc "DB.transaction_exists? used to catch it in MigrateTest mock"
+
+  alias Archethic.DB
+
+  def run() do
+    DB.transaction_exists?("0.0.2", :storage)
+  end
+end

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -26,7 +26,6 @@ environment Mix.env() do
   set include_src: false
   set vm_args: "rel/vm.args"
   set pre_configure_hooks: "rel/pre_configure"
-  set pre_start_hooks: "rel/pre_start"
 
   set config_providers: [
     {Distillery.Releases.Config.Providers.Elixir, ["${REL_DIR}/runtime_config.exs"]}
@@ -58,6 +57,7 @@ release :archethic_node do
   ]
 
   set appup_transforms: [
-    {Archethic.Release.TransformPurge, []}
+    {Archethic.Release.TransformPurge, []},
+    {Archethic.Release.CallMigrateScript, []}
   ]
 end

--- a/rel/pre_start/migrate.sh
+++ b/rel/pre_start/migrate.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-release_remote_ctl eval --mfa "Mix.Tasks.Archethic.Migrate.run/1" --argv "$@"

--- a/test/mix/tasks/migrate_test.exs
+++ b/test/mix/tasks/migrate_test.exs
@@ -44,14 +44,14 @@ defmodule Mix.Tasks.Archethic.MigrateTest do
       assert "0.0.1" = File.read!(migration_path)
     end
 
-    test "should update version number even without migration", %{
+    test "should not update version number on version without migration", %{
       migration_path: migration_path
     } do
       Migrate.run("0.0.2")
       assert "0.0.2" = File.read!(migration_path)
 
       Migrate.run("0.0.3")
-      assert "0.0.3" = File.read!(migration_path)
+      assert "0.0.2" = File.read!(migration_path)
     end
 
     test "should run all missed upgrade", %{
@@ -64,7 +64,7 @@ defmodule Mix.Tasks.Archethic.MigrateTest do
       |> expect(:transaction_exists?, fn "0.0.2", _ -> true end)
 
       Migrate.run("0.0.3")
-      assert "0.0.3" = File.read!(migration_path)
+      assert "0.0.2" = File.read!(migration_path)
     end
 
     test "should not run migration already done", %{

--- a/test/mix/tasks/migrate_test.exs
+++ b/test/mix/tasks/migrate_test.exs
@@ -1,0 +1,86 @@
+defmodule Mix.Tasks.Archethic.MigrateTest do
+  use ArchethicCase
+
+  alias Archethic.Crypto
+  alias Archethic.DB.EmbeddedImpl
+  alias Archethic.DB.EmbeddedImpl.ChainWriter
+  alias Archethic.P2P
+  alias Archethic.P2P.Node
+
+  alias Mix.Tasks.Archethic.Migrate
+
+  import Mox
+
+  describe "run/1" do
+    setup do
+      EmbeddedImpl.Supervisor.start_link()
+      migration_path = EmbeddedImpl.db_path() |> ChainWriter.migration_file_path()
+
+      P2P.add_and_connect_node(%Node{
+        ip: {127, 0, 0, 1},
+        port: 3001,
+        first_public_key: Crypto.first_node_public_key(),
+        last_public_key: Crypto.last_node_public_key(),
+        available?: true,
+        geo_patch: "AAA",
+        network_patch: "AAA",
+        authorized?: true,
+        authorization_date: DateTime.utc_now()
+      })
+
+      on_exit(fn -> Process.sleep(50) end)
+
+      %{migration_path: migration_path}
+    end
+
+    test "should create migration file with current version", %{
+      migration_path: migration_path
+    } do
+      refute File.exists?(migration_path)
+
+      Migrate.run("0.0.1")
+
+      assert File.exists?(migration_path)
+      assert "0.0.1" = File.read!(migration_path)
+    end
+
+    test "should update version number even without migration", %{
+      migration_path: migration_path
+    } do
+      Migrate.run("0.0.2")
+      assert "0.0.2" = File.read!(migration_path)
+
+      Migrate.run("0.0.3")
+      assert "0.0.3" = File.read!(migration_path)
+    end
+
+    test "should run all missed upgrade", %{
+      migration_path: migration_path
+    } do
+      File.write!(migration_path, "0.0.0")
+
+      MockDB
+      |> expect(:transaction_exists?, fn "0.0.1", _ -> true end)
+      |> expect(:transaction_exists?, fn "0.0.2", _ -> true end)
+
+      Migrate.run("0.0.3")
+      assert "0.0.3" = File.read!(migration_path)
+    end
+
+    test "should not run migration already done", %{
+      migration_path: migration_path
+    } do
+      File.write!(migration_path, "0.0.1")
+
+      me = self()
+
+      MockDB
+      |> stub(:transaction_exists?, fn version, _ -> send(me, version) end)
+
+      Migrate.run("0.0.2")
+
+      refute_receive "0.0.1"
+      assert_receive "0.0.2"
+    end
+  end
+end


### PR DESCRIPTION
# Description

This PR aim to initialize the migration workflow.
Each migration needed will be an elixir scripts in `priv/migration_tasks` according the name to `[version]-[description].exs`.

There is 2 times when the migration is called:
- before starting the application
- during the execution of an upgrade thanks to the appup file. Migrate function call is automatically added at the end of appup

The migration file in DB always contains the last version the node runned the migrate tool, even if there is no migration to execute

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- Unit tests
- Create a new migration script that create a file somewhere. Build a release, start the node, run a hot reload, all the file should have been created

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
