### PR TITLE
Smart Contracts: Safe floating point maths + automatic amount conversion to 10^8

### DIFF
--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -4,6 +4,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
 
+  alias Archethic.Contracts.ContractConstants, as: Constants
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.Contracts.Interpreter.CommonInterpreter
   alias Archethic.Contracts.Interpreter.Library
@@ -42,6 +43,13 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
 
     # initiate a transaction that will be use by the "Contract" module
     next_tx = %Transaction{data: %TransactionData{}}
+
+    # Apply some transformations to the transactions
+    # We do it here because the Constants module is still used by InterpreterLegacy
+    constants =
+      constants
+      |> Constants.map_transactions(&Constants.stringify_transaction/1)
+      |> Constants.map_transactions(&Constants.cast_transaction_amount_to_float/1)
 
     # we use the process dictionary to store our scope
     # because it is mutable.

--- a/lib/archethic/contracts/interpreter/ast_helper.ex
+++ b/lib/archethic/contracts/interpreter/ast_helper.ex
@@ -182,4 +182,27 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
   """
   def wrap_in_block(ast = {:__block__, _, _}), do: ast
   def wrap_in_block(ast), do: {:__block__, [], [ast]}
+
+  @doc """
+  Delegate the arithmetic to the Decimal library
+  """
+  @spec decimal_arithmetic(Macro.t(), number(), number()) :: float()
+  def decimal_arithmetic(ast, lhs, rhs) do
+    operation =
+      case ast do
+        :* -> &Decimal.mult/2
+        :/ -> &Decimal.div/2
+        :+ -> &Decimal.add/2
+        :- -> &Decimal.sub/2
+      end
+
+    # the `0.0 + x` is used to cast integers to floats
+    Decimal.to_float(
+      Decimal.round(
+        operation.(Decimal.from_float(0.0 + lhs), Decimal.from_float(0.0 + rhs)),
+        8,
+        :floor
+      )
+    )
+  end
 end

--- a/lib/archethic/contracts/interpreter/ast_helper.ex
+++ b/lib/archethic/contracts/interpreter/ast_helper.ex
@@ -47,11 +47,17 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
   Return wether the given ast is an integer
 
     iex> ast = quote do: 1
-    iex> ASTHelper.is_integer?(ast)
+    iex> ASTHelper.is_number?(ast)
+    true
+
+    iex> ast = quote do: 1.01
+    iex> ASTHelper.is_number?(ast)
     true
   """
-  @spec is_integer?(Macro.t()) :: boolean()
-  def is_integer?(node), do: is_integer(node)
+  @spec is_number?(Macro.t()) :: boolean()
+  def is_number?(node) do
+    is_integer(node) || is_float(node)
+  end
 
   @doc ~S"""
   Return wether the given ast is an binary
@@ -71,16 +77,6 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
   def is_binary?(_), do: false
 
   @doc """
-  Return wether the given ast is an float
-
-    iex> ast= quote do: 1.0
-    iex> ASTHelper.is_float?(ast)
-    true
-  """
-  @spec is_float?(Macro.t()) :: boolean()
-  def is_float?(node), do: is_float(node)
-
-  @doc """
   Return wether the given ast is a a list
 
     iex> ast = quote do: [1, 2]
@@ -91,13 +87,22 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
   def is_list?(node), do: is_list(node)
 
   @doc """
-  Return wether the given ast is a variable or a function call.
-  Useful because we pretty much accept this everywhere
+  Return wether the given ast is a variable or a function call or a block.
+  Useful because we pretty much accept this everywhere.
+
+  We must accept blocks as well because we cannot determine its type.
+  (If the user code 1+1 it will be a block)
   """
   @spec is_variable_or_function_call?(Macro.t()) :: boolean()
   def is_variable_or_function_call?(ast) do
-    is_variable?(ast) || is_function_call?(ast)
+    is_variable?(ast) || is_function_call?(ast) || is_block?(ast)
   end
+
+  @doc """
+  Return wether the given ast is a block
+  """
+  def is_block?({:__block__, _, _}), do: true
+  def is_block?(_), do: false
 
   @doc """
   Return wether the given ast is a variable.

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -361,12 +361,11 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   end
 
   # BigInt mathematics to avoid floating point issues
-  @unit_uco 100_000_000
+  # the `0.0 + x` is used to cast integers to floats
   def postwalk(_node = {:*, meta, [lhs, rhs]}, acc) do
     new_node =
-      quote line: Keyword.fetch!(meta, :line),
-            bind_quoted: [lhs: lhs, rhs: rhs, bigint: @unit_uco] do
-        bigint * lhs * bigint * rhs / (bigint * bigint)
+      quote line: Keyword.fetch!(meta, :line) do
+        Float.floor(0.0 + unquote(lhs) * unquote(rhs), 8)
       end
 
     {new_node, acc}
@@ -374,9 +373,8 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
 
   def postwalk(_node = {:/, meta, [lhs, rhs]}, acc) do
     new_node =
-      quote line: Keyword.fetch!(meta, :line),
-            bind_quoted: [lhs: lhs, rhs: rhs, bigint: @unit_uco] do
-        bigint * lhs / (bigint * rhs)
+      quote line: Keyword.fetch!(meta, :line) do
+        Float.floor(0.0 + unquote(lhs) / unquote(rhs), 8)
       end
 
     {new_node, acc}
@@ -384,9 +382,8 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
 
   def postwalk(_node = {:+, meta, [lhs, rhs]}, acc) do
     new_node =
-      quote line: Keyword.fetch!(meta, :line),
-            bind_quoted: [lhs: lhs, rhs: rhs, bigint: @unit_uco] do
-        (bigint * lhs + bigint * rhs) / bigint
+      quote line: Keyword.fetch!(meta, :line) do
+        Float.floor(0.0 + (unquote(lhs) + unquote(rhs)), 8)
       end
 
     {new_node, acc}
@@ -394,9 +391,8 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
 
   def postwalk(_node = {:-, meta, [lhs, rhs]}, acc) do
     new_node =
-      quote line: Keyword.fetch!(meta, :line),
-            bind_quoted: [lhs: lhs, rhs: rhs, bigint: @unit_uco] do
-        (bigint * lhs - bigint * rhs) / bigint
+      quote line: Keyword.fetch!(meta, :line) do
+        Float.floor(0.0 + (unquote(lhs) - unquote(rhs)), 8)
       end
 
     {new_node, acc}

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -365,7 +365,16 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   def postwalk(_node = {:*, meta, [lhs, rhs]}, acc) do
     new_node =
       quote line: Keyword.fetch!(meta, :line) do
-        Float.floor(0.0 + unquote(lhs) * unquote(rhs), 8)
+        Decimal.to_float(
+          Decimal.round(
+            Decimal.mult(
+              Decimal.from_float(0.0 + unquote(lhs)),
+              Decimal.from_float(0.0 + unquote(rhs))
+            ),
+            8,
+            :floor
+          )
+        )
       end
 
     {new_node, acc}
@@ -374,7 +383,16 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   def postwalk(_node = {:/, meta, [lhs, rhs]}, acc) do
     new_node =
       quote line: Keyword.fetch!(meta, :line) do
-        Float.floor(0.0 + unquote(lhs) / unquote(rhs), 8)
+        Decimal.to_float(
+          Decimal.round(
+            Decimal.div(
+              Decimal.from_float(0.0 + unquote(lhs)),
+              Decimal.from_float(0.0 + unquote(rhs))
+            ),
+            8,
+            :floor
+          )
+        )
       end
 
     {new_node, acc}
@@ -383,7 +401,16 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   def postwalk(_node = {:+, meta, [lhs, rhs]}, acc) do
     new_node =
       quote line: Keyword.fetch!(meta, :line) do
-        Float.floor(0.0 + (unquote(lhs) + unquote(rhs)), 8)
+        Decimal.to_float(
+          Decimal.round(
+            Decimal.add(
+              Decimal.from_float(0.0 + unquote(lhs)),
+              Decimal.from_float(0.0 + unquote(rhs))
+            ),
+            8,
+            :floor
+          )
+        )
       end
 
     {new_node, acc}
@@ -392,7 +419,16 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   def postwalk(_node = {:-, meta, [lhs, rhs]}, acc) do
     new_node =
       quote line: Keyword.fetch!(meta, :line) do
-        Float.floor(0.0 + (unquote(lhs) - unquote(rhs)), 8)
+        Decimal.to_float(
+          Decimal.round(
+            Decimal.sub(
+              Decimal.from_float(0.0 + unquote(lhs)),
+              Decimal.from_float(0.0 + unquote(rhs))
+            ),
+            8,
+            :floor
+          )
+        )
       end
 
     {new_node, acc}

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -361,74 +361,10 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   end
 
   # BigInt mathematics to avoid floating point issues
-  # the `0.0 + x` is used to cast integers to floats
-  def postwalk(_node = {:*, meta, [lhs, rhs]}, acc) do
+  def postwalk(_node = {ast, meta, [lhs, rhs]}, acc) when ast in [:*, :/, :+, :-] do
     new_node =
       quote line: Keyword.fetch!(meta, :line) do
-        Decimal.to_float(
-          Decimal.round(
-            Decimal.mult(
-              Decimal.from_float(0.0 + unquote(lhs)),
-              Decimal.from_float(0.0 + unquote(rhs))
-            ),
-            8,
-            :floor
-          )
-        )
-      end
-
-    {new_node, acc}
-  end
-
-  def postwalk(_node = {:/, meta, [lhs, rhs]}, acc) do
-    new_node =
-      quote line: Keyword.fetch!(meta, :line) do
-        Decimal.to_float(
-          Decimal.round(
-            Decimal.div(
-              Decimal.from_float(0.0 + unquote(lhs)),
-              Decimal.from_float(0.0 + unquote(rhs))
-            ),
-            8,
-            :floor
-          )
-        )
-      end
-
-    {new_node, acc}
-  end
-
-  def postwalk(_node = {:+, meta, [lhs, rhs]}, acc) do
-    new_node =
-      quote line: Keyword.fetch!(meta, :line) do
-        Decimal.to_float(
-          Decimal.round(
-            Decimal.add(
-              Decimal.from_float(0.0 + unquote(lhs)),
-              Decimal.from_float(0.0 + unquote(rhs))
-            ),
-            8,
-            :floor
-          )
-        )
-      end
-
-    {new_node, acc}
-  end
-
-  def postwalk(_node = {:-, meta, [lhs, rhs]}, acc) do
-    new_node =
-      quote line: Keyword.fetch!(meta, :line) do
-        Decimal.to_float(
-          Decimal.round(
-            Decimal.sub(
-              Decimal.from_float(0.0 + unquote(lhs)),
-              Decimal.from_float(0.0 + unquote(rhs))
-            ),
-            8,
-            :floor
-          )
-        )
+        AST.decimal_arithmetic(unquote(ast), unquote(lhs), unquote(rhs))
       end
 
     {new_node, acc}

--- a/lib/archethic/contracts/interpreter/condition_validator.ex
+++ b/lib/archethic/contracts/interpreter/condition_validator.ex
@@ -16,12 +16,12 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
   """
   @spec valid_conditions?(Conditions.t(), map()) :: boolean()
   def valid_conditions?(conditions = %Conditions{}, constants = %{}) do
+    # Apply some transformations to the transactions
+    # We do it here because the Constants module is still used by InterpreterLegacy
     constants =
       constants
-      |> Enum.map(fn {subset, constants} ->
-        {subset, Constants.stringify(constants)}
-      end)
-      |> Enum.into(%{})
+      |> Constants.map_transactions(&Constants.stringify_transaction/1)
+      |> Constants.map_transactions(&Constants.cast_transaction_amount_to_float/1)
 
     conditions
     |> Map.from_struct()
@@ -85,7 +85,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
     {"type", previous_type == next_type}
   end
 
-  defp validate_condition({"content", nil}, %{"next" => %{"content" => ""}}) do
+  defp validate_condition({"content", nil}, %{"previous" => _, "next" => %{"content" => ""}}) do
     # Skip the verification when it's the default type
     {"content", true}
   end
@@ -106,7 +106,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
     {field, Map.get(prev, field) == Map.get(next, field)}
   end
 
-  defp validate_condition({field, condition}, constants = %{"next" => next}) do
+  defp validate_condition({field, condition}, constants = %{"previous" => _, "next" => next}) do
     result = evaluate_condition(condition, constants)
 
     if is_boolean(result) do

--- a/lib/archethic/contracts/interpreter/legacy/condition_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/legacy/condition_interpreter.ex
@@ -489,10 +489,7 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ConditionInterpreter do
   def valid_conditions?(conditions = %Conditions{}, constants = %{}) do
     constants =
       constants
-      |> Enum.map(fn {subset, constants} ->
-        {subset, Constants.stringify(constants)}
-      end)
-      |> Enum.into(%{})
+      |> Constants.map_transactions(&Constants.stringify_transaction/1)
 
     result =
       conditions

--- a/lib/archethic/contracts/interpreter/library/common/json.ex
+++ b/lib/archethic/contracts/interpreter/library/common/json.ex
@@ -44,8 +44,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Json do
       AST.is_variable_or_function_call?(first) ||
       AST.is_map?(first) ||
       AST.is_list?(first) ||
-      AST.is_float?(first) ||
-      AST.is_integer?(first)
+      AST.is_number?(first)
   end
 
   def check_types(:is_valid?, [first]) do

--- a/lib/archethic/contracts/interpreter/library/common/list.ex
+++ b/lib/archethic/contracts/interpreter/library/common/list.ex
@@ -4,10 +4,24 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.List do
 
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
 
-  @spec at(list(), integer()) :: any()
-  defdelegate at(list, idx),
-    to: Enum,
-    as: :at
+  @spec at(list(), integer() | float()) :: any()
+  def at(list, idx) do
+    cond do
+      is_integer(idx) ->
+        Enum.at(list, idx)
+
+      is_float(idx) && trunc(idx) == idx ->
+        Enum.at(list, trunc(idx))
+
+      true ->
+        raise %FunctionClauseError{
+          args: [list, idx],
+          arity: 2,
+          function: :at,
+          module: __MODULE__
+        }
+    end
+  end
 
   @spec size(list()) :: integer()
   defdelegate size(list),
@@ -47,7 +61,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.List do
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:at, [first, second]) do
     (AST.is_list?(first) || AST.is_variable_or_function_call?(first)) &&
-      (AST.is_integer?(second) || AST.is_variable_or_function_call?(second))
+      (AST.is_number?(second) || AST.is_variable_or_function_call?(second))
   end
 
   def check_types(:size, [first]) do

--- a/lib/archethic/contracts/interpreter/library/common/string.ex
+++ b/lib/archethic/contracts/interpreter/library/common/string.ex
@@ -14,25 +14,36 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.String do
     to: String,
     as: :contains?
 
-  @spec to_int(String.t()) :: integer()
-  defdelegate to_int(str),
-    to: String,
-    as: :to_integer
+  @spec to_number(String.t()) :: integer() | float() | nil
+  def to_number(string) do
+    try do
+      String.to_integer(string)
+    rescue
+      _ ->
+        try do
+          String.to_float(string)
+        rescue
+          _ ->
+            nil
+        end
+    end
+  end
 
-  @spec from_int(integer()) :: String.t()
-  defdelegate from_int(int),
-    to: Integer,
-    as: :to_string
+  @spec from_number(integer() | float()) :: String.t()
+  def from_number(int) when is_integer(int) do
+    Integer.to_string(int)
+  end
 
-  @spec to_float(String.t()) :: float()
-  defdelegate to_float(str),
-    to: String,
-    as: :to_float
+  def from_number(float) when is_float(float) do
+    truncated = trunc(float)
 
-  @spec from_float(float()) :: String.t()
-  defdelegate from_float(float),
-    to: Float,
-    as: :to_string
+    # we display as an int if there is no decimals
+    if truncated == float do
+      Integer.to_string(truncated)
+    else
+      Float.to_string(float)
+    end
+  end
 
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:size, [first]) do
@@ -44,20 +55,12 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.String do
       (AST.is_binary?(second) || AST.is_variable_or_function_call?(second))
   end
 
-  def check_types(:to_int, [first]) do
+  def check_types(:to_number, [first]) do
     AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
   end
 
-  def check_types(:from_int, [first]) do
-    AST.is_integer?(first) || AST.is_variable_or_function_call?(first)
-  end
-
-  def check_types(:to_float, [first]) do
-    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
-  end
-
-  def check_types(:from_float, [first]) do
-    AST.is_float?(first) || AST.is_variable_or_function_call?(first)
+  def check_types(:from_number, [first]) do
+    AST.is_integer?(first) || AST.is_float?(first) || AST.is_variable_or_function_call?(first)
   end
 
   def check_types(_, _), do: false

--- a/lib/archethic/contracts/interpreter/library/common/string.ex
+++ b/lib/archethic/contracts/interpreter/library/common/string.ex
@@ -60,7 +60,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.String do
   end
 
   def check_types(:from_number, [first]) do
-    AST.is_integer?(first) || AST.is_float?(first) || AST.is_variable_or_function_call?(first)
+    AST.is_number?(first) || AST.is_variable_or_function_call?(first)
   end
 
   def check_types(_, _), do: false

--- a/lib/archethic/contracts/interpreter/library/contract.ex
+++ b/lib/archethic/contracts/interpreter/library/contract.ex
@@ -7,6 +7,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Contract do
   @behaviour Archethic.Contracts.Interpreter.Library
 
   alias Archethic.Contracts.Interpreter.Scope
+  alias Archethic.Contracts.Interpreter.Library
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.TransactionChain.Transaction
   alias Archethic.Contracts.Interpreter.Legacy.TransactionStatements
@@ -24,8 +25,17 @@ defmodule Archethic.Contracts.Interpreter.Library.Contract do
     to: TransactionStatements
 
   @spec set_content(Transaction.t(), binary() | integer() | float()) :: Transaction.t()
-  defdelegate set_content(next_tx, content),
-    to: TransactionStatements
+  def set_content(next_tx, content) when is_binary(content) do
+    put_in(next_tx, [Access.key(:data), Access.key(:content)], content)
+  end
+
+  def set_content(next_tx, content) when is_integer(content) or is_float(content) do
+    put_in(
+      next_tx,
+      [Access.key(:data), Access.key(:content)],
+      Library.Common.String.from_number(content)
+    )
+  end
 
   @spec set_code(Transaction.t(), binary()) :: Transaction.t()
   defdelegate set_code(next_tx, args),

--- a/lib/archethic/contracts/interpreter/library/contract.ex
+++ b/lib/archethic/contracts/interpreter/library/contract.ex
@@ -92,7 +92,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Contract do
   end
 
   def check_types(:set_content, [first]) do
-    AST.is_binary?(first) || AST.is_integer?(first) || AST.is_float?(first) ||
+    AST.is_binary?(first) || AST.is_number?(first) ||
       AST.is_variable_or_function_call?(first)
   end
 

--- a/lib/archethic/contracts/interpreter/library/contract.ex
+++ b/lib/archethic/contracts/interpreter/library/contract.ex
@@ -10,6 +10,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Contract do
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.TransactionChain.Transaction
   alias Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+  alias Archethic.Utils
 
   @spec get_calls() :: list(map())
   def get_calls() do
@@ -40,24 +41,24 @@ defmodule Archethic.Contracts.Interpreter.Library.Contract do
 
   @spec add_uco_transfer(Transaction.t(), map()) :: Transaction.t()
   def add_uco_transfer(next_tx, args) do
+    args = Map.update!(args, "amount", &Utils.to_bigint/1)
     TransactionStatements.add_uco_transfer(next_tx, Map.to_list(args))
   end
 
   @spec add_uco_transfers(Transaction.t(), list(map())) :: Transaction.t()
   def add_uco_transfers(next_tx, args) do
-    casted_args = Enum.map(args, &Map.to_list/1)
-    TransactionStatements.add_uco_transfers(next_tx, casted_args)
+    Enum.reduce(args, next_tx, &add_uco_transfer(&2, &1))
   end
 
   @spec add_token_transfer(Transaction.t(), map()) :: Transaction.t()
   def add_token_transfer(next_tx, args) do
+    args = Map.update!(args, "amount", &Utils.to_bigint/1)
     TransactionStatements.add_token_transfer(next_tx, Map.to_list(args))
   end
 
   @spec add_token_transfers(Transaction.t(), list(map())) :: Transaction.t()
   def add_token_transfers(next_tx, args) do
-    casted_args = Enum.map(args, &Map.to_list/1)
-    TransactionStatements.add_token_transfers(next_tx, casted_args)
+    Enum.reduce(args, next_tx, &add_token_transfer(&2, &1))
   end
 
   @spec add_ownership(Transaction.t(), map()) :: Transaction.t()

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -19,6 +19,24 @@ defmodule Archethic.Utils do
 
   import Bitwise
 
+  @type bigint() :: integer()
+
+  @doc """
+  Convert a number to a bigint
+  """
+  @spec to_bigint(integer() | float()) :: bigint()
+  def to_bigint(value) do
+    trunc(value * 100_000_000)
+  end
+
+  @doc """
+  Convert a bigint into a float
+  """
+  @spec from_bigint(bigint()) :: float()
+  def from_bigint(value) do
+    value / 100_000_000
+  end
+
   @doc """
   Compute an offset of the next shift in seconds for a given time interval
 

--- a/mix.exs
+++ b/mix.exs
@@ -120,6 +120,7 @@ defmodule Archethic.MixProject do
       {:ex_cldr, "~> 2.7"},
       {:ex_cldr_numbers, "~> 2.29"},
       {:git_diff, "~> 0.6.4"},
+      {:decimal, "~> 2.0"},
 
       # Numbering
       {:nx, "~> 0.5"},

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -952,7 +952,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       code = ~s"""
       actions triggered_by: transaction do
         if transaction.uco_transfers["#{address_hex}"] == 2 do
-          if List.at(transaction.token_transfers["#{address2_hex}"], 0).amount == 3 do
+          if List.at(transaction.token_transfers["#{address2_hex}"], 0).amount == 3.12345 do
             Contract.set_content "ok"
           end
         end
@@ -966,7 +966,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
               transfers: [
                 %TokenTransfer{
                   to: address2,
-                  amount: Archethic.Utils.to_bigint(3),
+                  amount: Archethic.Utils.to_bigint(3.12345),
                   token_address: token_address,
                   token_id: 1
                 }

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -371,7 +371,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       actions triggered_by: transaction do
         numbers = ["1": 1, two: 2, three: 3]
 
-        Contract.set_content numbers[String.from_int 1]
+        Contract.set_content numbers[String.from_number 1]
       end
       """
 
@@ -773,7 +773,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       end
       """
 
-      assert %Transaction{data: %TransactionData{content: "6.0"}} = sanitize_parse_execute(code)
+      assert %Transaction{data: %TransactionData{content: "6"}} = sanitize_parse_execute(code)
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -788,7 +788,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       end
       """
 
-      assert %Transaction{data: %TransactionData{content: "6.0"}} = sanitize_parse_execute(code)
+      assert %Transaction{data: %TransactionData{content: "6"}} = sanitize_parse_execute(code)
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -803,7 +803,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       end
       """
 
-      assert %Transaction{data: %TransactionData{content: "12.0"}} = sanitize_parse_execute(code)
+      assert %Transaction{data: %TransactionData{content: "12"}} = sanitize_parse_execute(code)
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -876,7 +876,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       actions triggered_by: transaction do
         numbers = ["1": 1, two: 2, three: 3]
 
-        Contract.set_content numbers[String.from_int 1]
+        Contract.set_content numbers[String.from_number 1]
       end
       """
 

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -1004,6 +1004,50 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
 
       code = ~s"""
       actions triggered_by: transaction do
+        a = 0.145 * 2
+        if a == 0.29 do
+          Contract.set_content "ok"
+        end
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+
+      code = ~s"""
+      actions triggered_by: transaction do
+        a = 1 / 3
+        if a == 0.33333333 do
+          Contract.set_content "ok"
+        end
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+
+      code = ~s"""
+      actions triggered_by: transaction do
+        a = 2 / 3
+        if a == 0.66666666 do
+          Contract.set_content "ok"
+        end
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+
+      code = ~s"""
+      actions triggered_by: transaction do
+        a = 0.29 + 0.15
+        if a == 0.44 do
+          Contract.set_content "ok"
+        end
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+
+      code = ~s"""
+      actions triggered_by: transaction do
         a = 12 / 2
         if a == 6 do
           Contract.set_content "ok"

--- a/test/archethic/contracts/interpreter/library/common/list_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/list_test.exs
@@ -27,6 +27,17 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ListTest do
 
       assert %Transaction{data: %TransactionData{content: "Jean"}} = sanitize_parse_execute(code)
     end
+
+    test "should work with maths (because bigint)" do
+      code = ~s"""
+      actions triggered_by: transaction do
+        list = ["Jennifer", "John", "Jean", "Julie"]
+        Contract.set_content List.at(list, 1+1)
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "Jean"}} = sanitize_parse_execute(code)
+    end
   end
 
   # ----------------------------------------

--- a/test/archethic/contracts/interpreter/library/common/string_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/string_test.exs
@@ -83,6 +83,18 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
 
       assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
     end
+
+    test "should return nil if not a number" do
+      code = ~s"""
+      actions triggered_by: transaction do
+        if String.to_number("bob") == nil do
+          Contract.set_content "ok"
+        end
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+    end
   end
 
   # ----------------------------------------

--- a/test/archethic/contracts/interpreter/library/common/string_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/string_test.exs
@@ -59,11 +59,23 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
   end
 
   # ----------------------------------------
-  describe "to_int/1" do
-    test "should work" do
+  describe "to_number/1" do
+    test "should parse integer" do
       code = ~s"""
       actions triggered_by: transaction do
-        if String.to_int("14") == 14 do
+        if String.to_number("14") == 14 do
+          Contract.set_content "ok"
+        end
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+    end
+
+    test "should parse float" do
+      code = ~s"""
+      actions triggered_by: transaction do
+        if String.to_number("14.1") == 14.1 do
           Contract.set_content "ok"
         end
       end
@@ -74,11 +86,11 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
   end
 
   # ----------------------------------------
-  describe "from_int/1" do
-    test "should work" do
+  describe "from_number/1" do
+    test "should convert int" do
       code = ~s"""
       actions triggered_by: transaction do
-        if String.from_int(14) == "14" do
+        if String.from_number(14) == "14" do
           Contract.set_content "ok"
         end
       end
@@ -86,14 +98,11 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
 
       assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
     end
-  end
 
-  # ----------------------------------------
-  describe "to_float/1" do
-    test "should work" do
+    test "should convert float" do
       code = ~s"""
       actions triggered_by: transaction do
-        if String.to_float("0.1") == 0.1 do
+        if String.from_number(14.1) == "14.1" do
           Contract.set_content "ok"
         end
       end
@@ -101,14 +110,11 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
 
       assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
     end
-  end
 
-  # ----------------------------------------
-  describe "from_float/1" do
-    test "should work" do
+    test "should display float as int if possible" do
       code = ~s"""
       actions triggered_by: transaction do
-        if String.from_float(0.1) == "0.1" do
+        if String.from_number(14.0) == "14" do
           Contract.set_content "ok"
         end
       end

--- a/test/archethic/contracts/interpreter/library/contract_test.exs
+++ b/test/archethic/contracts/interpreter/library/contract_test.exs
@@ -398,15 +398,15 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
       code = ~s"""
       actions triggered_by: transaction do
         transfers = [
-          [to: "#{Base.encode16(address)}", amount: 1234],
-          [to: "#{Base.encode16(address2)}", amount: 5678]
+          [to: "#{Base.encode16(address)}", amount: 12.34],
+          [to: "#{Base.encode16(address2)}", amount: 567.8]
         ]
         Contract.add_uco_transfers(transfers)
       end
       """
 
-      expected_amount1 = Archethic.Utils.to_bigint(1234)
-      expected_amount2 = Archethic.Utils.to_bigint(5678)
+      expected_amount1 = Archethic.Utils.to_bigint(12.34)
+      expected_amount2 = Archethic.Utils.to_bigint(567.8)
 
       assert %Transaction{
                data: %TransactionData{
@@ -433,14 +433,14 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
       code = ~s"""
       actions triggered_by: transaction do
         transfers = [
-          [to: "#{Base.encode16(address)}", amount: 14, token_address: "#{Base.encode16(token_address)}"],
+          [to: "#{Base.encode16(address)}", amount: 14.1864, token_address: "#{Base.encode16(token_address)}"],
           [to: "#{Base.encode16(address2)}", amount: 3,token_id: 4, token_address: "#{Base.encode16(token_address)}"]
         ]
         Contract.add_token_transfers(transfers)
       end
       """
 
-      expected_amount1 = Archethic.Utils.to_bigint(14)
+      expected_amount1 = Archethic.Utils.to_bigint(14.1864)
       expected_amount2 = Archethic.Utils.to_bigint(3)
 
       assert %Transaction{

--- a/test/archethic/contracts/interpreter/library/contract_test.exs
+++ b/test/archethic/contracts/interpreter/library/contract_test.exs
@@ -141,12 +141,14 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
       end
       """
 
+      expected_amount = Archethic.Utils.to_bigint(9000)
+
       assert %Transaction{
                data: %TransactionData{
                  ledger: %Ledger{
                    uco: %UCOLedger{
                      transfers: [
-                       %UCOTransfer{amount: 9000, to: ^address}
+                       %UCOTransfer{amount: ^expected_amount, to: ^address}
                      ]
                    }
                  }
@@ -164,12 +166,14 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
       end
       """
 
+      expected_amount = Archethic.Utils.to_bigint(9000)
+
       assert %Transaction{
                data: %TransactionData{
                  ledger: %Ledger{
                    uco: %UCOLedger{
                      transfers: [
-                       %UCOTransfer{amount: 9000, to: ^address}
+                       %UCOTransfer{amount: ^expected_amount, to: ^address}
                      ]
                    }
                  }
@@ -190,6 +194,8 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
       end
       """
 
+      expected_amount = Archethic.Utils.to_bigint(14)
+
       assert %Transaction{
                data: %TransactionData{
                  ledger: %Ledger{
@@ -197,7 +203,7 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
                      transfers: [
                        %TokenTransfer{
                          to: ^address,
-                         amount: 14,
+                         amount: ^expected_amount,
                          token_address: ^token_address,
                          token_id: 0
                        }
@@ -219,6 +225,8 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
       end
       """
 
+      expected_amount = Archethic.Utils.to_bigint(15)
+
       assert %Transaction{
                data: %TransactionData{
                  ledger: %Ledger{
@@ -226,7 +234,7 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
                      transfers: [
                        %TokenTransfer{
                          to: ^address,
-                         amount: 15,
+                         amount: ^expected_amount,
                          token_address: ^token_address,
                          token_id: 1
                        }
@@ -389,13 +397,16 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
       end
       """
 
+      expected_amount1 = Archethic.Utils.to_bigint(1234)
+      expected_amount2 = Archethic.Utils.to_bigint(5678)
+
       assert %Transaction{
                data: %TransactionData{
                  ledger: %Ledger{
                    uco: %UCOLedger{
                      transfers: [
-                       %UCOTransfer{amount: 5678, to: ^address2},
-                       %UCOTransfer{amount: 1234, to: ^address}
+                       %UCOTransfer{amount: ^expected_amount2, to: ^address2},
+                       %UCOTransfer{amount: ^expected_amount1, to: ^address}
                      ]
                    }
                  }
@@ -421,6 +432,9 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
       end
       """
 
+      expected_amount1 = Archethic.Utils.to_bigint(14)
+      expected_amount2 = Archethic.Utils.to_bigint(3)
+
       assert %Transaction{
                data: %TransactionData{
                  ledger: %Ledger{
@@ -428,13 +442,13 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
                      transfers: [
                        %TokenTransfer{
                          to: ^address2,
-                         amount: 3,
+                         amount: ^expected_amount2,
                          token_address: ^token_address,
                          token_id: 4
                        },
                        %TokenTransfer{
                          to: ^address,
-                         amount: 14,
+                         amount: ^expected_amount1,
                          token_address: ^token_address,
                          token_id: 0
                        }
@@ -532,9 +546,11 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
                      address: <<0::16, :crypto.strong_rand_bytes(32)::binary>>
                    })
                  ],
-                 "contract" => %{
-                   "address" => Base.encode16(contract_address)
-                 }
+                 "contract" =>
+                   Constants.from_transaction(%Transaction{
+                     data: %TransactionData{},
+                     address: contract_address
+                   })
                })
     end
   end

--- a/test/archethic/contracts/interpreter/library/contract_test.exs
+++ b/test/archethic/contracts/interpreter/library/contract_test.exs
@@ -87,11 +87,19 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
     test "should work with float" do
       code = ~S"""
       actions triggered_by: transaction do
+        Contract.set_content 13.1
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "13.1"}} = sanitize_parse_execute(code)
+
+      code = ~S"""
+      actions triggered_by: transaction do
         Contract.set_content 13.0
       end
       """
 
-      assert %Transaction{data: %TransactionData{content: "13.0"}} = sanitize_parse_execute(code)
+      assert %Transaction{data: %TransactionData{content: "13"}} = sanitize_parse_execute(code)
     end
 
     test "should work with variable" do

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -81,19 +81,19 @@ defmodule Archethic.ContractsTest do
     end
 
     test "should return true when the inherit constraints matches the next transaction" do
-      code = """
+      address = <<0::16, :crypto.strong_rand_bytes(32)::binary>>
+
+      code = ~s"""
       condition inherit: [
         content: regex_match?("hello"),
-        uco_transfers: %{
-          "3265CCD78CD74984FAB3CC6984D30C8C82044EBBAB1A4FFFB683BDB2D8C5BCF9" => 1000000000
-        },
+        uco_transfers: %{"#{Base.encode16(address)}" => 1000000000},
         type: transfer
       ]
 
       condition transaction: []
 
       actions triggered_by: transaction do
-        add_uco_transfer to: \"3265CCD78CD74984FAB3CC6984D30C8C82044EBBAB1A4FFFB683BDB2D8C5BCF9\", amount: 1000000000
+        add_uco_transfer to: "#{Base.encode16(address)}", amount: 1000000000
         set_content "hello"
         set_type transfer
       end
@@ -114,9 +114,7 @@ defmodule Archethic.ContractsTest do
             uco: %UCOLedger{
               transfers: [
                 %Transfer{
-                  to:
-                    <<50, 101, 204, 215, 140, 215, 73, 132, 250, 179, 204, 105, 132, 211, 12, 140,
-                      130, 4, 78, 187, 171, 26, 79, 255, 182, 131, 189, 178, 216, 197, 188, 249>>,
+                  to: address,
                   amount: 1_000_000_000
                 }
               ]


### PR DESCRIPTION
# Description

**This PR is based on https://github.com/archethic-foundation/archethic-node/pull/967. To be rebased as soon as it is merged.**

1. User may now code `Contract.add_uco_transfer to: "...", amount: 1` to transfer 1 UCO (before he/she had to specify amount: 100000000 to send 1 UCO. Makes the language friendlier. 
1. Floating points mathematics are now done in BigInt so there is no floating point precision issue.
1. Since we use BigInt for maths, we loose the types of the numbers (1 + 1 == 2.0). To address this inconvenience, I updated the library to have `String.from_number/1` and `String.to_number/1` instead of `String.from_float/1`, `String.from_int/1`, `String.to_float/1`, `String.to_int/1`.

Fixes #893

_ps: I suggest to ignore `test/archethic/contracts/interpreter/condition_interpreter_test.exs` when reviewing. This is just tests adaption due to the function being stricter than before (it is a good thing)._

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests :heavy_check_mark: 
Manual tests: :grey_question: 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
