### PR TITLE
Fix p2p view upgrade

### DIFF
--- a/lib/archethic/beacon_chain/subset/summary_cache.ex
+++ b/lib/archethic/beacon_chain/subset/summary_cache.ex
@@ -183,7 +183,7 @@ defmodule Archethic.BeaconChain.Subset.SummaryCache do
     try do
       {node_public_key, rest} = Utils.deserialize_public_key(rest)
       deserialize(rest, [{summary_time, slot, node_public_key} | acc])
-    catch
+    rescue
       _ ->
         deserialize(rest, [{summary_time, slot} | acc])
     end

--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -76,14 +76,14 @@ defmodule Archethic.DB do
                  average_availability :: float(), availability_update :: DateTime.t(),
                  network_patch :: binary()}
               )
-            ) ::
-              :ok
+            ) :: :ok
 
-  @callback get_last_p2p_summaries() :: %{
-              (node_public_key :: Crypto.key()) =>
-                {available? :: boolean(), average_availability :: float(),
-                 network_patch :: binary() | nil}
-            }
+  @callback get_last_p2p_summaries() ::
+              list(
+                {node_public_key :: Crypto.key(), available? :: boolean(),
+                 average_availability :: float(), availability_update :: DateTime.t(),
+                 network_patch :: String.t() | nil}
+              )
 
   @callback get_bootstrap_info(key :: String.t()) :: String.t() | nil
   @callback set_bootstrap_info(key :: String.t(), value :: String.t()) :: :ok

--- a/lib/archethic/db/embedded_impl.ex
+++ b/lib/archethic/db/embedded_impl.ex
@@ -350,13 +350,12 @@ defmodule Archethic.DB.EmbeddedImpl do
   @doc """
   Register a new node view from the last self-repair cycle
   """
-  @spec get_last_p2p_summaries() :: %{
-          (node_public_key :: Crypto.key()) => {
-            available? :: boolean(),
-            average_availability :: float(),
-            network_patch :: binary() | nil
-          }
-        }
+  @spec get_last_p2p_summaries() ::
+          list(
+            {node_public_key :: Crypto.key(), available? :: boolean(),
+             average_availability :: float(), availability_update :: DateTime.t(),
+             network_patch :: String.t() | nil}
+          )
   defdelegate get_last_p2p_summaries, to: P2PView, as: :get_views
 
   @doc """

--- a/lib/archethic/db/embedded_impl/p2p_view.ex
+++ b/lib/archethic/db/embedded_impl/p2p_view.ex
@@ -23,14 +23,13 @@ defmodule Archethic.DB.EmbeddedImpl.P2PView do
   @doc """
   Return the last node views from the last self-repair cycle
   """
-  @spec get_views :: %{
-          (node_public_key :: Crypto.key()) => {
-            available? :: boolean(),
-            average_availability :: float(),
-            network_patch :: String.t() | nil
-          }
-        }
-  def get_views do
+  @spec get_views() ::
+          list(
+            {node_public_key :: Crypto.key(), available? :: boolean(),
+             average_availability :: float(), availability_update :: DateTime.t(),
+             network_patch :: String.t() | nil}
+          )
+  def get_views() do
     GenServer.call(__MODULE__, :get_node_views)
   end
 

--- a/lib/archethic/db/embedded_impl/p2p_view.ex
+++ b/lib/archethic/db/embedded_impl/p2p_view.ex
@@ -118,4 +118,22 @@ defmodule Archethic.DB.EmbeddedImpl.P2PView do
 
     deserialize(rest, [view | acc])
   end
+
+  def code_change("1.0.7", state = %{views: nodes_view, filepath: filepath}, _) do
+    new_nodes_view =
+      Enum.map(nodes_view, fn
+        {node_key, available?, avg_availability, availability_update} ->
+          {node_key, available?, avg_availability, availability_update, nil}
+
+        view ->
+          view
+      end)
+
+    nodes_view_bin = serialize(new_nodes_view, <<>>)
+    File.write!(filepath, nodes_view_bin, [:binary])
+
+    {:ok, %{state | views: new_nodes_view}}
+  end
+
+  def code_change(_, state, _), do: {:ok, state}
 end


### PR DESCRIPTION
# Description

This PR adds a function `code_change` in the P2PView genserver to update the backup file with the new serialization

Also fix the backward compatibility when deserializing SummaryCache backup file

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Create a release from master branch
- Switch to this PR branch and create a new release
- Apply the release at the beginning of a summary
- Stop the node and restart it, it should restart without error with the good P2P view and with the summary cache filled with all slots

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
