### PR TITLE
Smart Contract: `is_function_call?` bug

### DIFF
--- a/lib/archethic/contracts/interpreter/ast_helper.ex
+++ b/lib/archethic/contracts/interpreter/ast_helper.ex
@@ -135,7 +135,7 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
   """
   @spec is_function_call?(Macro.t()) :: boolean()
   def is_function_call?({{:atom, _}, _, list}) when is_list(list), do: true
-  def is_function_call?({{:., _, [{:__aliases__, _, [_]}, _]}, _, _}), do: true
+  def is_function_call?({{:., _, [{:__aliases__, _, _}, _]}, _, _}), do: true
   def is_function_call?(_), do: false
 
   @doc """

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -238,6 +238,21 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                |> ActionInterpreter.parse()
     end
 
+    test "should be able to use a function call as a parameter to a lib function" do
+      code = ~S"""
+      actions triggered_by: transaction do
+        count = List.size(Contract.get_calls())
+        Contract.set_content(count)
+      end
+      """
+
+      assert {:ok, :transaction, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionInterpreter.parse()
+    end
+
     test "should not be able to use wrong types in contract functions" do
       code = ~S"""
       actions triggered_by: transaction do


### PR DESCRIPTION
# Description

Some SC were not parsing such as the one I added in the test suite. 
This happened because there was a pattern match `[_]` on alias. This is wrong, an alias can be of any size (e.g. `[:Archethic, :Contracts, :Interpreter, :Library, :Contract]`)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test added.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
