### PR TITLE
Smart Contracts: empty list should not be transformed to an empty map

### DIFF
--- a/lib/archethic/contracts/interpreter/ast_helper.ex
+++ b/lib/archethic/contracts/interpreter/ast_helper.ex
@@ -9,7 +9,7 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
 
     iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("[]")
     iex> ASTHelper.is_keyword_list?(ast)
-    true
+    false
 
     iex> {:ok, ast} = Archethic.Contracts.Interpreter.sanitize_code("[sum: 1, product: 10]")
     iex> ASTHelper.is_keyword_list?(ast)
@@ -20,7 +20,7 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
     false
   """
   @spec is_keyword_list?(Macro.t()) :: boolean()
-  def is_keyword_list?(ast) when is_list(ast) do
+  def is_keyword_list?(ast = [_ | _]) do
     Enum.all?(ast, fn
       {{:atom, bin}, _value} when is_binary(bin) ->
         true

--- a/test/archethic/contracts/interpreter/library/common/list_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/list_test.exs
@@ -42,6 +42,16 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ListTest do
 
   # ----------------------------------------
   describe "size/1" do
+    test "empty list should return 0" do
+      code = ~s"""
+      actions triggered_by: transaction do
+        Contract.set_content List.size([])
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{content: "0"}} = sanitize_parse_execute(code)
+    end
+
     test "should work" do
       code = ~s"""
       actions triggered_by: transaction do


### PR DESCRIPTION
# Description

An empty list should not be transformed to an empty map. Empty map should be create with the `Map.new()` function call.

Fixes #996

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test added to the suite.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
