### PR TITLE
SmartContracts: Pass the calls to Interpreter.execute/3 & create corresponding message

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -323,6 +323,7 @@ defmodule Archethic do
   @spec execute_contract(
           Contract.trigger_type(),
           Contract.t(),
+          nil | Transaction.t(),
           [Transaction.t()]
         ) ::
           {:ok, nil | Transaction.t()}
@@ -332,7 +333,7 @@ defmodule Archethic do
              | :invalid_transaction_constraints
              | :invalid_oracle_constraints
              | :invalid_inherit_constraints}
-  defdelegate execute_contract(trigger_type, contract, calls),
+  defdelegate execute_contract(trigger_type, contract, maybe_trigger_tx, calls),
     to: Interpreter,
     as: :execute
 

--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -323,7 +323,7 @@ defmodule Archethic do
   @spec execute_contract(
           Contract.trigger_type(),
           Contract.t(),
-          nil | Transaction.t()
+          [Transaction.t()]
         ) ::
           {:ok, nil | Transaction.t()}
           | {:error,
@@ -332,7 +332,7 @@ defmodule Archethic do
              | :invalid_transaction_constraints
              | :invalid_oracle_constraints
              | :invalid_inherit_constraints}
-  defdelegate execute_contract(trigger_type, contract, maybe_tx),
+  defdelegate execute_contract(trigger_type, contract, calls),
     to: Interpreter,
     as: :execute
 

--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -47,8 +47,9 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
     # because it is mutable.
     #
     # constants should already contains the global variables:
+    #   - "calls": the transactions that called this exact contract version
     #   - "contract": current contract transaction
-    #   - "transaction": the incoming transaction (when trigger=transaction)
+    #   - "transaction": the incoming transaction (when trigger=transaction|oracle)
     Scope.init(Map.put(constants, "next_transaction", next_tx))
 
     # we can ignore the result & binding
@@ -150,19 +151,15 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
   #  | .__/ \___/|___/\__| \_/\_/ \__,_|_|_|\_\
   #  |_|
   # ----------------------------------------------------------------------
-  # Contract.get_calls() => Contract.get_calls(contract.address)
+  # Contract.get_calls()
   defp postwalk(
          _node =
            {{:., _meta, [{:__aliases__, _, [atom: "Contract"]}, {:atom, "get_calls"}]}, _, []},
          acc
        ) do
-    # contract is one of the "magic" variables that we expose to the user's code
-    # it is bound in the root scope
     new_node =
       quote do
-        Archethic.Contracts.Interpreter.Library.Contract.get_calls(
-          Scope.read_global(["contract", "address"])
-        )
+        Archethic.Contracts.Interpreter.Library.Contract.get_calls()
       end
 
     {new_node, acc}

--- a/lib/archethic/contracts/interpreter/condition_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/condition_interpreter.ex
@@ -171,24 +171,6 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
     {new_node, acc}
   end
 
-  # Override Contract.get_calls()
-  defp postwalk(
-         _subject = [_global_variable, _],
-         node =
-           {{:., _meta, [{:__aliases__, _, [atom: "Contract"]}, {:atom, "get_calls"}]}, _, []},
-         _acc
-       ) do
-    # new_node =
-    #   quote do
-    #     Archethic.Contracts.Interpreter.Library.Contract.get_calls(
-    #       Scope.read_global([unquote(global_variable), "address"])
-    #     )
-    #   end
-
-    # {new_node, acc}
-    throw({:error, node, "Contract.get_calls() not yet implemented in the conditions"})
-  end
-
   defp postwalk(_subject, node, acc) do
     CommonInterpreter.postwalk(node, acc)
   end

--- a/lib/archethic/contracts/interpreter/legacy/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/legacy/action_interpreter.ex
@@ -139,14 +139,6 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreter do
     {node, {:ok, %{context | scope: {:function, function, parent_scope}}}}
   end
 
-  # Whitelist the get_calls/0 (this will be expanded to a get_calls(contract.address) in postwalk)
-  defp prewalk(
-         node = {{:atom, "get_calls"}, _, []},
-         acc = {:ok, %{scope: {:actions, _}}}
-       ) do
-    {node, acc}
-  end
-
   # Blacklist the add_uco_transfer argument list
   defp prewalk(
          node = {{:atom, "to"}, address},
@@ -292,26 +284,6 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreter do
       "oracle" ->
         {node, {:ok, :oracle, actions}}
     end
-  end
-
-  # expand get_calls() to get_calls(contract.address)
-  defp postwalk(
-         {{:atom, "get_calls"}, meta, []},
-         acc
-       ) do
-    node = {
-      {:atom, "get_calls"},
-      meta,
-      [
-        {:get_in, meta,
-         [
-           {:scope, meta, nil},
-           ["contract", "address"]
-         ]}
-      ]
-    }
-
-    {node, acc}
   end
 
   defp postwalk(node, acc) do

--- a/lib/archethic/contracts/interpreter/legacy/library.ex
+++ b/lib/archethic/contracts/interpreter/legacy/library.ex
@@ -7,8 +7,6 @@ defmodule Archethic.Contracts.Interpreter.Legacy.Library do
     P2P.Message.GetFirstPublicKey,
     P2P.Message.FirstPublicKey,
     TransactionChain,
-    Contracts.ContractConstants,
-    Contracts.TransactionLookup,
     Utils
   }
 

--- a/lib/archethic/contracts/interpreter/legacy/library.ex
+++ b/lib/archethic/contracts/interpreter/legacy/library.ex
@@ -191,23 +191,6 @@ defmodule Archethic.Contracts.Interpreter.Legacy.Library do
   def size(map) when is_map(map), do: map_size(map)
 
   @doc """
-  Get the inputs(type= :call) of the given transaction
-
-  This is useful for contracts that want to throttle their calls
-  """
-  @spec get_calls(binary()) :: list(map())
-  def get_calls(contract_address) do
-    contract_address
-    |> UtilsInterpreter.maybe_decode_hex()
-    |> TransactionLookup.list_contract_transactions()
-    |> Enum.map(fn {address, _, _} ->
-      # TODO: parallelize
-      {:ok, tx} = TransactionChain.get_transaction(address, [], :io)
-      ContractConstants.from_transaction(tx)
-    end)
-  end
-
-  @doc """
   Get the genesis public key
   """
   @spec get_genesis_public_key(binary()) :: binary()

--- a/lib/archethic/contracts/interpreter/library/contract.ex
+++ b/lib/archethic/contracts/interpreter/library/contract.ex
@@ -6,16 +6,16 @@ defmodule Archethic.Contracts.Interpreter.Library.Contract do
   """
   @behaviour Archethic.Contracts.Interpreter.Library
 
+  alias Archethic.Contracts.Interpreter.Scope
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.TransactionChain.Transaction
   alias Archethic.Contracts.Interpreter.Legacy.TransactionStatements
 
-  # get_calls has it's own postwalk (to inject the address),
-  # it does not require a check_types
-  @spec get_calls(binary()) :: list(map())
-  def get_calls(contract_address) do
-    # FIXME TODO
-    []
+  @spec get_calls() :: list(map())
+  def get_calls() do
+    # DISCUSS:
+    # this function is not really needed, we might just tell the users there is a "calls" global variable?
+    Scope.read_global(["calls"])
   end
 
   @spec set_type(Transaction.t(), binary()) :: Transaction.t()
@@ -119,6 +119,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Contract do
 
   def check_types(:add_uco_transfers, [first]) do
     AST.is_list?(first) || AST.is_variable_or_function_call?(first)
+  end
+
+  def check_types(:get_calls, []) do
+    true
   end
 
   def check_types(_, _), do: false

--- a/lib/archethic/contracts/interpreter/library/contract.ex
+++ b/lib/archethic/contracts/interpreter/library/contract.ex
@@ -8,14 +8,15 @@ defmodule Archethic.Contracts.Interpreter.Library.Contract do
 
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.TransactionChain.Transaction
-  alias Archethic.Contracts.Interpreter.Legacy
   alias Archethic.Contracts.Interpreter.Legacy.TransactionStatements
 
   # get_calls has it's own postwalk (to inject the address),
   # it does not require a check_types
   @spec get_calls(binary()) :: list(map())
-  defdelegate get_calls(contract_address),
-    to: Legacy.Library
+  def get_calls(contract_address) do
+    # FIXME TODO
+    []
+  end
 
   @spec set_type(Transaction.t(), binary()) :: Transaction.t()
   defdelegate set_type(next_tx, type),

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -86,7 +86,7 @@ defmodule Archethic.Contracts.Worker do
 
     with true <- enough_funds?(contract_tx.address),
          {:ok, next_tx = %Transaction{}} <-
-           Interpreter.execute(:transaction, contract, incoming_tx, skip_inherit_check?: true),
+           Interpreter.execute(:transaction, contract, [incoming_tx], skip_inherit_check?: true),
          {:ok, next_tx} <- chain_transaction(next_tx, contract_tx),
          :ok <- ensure_enough_funds(next_tx, contract_tx.address),
          :ok <- handle_new_transaction(next_tx) do
@@ -110,8 +110,9 @@ defmodule Archethic.Contracts.Worker do
     Logger.debug("Contract execution started", meta)
 
     with true <- enough_funds?(contract_tx.address),
+         {:ok, calls} <- TransactionChain.fetch_contract_calls(contract_tx.address),
          {:ok, next_tx = %Transaction{}} <-
-           Interpreter.execute(trigger_type, contract, nil, skip_inherit_check?: true),
+           Interpreter.execute(trigger_type, contract, calls, skip_inherit_check?: true),
          {:ok, next_tx} <- chain_transaction(next_tx, contract_tx),
          :ok <- ensure_enough_funds(next_tx, contract_tx.address),
          :ok <- handle_new_transaction(next_tx) do
@@ -135,8 +136,9 @@ defmodule Archethic.Contracts.Worker do
     Logger.debug("Contract execution started", meta)
 
     with true <- enough_funds?(contract_tx.address),
+         {:ok, calls} <- TransactionChain.fetch_contract_calls(contract_tx.address),
          {:ok, next_tx = %Transaction{}} <-
-           Interpreter.execute(trigger_type, contract, nil, skip_inherit_check?: true),
+           Interpreter.execute(trigger_type, contract, calls, skip_inherit_check?: true),
          {:ok, next_tx} <- chain_transaction(next_tx, contract_tx),
          :ok <- ensure_enough_funds(next_tx, contract_tx.address),
          :ok <- handle_new_transaction(next_tx) do
@@ -163,7 +165,7 @@ defmodule Archethic.Contracts.Worker do
 
     with true <- enough_funds?(contract_tx.address),
          {:ok, next_tx = %Transaction{}} <-
-           Interpreter.execute(:oracle, contract, oracle_tx, skip_inherit_check?: true),
+           Interpreter.execute(:oracle, contract, [oracle_tx], skip_inherit_check?: true),
          {:ok, next_tx} <- chain_transaction(next_tx, contract_tx),
          :ok <- ensure_enough_funds(next_tx, contract_tx.address),
          :ok <- handle_new_transaction(next_tx) do

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -174,14 +174,7 @@ defmodule Archethic.Contracts.Worker do
     with true <- enough_funds?(contract_tx.address),
          {:ok, calls} <- TransactionChain.fetch_contract_calls(contract_tx.address),
          {:ok, next_tx = %Transaction{}} <-
-           Interpreter.execute(
-             :oracle,
-             contract,
-             oracle_tx,
-             # we append the oracle_tx to the calls in case it is missing due to race condition
-             Enum.uniq([oracle_tx | calls]),
-             skip_inherit_check?: true
-           ),
+           Interpreter.execute(:oracle, contract, oracle_tx, calls, skip_inherit_check?: true),
          {:ok, next_tx} <- chain_transaction(next_tx, contract_tx),
          :ok <- ensure_enough_funds(next_tx, contract_tx.address),
          :ok <- handle_new_transaction(next_tx) do

--- a/lib/archethic/p2p/message/get_contract_calls.ex
+++ b/lib/archethic/p2p/message/get_contract_calls.ex
@@ -1,0 +1,43 @@
+defmodule Archethic.P2P.Message.GetContractCalls do
+  @moduledoc """
+  Represents a message to request the transactions that called this version of the contract.
+  """
+  @enforce_keys [:address]
+  defstruct [:address]
+
+  alias Archethic.Contracts
+  alias Archethic.Crypto
+  alias Archethic.TransactionChain
+  alias Archethic.P2P.Message.TransactionList
+  alias Archethic.Utils
+
+  @type t :: %__MODULE__{
+          address: Crypto.versioned_hash()
+        }
+
+  @spec process(__MODULE__.t(), Crypto.key()) :: TransactionList.t()
+  def process(%__MODULE__{address: address}, _) do
+    transaction_addresses =
+      Contracts.list_contract_transactions(address)
+      |> Enum.map(&elem(&1, 0))
+
+    # will crash if a task did not succeed
+    transactions =
+      Task.async_stream(transaction_addresses, &TransactionChain.get_transaction(&1))
+      |> Stream.map(fn {:ok, {:ok, tx}} -> tx end)
+      |> Enum.to_list()
+
+    %TransactionList{transactions: transactions, paging_state: nil, more?: false}
+  end
+
+  @spec serialize(t()) :: bitstring()
+  def serialize(%__MODULE__{address: address}) do
+    <<address::binary>>
+  end
+
+  @spec deserialize(bitstring()) :: {t(), bitstring}
+  def deserialize(<<rest::bitstring>>) do
+    {address, rest} = Utils.deserialize_address(rest)
+    {%__MODULE__{address: address}, rest}
+  end
+end

--- a/lib/archethic/p2p/message/message_id.ex
+++ b/lib/archethic/p2p/message/message_id.ex
@@ -65,7 +65,8 @@ defmodule Archethic.P2P.MessageId do
     ReplicatePendingTransactionChain,
     NotifyReplicationValidation,
     TransactionSummaryMessage,
-    ReplicationAttestationMessage
+    ReplicationAttestationMessage,
+    GetContractCalls
   }
 
   alias Archethic.TransactionChain.{
@@ -118,6 +119,7 @@ defmodule Archethic.P2P.MessageId do
     ValidateTransaction => 36,
     ReplicatePendingTransactionChain => 37,
     NotifyReplicationValidation => 38,
+    GetContractCalls => 39,
 
     # Responses
     FirstTransactionAddress => 228,

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -219,7 +219,7 @@ defmodule ArchethicWeb.API.TransactionController do
   defp fetch_recipient_tx_and_simulate(recipient_address, tx) do
     with {:ok, contract_tx} <- Archethic.search_transaction(recipient_address),
          {:ok, contract} <- Archethic.parse_contract(contract_tx),
-         {:ok, _} <- Archethic.execute_contract(:transaction, contract, tx) do
+         {:ok, _} <- Archethic.execute_contract(:transaction, contract, [tx]) do
       :ok
     else
       # search_transaction errors

--- a/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
@@ -12,11 +12,7 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
   alias Archethic.P2P.Message.FirstTransactionAddress
 
   alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.TransactionInput
-  alias Archethic.TransactionChain.VersionedTransactionInput
   alias Archethic.TransactionChain.TransactionData
-
-  alias Archethic.TransactionFactory
 
   doctest ActionInterpreter
 

--- a/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
@@ -322,32 +322,6 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
              |> ActionInterpreter.execute()
   end
 
-  test "get_calls() should be expanded to get_calls(contract.address)" do
-    {:ok, :transaction, ast} =
-      ~S"""
-        actions triggered_by: transaction do
-          get_calls()
-        end
-      """
-      |> Interpreter.sanitize_code()
-      |> elem(1)
-      |> ActionInterpreter.parse()
-
-    assert {{:., [line: 2],
-             [
-               {:__aliases__, [alias: Archethic.Contracts.Interpreter.Legacy.Library],
-                [:Library]},
-               :get_calls
-             ]}, [line: 2],
-            [
-              {:get_in, meta,
-               [
-                 {:scope, meta, nil},
-                 ["contract", "address"]
-               ]}
-            ]} = ast
-  end
-
   test "shall use get_genesis_address/1 in actions" do
     key = <<0::16, :crypto.strong_rand_bytes(32)::binary>>
 
@@ -479,63 +453,6 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
              |> ActionInterpreter.parse()
              |> elem(2)
              |> ActionInterpreter.execute()
-  end
-
-  test "shall use get_calls/1 in actions" do
-    key = <<0::16, :crypto.strong_rand_bytes(32)::binary>>
-
-    P2P.add_and_connect_node(%Node{
-      ip: {127, 0, 0, 1},
-      port: 3000,
-      first_public_key: key,
-      last_public_key: key,
-      available?: true,
-      geo_patch: "AAA",
-      network_patch: "AAA",
-      authorized?: true,
-      authorization_date: DateTime.utc_now()
-    })
-
-    address = Base.decode16!("64F05F5236088FC64D1BB19BD13BC548F1C49A42432AF02AD9024D8A2990B2B4")
-
-    MockDB
-    |> stub(:get_inputs, fn _, ^address ->
-      [
-        %VersionedTransactionInput{
-          protocol_version: ArchethicCase.current_protocol_version(),
-          input: %TransactionInput{
-            from: address,
-            amount: nil,
-            type: :call,
-            timestamp: DateTime.utc_now(),
-            spent?: false,
-            reward?: false
-          }
-        }
-      ]
-    end)
-    |> stub(:get_transaction, fn ^address, _, _ ->
-      {:ok, TransactionFactory.create_valid_transaction()}
-    end)
-
-    # TODO: find a way to check the transactions returned by get_calls
-
-    assert %Transaction{data: %TransactionData{content: "1"}} =
-             ~s"""
-             actions triggered_by: transaction do
-               transactions = get_calls()
-               set_content size(transactions)
-             end
-             """
-             |> Interpreter.sanitize_code()
-             |> elem(1)
-             |> ActionInterpreter.parse()
-             |> elem(2)
-             |> ActionInterpreter.execute(%{
-               "contract" => %{
-                 "address" => "64F05F5236088FC64D1BB19BD13BC548F1C49A42432AF02AD9024D8A2990B2B4"
-               }
-             })
   end
 
   describe "blacklist" do

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -139,7 +139,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                Interpreter.execute(
                  :transaction,
                  Contract.from_transaction!(contract_tx),
-                 incoming_tx
+                 [incoming_tx]
                )
     end
 
@@ -175,7 +175,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                Interpreter.execute(
                  :transaction,
                  Contract.from_transaction!(contract_tx),
-                 incoming_tx
+                 [incoming_tx]
                )
     end
 
@@ -211,7 +211,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                Interpreter.execute(
                  :transaction,
                  Contract.from_transaction!(contract_tx),
-                 incoming_tx
+                 [incoming_tx]
                )
              )
     end
@@ -249,7 +249,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                Interpreter.execute(
                  :transaction,
                  Contract.from_transaction!(contract_tx),
-                 incoming_tx
+                 [incoming_tx]
                )
              )
     end
@@ -288,7 +288,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                Interpreter.execute(
                  :oracle,
                  Contract.from_transaction!(contract_tx),
-                 oracle_tx
+                 [oracle_tx]
                )
              )
     end
@@ -323,7 +323,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                Interpreter.execute(
                  :transaction,
                  Contract.from_transaction!(contract_tx),
-                 incoming_tx
+                 [incoming_tx]
                )
              )
     end
@@ -351,7 +351,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                Interpreter.execute(
                  {:datetime, ~U[2023-03-16 16:28:56Z]},
                  Contract.from_transaction!(contract_tx),
-                 nil
+                 []
                )
     end
 
@@ -378,7 +378,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                Interpreter.execute(
                  {:interval, "* * * * *"},
                  Contract.from_transaction!(contract_tx),
-                 nil
+                 []
                )
     end
 
@@ -404,7 +404,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       }
 
       assert {:ok, %Transaction{}} =
-               Interpreter.execute(:oracle, Contract.from_transaction!(contract_tx), nil)
+               Interpreter.execute(:oracle, Contract.from_transaction!(contract_tx), [])
     end
   end
 end

--- a/test/archethic/p2p/message/get_contract_calls_test.exs
+++ b/test/archethic/p2p/message/get_contract_calls_test.exs
@@ -1,0 +1,61 @@
+defmodule Archethic.P2P.Message.GetContractCallsTest do
+  @moduledoc false
+  use ArchethicCase
+
+  alias Archethic.Contracts.TransactionLookup
+  alias Archethic.Crypto
+  alias Archethic.P2P.Message
+  alias Archethic.P2P.Message.GetContractCalls
+  alias Archethic.P2P.Message.TransactionList
+  alias Archethic.TransactionChain.Transaction
+
+  import Mox
+
+  doctest GetContractCalls
+
+  test "should serialize/deserialize properly" do
+    msg = %GetContractCalls{address: <<0::16, :crypto.strong_rand_bytes(32)::binary>>}
+
+    assert msg ==
+             msg
+             |> Message.encode()
+             |> Message.decode()
+             |> elem(0)
+  end
+
+  test "process/2 should work" do
+    contract_address = <<0::16, :crypto.strong_rand_bytes(32)::binary>>
+    msg = %GetContractCalls{address: contract_address}
+
+    tx1 = %Transaction{address: <<0::16, :crypto.strong_rand_bytes(32)::binary>>}
+    tx2 = %Transaction{address: <<0::16, :crypto.strong_rand_bytes(32)::binary>>}
+    tx1_address = tx1.address
+    tx2_address = tx2.address
+
+    TransactionLookup.add_contract_transaction(
+      contract_address,
+      tx1.address,
+      DateTime.utc_now(),
+      ArchethicCase.current_protocol_version()
+    )
+
+    TransactionLookup.add_contract_transaction(
+      contract_address,
+      tx2.address,
+      DateTime.utc_now(),
+      ArchethicCase.current_protocol_version()
+    )
+
+    MockDB
+    |> expect(:get_transaction, fn ^tx1_address, _, _ ->
+      {:ok, tx1}
+    end)
+    |> expect(:get_transaction, fn ^tx2_address, _, _ ->
+      {:ok, tx2}
+    end)
+
+    # asserts
+    assert %TransactionList{transactions: [^tx1, ^tx2]} =
+             GetContractCalls.process(msg, Crypto.first_node_public_key())
+  end
+end


### PR DESCRIPTION
# Description

Create a `GetContractCalls` message. Then refactor the `Interpreter.execute/3` to have the calls as a parameter instead of doing some I/O from within the contract execution. 

The `Contract.get_calls()` is actually not really necessary anymore and we could tell the users there is a `calls` global variable available. 

I entirely removed the `get_calls` function from Legacy interpreter since it did not work at all anyway.
I also only added it for the `action` blocks since there are no use case to handle it in `condition` block.

**This PR is based on the branch https://github.com/archethic-foundation/archethic-node/pull/963. We need to rebase it after the merge**

Fixes #926

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests :heavy_check_mark: 
Manual test (faucet smart contract): :heavy_check_mark: 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
