### PR TITLE
Improve migration script

### DIFF
--- a/lib/archethic/application.ex
+++ b/lib/archethic/application.ex
@@ -108,7 +108,7 @@ defmodule Archethic.Application do
   end
 
   def start_phase(:migrate, :normal, _options) do
-    Application.spec(:archethic, :vsn) |> Migrate.run()
+    Application.spec(:archethic, :vsn) |> Migrate.run(false)
   end
 
   defp try_open_port(nil), do: :ok

--- a/lib/archethic/beacon_chain/slot.ex
+++ b/lib/archethic/beacon_chain/slot.ex
@@ -647,7 +647,8 @@ defmodule Archethic.BeaconChain.Slot do
           fn attestation = %ReplicationAttestation{transaction_summary: summary} ->
             new_summary = TransactionSummary.transform("1.0.8", summary)
             %ReplicationAttestation{attestation | transaction_summary: new_summary}
-          end
+          end,
+          max_concurrency: System.schedulers_online() * 10
         )
         |> Stream.filter(&match?({:ok, _}, &1))
         |> Enum.map(fn {:ok, attestation} -> attestation end)

--- a/lib/mix/tasks/migrate.ex
+++ b/lib/mix/tasks/migrate.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Archethic.Migrate do
 
   require Logger
 
-  @env Mix.env()
+  @env if Mix.env() == :test, do: "test", else: "prod"
 
   @doc """
   Run migration available migration scripts since last updated version

--- a/lib/release/call_migrate_script.ex
+++ b/lib/release/call_migrate_script.ex
@@ -13,7 +13,7 @@ defmodule Archethic.Release.CallMigrateScript do
   def down(_, _, _, instructions, _), do: instructions
 
   defp add_migrate_script_call(new_version, instructions) do
-    call_instruction = {:apply, {Migrate, :run, [new_version]}}
+    call_instruction = {:apply, {Migrate, :run, [new_version, true]}}
 
     instructions ++ [call_instruction]
   end


### PR DESCRIPTION
# Description

This PR makes the migration script running asynchronously. It prevent the erlang upgrade process to wait for the end of migration that can take a while.

Also improve the max_concurrency option in `async_stream` process to speed up the migration task

Redirect migration script folder to prod when running a release from dev en

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
