### PR TITLE
Catch the contract execution errors, and return an error msg to the user

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -327,7 +327,8 @@ defmodule Archethic do
         ) ::
           {:ok, nil | Transaction.t()}
           | {:error,
-             :invalid_triggers_execution
+             :contract_failure
+             | :invalid_triggers_execution
              | :invalid_transaction_constraints
              | :invalid_oracle_constraints
              | :invalid_inherit_constraints}

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -126,7 +126,8 @@ defmodule Archethic.Contracts.Interpreter do
         ) ::
           {:ok, nil | Transaction.t()}
           | {:error,
-             :invalid_triggers_execution
+             :contract_failure
+             | :invalid_triggers_execution
              | :invalid_transaction_constraints
              | :invalid_oracle_constraints
              | :invalid_inherit_constraints}
@@ -251,6 +252,10 @@ defmodule Archethic.Contracts.Interpreter do
     else
       {:error, :invalid_transaction_constraints}
     end
+  rescue
+    _ ->
+      # it's ok to loose the error because it's user-code
+      {:error, :contract_failure}
   end
 
   defp do_execute(

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -243,6 +243,9 @@ defmodule ArchethicWeb.API.TransactionController do
         {:error, "Network issue, please try again later."}
 
       # execute_contract errors
+      {:error, :contract_failure} ->
+        {:error, "Contract execution produced an error."}
+
       {:error, :invalid_triggers_execution} ->
         {:error, "Contract does not have a `actions triggered_by: transaction` block."}
 

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -293,6 +293,41 @@ defmodule Archethic.Contracts.InterpreterTest do
              )
     end
 
+    test "should return contract_failure if contract code crash" do
+      code = """
+        @version 1
+        condition inherit: [
+          content: true
+        ]
+
+        actions triggered_by: transaction do
+          x = 10 / 0
+          Contract.set_content x
+        end
+      """
+
+      contract_tx = %Transaction{
+        type: :contract,
+        data: %TransactionData{
+          code: code
+        }
+      }
+
+      incoming_tx = %Transaction{
+        type: :transfer,
+        data: %TransactionData{}
+      }
+
+      assert match?(
+               {:error, :contract_failure},
+               Interpreter.execute(
+                 :transaction,
+                 Contract.from_transaction!(contract_tx),
+                 incoming_tx
+               )
+             )
+    end
+
     test "should be able to simulate a trigger: datetime" do
       code = """
         @version 1

--- a/test/archethic/contracts/worker_test.exs
+++ b/test/archethic/contracts/worker_test.exs
@@ -579,5 +579,66 @@ defmodule Archethic.Contracts.WorkerTest do
           raise "Timeout"
       end
     end
+
+    test "should not crash the worker if contract code crashes", %{
+      constants: constants = %{"address" => contract_address}
+    } do
+      # the contract need uco to be executed
+      Archethic.Account.MemTables.TokenLedger.add_unspent_output(
+        contract_address,
+        %VersionedUnspentOutput{
+          unspent_output: %UnspentOutput{
+            from: "@Bob3",
+            amount: 100_000_000 * 10_000,
+            type: {:token, contract_address, 0},
+            timestamp: DateTime.utc_now() |> DateTime.truncate(:millisecond)
+          },
+          protocol_version: ArchethicCase.current_protocol_version()
+        }
+      )
+
+      code = """
+      @version 1
+      condition transaction: []
+
+      actions triggered_by: transaction do
+        n = 10 / 0
+        Contract.set_content n
+      end
+
+      condition inherit: [
+        content: true
+      ]
+      """
+
+      {:ok, contract} = Interpreter.parse(code)
+
+      contract = %{
+        contract
+        | constants: %ContractConstants{contract: Map.put(constants, "code", code)}
+      }
+
+      {:ok, worker_pid} = Worker.start_link(contract)
+
+      Worker.execute(contract_address, %Transaction{
+        address: @bob_address,
+        type: :transfer,
+        data: %TransactionData{
+          ledger: %Ledger{
+            uco: %UCOLedger{
+              transfers: [
+                %Transfer{to: contract_address, amount: 100_000_000}
+              ]
+            }
+          },
+          recipients: [contract_address]
+        },
+        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+      })
+
+      Process.sleep(100)
+
+      assert Process.alive?(worker_pid)
+    end
   end
 end

--- a/test/archethic/oracle_chain/scheduler_test.exs
+++ b/test/archethic/oracle_chain/scheduler_test.exs
@@ -18,8 +18,6 @@ defmodule Archethic.OracleChain.SchedulerTest do
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.TransactionData
 
-  alias ArchethicCache.HydratingCache
-
   import ArchethicCase, only: [setup_before_send_tx: 0]
 
   import Mox


### PR DESCRIPTION
# Description

Catch contract execution error, so the worker does not crash.
We can't provide a detailed error message to the user because it is an erlang error message based on the code we generated after AST manipulation. We might be able to get the line number, I'll create an issue (https://github.com/archethic-foundation/archethic-node/issues/964) about it.

**This PR is based on branch pr/netbox/802 which is the following PR: https://github.com/archethic-foundation/archethic-node/pull/802. Once it is merged, we will need to change the base branch.**

Fixes #919

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

tested with manual contract execution & added unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
