### PR TITLE
FaucetRateLimiter test async: false

### DIFF
--- a/test/archethic/oracle_chain/scheduler_test.exs
+++ b/test/archethic/oracle_chain/scheduler_test.exs
@@ -18,8 +18,6 @@ defmodule Archethic.OracleChain.SchedulerTest do
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.TransactionData
 
-  alias ArchethicCache.HydratingCache
-
   import ArchethicCase, only: [setup_before_send_tx: 0]
 
   import Mox

--- a/test/archethic_web/plugs/remote_ip_test.exs
+++ b/test/archethic_web/plugs/remote_ip_test.exs
@@ -1,5 +1,5 @@
 defmodule ArchethicWeb.Plugs.RemoteIPTest do
-  use ArchethicWeb.ConnCase, async: true
+  use ArchethicWeb.ConnCase
 
   describe "Plug should get first x-forwarded remote ip " do
     test "should modify remote ip if x-forwarded header exists", %{conn: conn} do


### PR DESCRIPTION
# Description

Fixes this test on develop:

```
  1) test Plug should get first x-forwarded remote ip  should not modifiy remote ip if x-forwarded header is empty (ArchethicWeb.Plugs.RemoteIPTest)
     test/archethic_web/plugs/remote_ip_test.exs:17
     ** (RuntimeError) failed to start child with the spec ArchethicWeb.FaucetRateLimiter.
     Reason: already started: #PID<0.4309.0>
     stacktrace:
       (ex_unit 1.14.1) lib/ex_unit/callbacks.ex:538: ExUnit.Callbacks.start_supervised!/2
       (archethic 1.0.7) test/support/conn_case.ex:41: ArchethicWeb.ConnCase.__ex_unit_setup_0/1
       (archethic 1.0.7) test/support/conn_case.ex:1: ArchethicWeb.ConnCase.__ex_unit__/2
       test/archethic_web/plugs/remote_ip_test.exs:1: ArchethicWeb.Plugs.RemoteIPTest.__ex_unit__/2
```

Because the setup is using start_supervised!/1, it cannot be async.

## Type of change

fix develop tests

# How Has This Been Tested?

mix test 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
