### PR TITLE
Add json parse smart contracts

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/json.ex
+++ b/lib/archethic/contracts/interpreter/library/common/json.ex
@@ -19,7 +19,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Json do
   defdelegate to_string(term),
     to: Jason,
     as: :encode!
-  
+
   @spec parse(String.t()) :: map()
   defdelegate parse(text),
     to: Jason,
@@ -56,7 +56,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Json do
     AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
   end
 
-  def check_types(:parse, [first]) do 
+  def check_types(:parse, [first]) do
     AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
   end
 

--- a/lib/archethic/contracts/interpreter/library/common/json.ex
+++ b/lib/archethic/contracts/interpreter/library/common/json.ex
@@ -19,6 +19,11 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Json do
   defdelegate to_string(term),
     to: Jason,
     as: :encode!
+  
+  @spec parse(String.t()) :: map()
+  defdelegate parse(text),
+    to: Jason,
+    as: :decode!
 
   @spec is_valid?(String.t()) :: boolean()
   def is_valid?(str) do
@@ -48,6 +53,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Json do
   end
 
   def check_types(:is_valid?, [first]) do
+    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+  end
+
+  def check_types(:parse, [first]) do 
     AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
   end
 

--- a/lib/archethic/contracts/interpreter/library/common/json.ex
+++ b/lib/archethic/contracts/interpreter/library/common/json.ex
@@ -20,7 +20,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Json do
     to: Jason,
     as: :encode!
 
-  @spec parse(String.t()) :: map()
+  @spec parse(String.t()) :: any()
   defdelegate parse(text),
     to: Jason,
     as: :decode!

--- a/test/archethic/contracts/interpreter/library/common/json_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/json_test.exs
@@ -84,6 +84,83 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
   end
 
   # ----------------------------------------
+  describe "parse/1" do
+    test "should work with string" do
+      code =  ~S"""
+      actions triggered_by: transaction do
+        x = Json.parse("{ \"hello\": \"world\", \"foo\": \"bar\"}")
+        Contract.set_content x.hello
+      end
+      """
+      
+      assert %Transaction{data: %TransactionData{content: "world"}} =
+               sanitize_parse_execute(code)
+    end
+    
+    test "should work with integer" do
+      code =  ~S"""
+      actions triggered_by: transaction do
+        x = Json.parse("{ \"integer\": 42, \"foo\": \"bar\"}")
+        Contract.set_content x.integer
+      end
+      """
+      
+      assert %Transaction{data: %TransactionData{content: "42"}} =
+               sanitize_parse_execute(code)
+    end
+
+    test "should work with list" do
+      code =  ~S"""
+      actions triggered_by: transaction do
+        x = Json.parse("{ \"list\": [1,2,3], \"foo\": \"bar\"}")
+        Contract.set_content Json.to_string(x.list)
+      end
+      """
+      
+      assert %Transaction{data: %TransactionData{content: "[1,2,3]"}} =
+               sanitize_parse_execute(code)
+    end
+
+    test "should work with map" do
+      code =  ~S"""
+      actions triggered_by: transaction do
+        x = Json.parse("{ \"map\": {\"foo\" : \"bar\"} }")
+        Contract.set_content Json.to_string(x.map)
+      end
+      """
+      
+      assert %Transaction{data: %TransactionData{content: "{\"foo\":\"bar\"}"}} =
+               sanitize_parse_execute(code)
+    end   
+    
+    test "should work with variable" do
+      code =  ~S"""
+      actions triggered_by: transaction do
+        data = "{ \"list\": [1,2,3], \"foo\": \"bar\"}" 
+        x = Json.parse(data)
+        Contract.set_content Json.to_string(x.list)
+      end
+      """
+      
+      assert %Transaction{data: %TransactionData{content: "[1,2,3]"}} =
+               sanitize_parse_execute(code)
+    end
+    test "should work with affected variable" do
+      code =  ~S"""
+      actions triggered_by: transaction do
+        x = Json.parse("{ \"list\": [1,2,3], \"foo\": \"bar\"}")
+        y = x.list
+        Contract.set_content Json.to_string(y)
+      end
+      """
+      
+      assert %Transaction{data: %TransactionData{content: "[1,2,3]"}} =
+               sanitize_parse_execute(code)
+    end
+  end
+
+
+  # ----------------------------------------
   describe "is_valid?/1" do
     test "should work" do
       code = ~S"""

--- a/test/archethic/contracts/interpreter/library/common/json_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/json_test.exs
@@ -86,79 +86,77 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
   # ----------------------------------------
   describe "parse/1" do
     test "should work with string" do
-      code =  ~S"""
+      code = ~S"""
       actions triggered_by: transaction do
         x = Json.parse("{ \"hello\": \"world\", \"foo\": \"bar\"}")
         Contract.set_content x.hello
       end
       """
-      
-      assert %Transaction{data: %TransactionData{content: "world"}} =
-               sanitize_parse_execute(code)
+
+      assert %Transaction{data: %TransactionData{content: "world"}} = sanitize_parse_execute(code)
     end
-    
+
     test "should work with integer" do
-      code =  ~S"""
+      code = ~S"""
       actions triggered_by: transaction do
         x = Json.parse("{ \"integer\": 42, \"foo\": \"bar\"}")
         Contract.set_content x.integer
       end
       """
-      
-      assert %Transaction{data: %TransactionData{content: "42"}} =
-               sanitize_parse_execute(code)
+
+      assert %Transaction{data: %TransactionData{content: "42"}} = sanitize_parse_execute(code)
     end
 
     test "should work with list" do
-      code =  ~S"""
+      code = ~S"""
       actions triggered_by: transaction do
         x = Json.parse("{ \"list\": [1,2,3], \"foo\": \"bar\"}")
         Contract.set_content Json.to_string(x.list)
       end
       """
-      
+
       assert %Transaction{data: %TransactionData{content: "[1,2,3]"}} =
                sanitize_parse_execute(code)
     end
 
     test "should work with map" do
-      code =  ~S"""
+      code = ~S"""
       actions triggered_by: transaction do
         x = Json.parse("{ \"map\": {\"foo\" : \"bar\"} }")
         Contract.set_content Json.to_string(x.map)
       end
       """
-      
+
       assert %Transaction{data: %TransactionData{content: "{\"foo\":\"bar\"}"}} =
                sanitize_parse_execute(code)
-    end   
-    
+    end
+
     test "should work with variable" do
-      code =  ~S"""
+      code = ~S"""
       actions triggered_by: transaction do
         data = "{ \"list\": [1,2,3], \"foo\": \"bar\"}" 
         x = Json.parse(data)
         Contract.set_content Json.to_string(x.list)
       end
       """
-      
+
       assert %Transaction{data: %TransactionData{content: "[1,2,3]"}} =
                sanitize_parse_execute(code)
     end
+
     test "should work with affected variable" do
-      code =  ~S"""
+      code = ~S"""
       actions triggered_by: transaction do
         x = Json.parse("{ \"list\": [1,2,3], \"foo\": \"bar\"}")
         y = x.list
         Contract.set_content Json.to_string(y)
       end
       """
-      
+
       assert %Transaction{data: %TransactionData{content: "[1,2,3]"}} =
                sanitize_parse_execute(code)
     end
   end
-
 
   # ----------------------------------------
   describe "is_valid?/1" do

--- a/test/archethic/contracts/interpreter/library/common/json_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/json_test.exs
@@ -94,6 +94,15 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
       """
 
       assert %Transaction{data: %TransactionData{content: "world"}} = sanitize_parse_execute(code)
+
+      code = ~S"""
+      actions triggered_by: transaction do
+        Contract.set_content Json.parse("\"Whoopi Goldberg\"")
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "Whoopi Goldberg"}} =
+               sanitize_parse_execute(code)
     end
 
     test "should work with integer" do
@@ -105,6 +114,16 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
       """
 
       assert %Transaction{data: %TransactionData{content: "42"}} = sanitize_parse_execute(code)
+
+      code = ~S"""
+      actions triggered_by: transaction do
+        if Json.parse("42") == 42 do
+          Contract.set_content "ok"
+        end
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
     end
 
     test "should work with list" do
@@ -117,6 +136,17 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
 
       assert %Transaction{data: %TransactionData{content: "[1,2,3]"}} =
                sanitize_parse_execute(code)
+
+      code = ~S"""
+      actions triggered_by: transaction do
+        x = Json.parse("[1,2,3]")
+        if List.at(x, 0) == 1 do
+          Contract.set_content "ok"
+        end
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
     end
 
     test "should work with map" do
@@ -134,7 +164,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
     test "should work with variable" do
       code = ~S"""
       actions triggered_by: transaction do
-        data = "{ \"list\": [1,2,3], \"foo\": \"bar\"}" 
+        data = "{ \"list\": [1,2,3], \"foo\": \"bar\"}"
         x = Json.parse(data)
         Contract.set_content Json.to_string(x.list)
       end
@@ -155,6 +185,17 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
 
       assert %Transaction{data: %TransactionData{content: "[1,2,3]"}} =
                sanitize_parse_execute(code)
+    end
+
+    test "should not parse if parameter is not a string" do
+      code = ~S"""
+      actions triggered_by: transaction do
+        Json.parse(key: "value")
+      end
+      """
+
+      assert {:ok, sanitized_code} = Interpreter.sanitize_code(code)
+      assert {:error, _, _} = ActionInterpreter.parse(sanitized_code)
     end
   end
 


### PR DESCRIPTION
# Description

This PR adds a Json.parse/1 function to the smart contract interpreter, in link with issue #989 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with similar tests as Json.path_extract 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
