### PR TITLE
add AtVsn credo rule

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -16,7 +16,11 @@
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
       color: true,
+      requires: ["./lib/checks/*.ex"],
       checks: [
+        # Custom checks
+        {Archethic.Checks.AtVsn, []},
+
         # Consistency Checks
         {Credo.Check.Consistency.LineEndings, []},
         {Credo.Check.Consistency.ParameterPatternMatching, []},

--- a/lib/archethic/oracle_chain/services/hydrating_cache.ex
+++ b/lib/archethic/oracle_chain/services/hydrating_cache.ex
@@ -6,6 +6,7 @@ defmodule Archethic.OracleChain.Services.HydratingCache do
   - Return the value when requested
   """
   use GenServer
+  @vsn Mix.Project.config()[:version]
 
   alias Archethic.Utils
   require Logger

--- a/lib/checks/at_vsn.ex
+++ b/lib/checks/at_vsn.ex
@@ -1,0 +1,41 @@
+defmodule Archethic.Checks.AtVsn do
+  @moduledoc """
+  Check that GenServer & GenStateMachine have a @vsn attribute
+  """
+
+  use Credo.Check
+
+  defstruct is_a_server: false,
+            has_a_at_vsn: false,
+            issues: []
+
+  def run(source_file = %SourceFile{}, params = []) do
+    # IssueMeta helps keeping track of the source file and the check's params
+    # (technically, it's just a custom tagged tuple)
+    issue_meta = IssueMeta.for(source_file, params)
+
+    case Credo.Code.prewalk(source_file, &traverse(&1, &2), %__MODULE__{}) do
+      %__MODULE__{is_a_server: true, has_a_at_vsn: false} ->
+        [format_issue(issue_meta, message: "Missing @vsn attribute")]
+
+      _ ->
+        []
+    end
+  end
+
+  defp traverse(ast = {:use, _, [{:__aliases__, _, [:GenServer]} | _]}, acc) do
+    {ast, %__MODULE__{acc | is_a_server: true}}
+  end
+
+  defp traverse(ast = {:use, _, [{:__aliases__, _, [:GenStateMachine]} | _]}, acc) do
+    {ast, %__MODULE__{acc | is_a_server: true}}
+  end
+
+  defp traverse(ast = {:@, _, [{:vsn, _, _}]}, acc) do
+    {ast, %__MODULE__{acc | has_a_at_vsn: true}}
+  end
+
+  defp traverse(ast, acc) do
+    {ast, acc}
+  end
+end

--- a/lib/checks/at_vsn.ex
+++ b/lib/checks/at_vsn.ex
@@ -3,7 +3,7 @@ defmodule Archethic.Checks.AtVsn do
   Check that GenServer & GenStateMachine have a @vsn attribute
   """
 
-  use Credo.Check
+  use Credo.Check, category: :warning
 
   defstruct is_a_server: false,
             has_a_at_vsn: false,


### PR DESCRIPTION
Add a credo rules to check for `@vsn` attributes on GenServer and GenStateMachine.

Example:
![Screenshot_2023-03-31_16-13-34](https://user-images.githubusercontent.com/74045243/229144932-f8747040-2eb1-492f-9d1b-1261effc3131.png)

I find it add ~300ms run time on my computer 5.8s vs 5.5s.