### PR TITLE
Fix P2P benchmark

### DIFF
--- a/lib/archethic/p2p/message_envelop.ex
+++ b/lib/archethic/p2p/message_envelop.ex
@@ -118,7 +118,9 @@ defmodule Archethic.P2P.MessageEnvelop do
   def decode_raw_message(<<message_id::32, _::8, curve_id::8, _origin_id::8, rest::bitstring>>) do
     key_size = Crypto.key_size(curve_id)
 
-    <<_public_key::binary-size(key_size), encrypted_message::bitstring>> = rest
+    <<_public_key::binary-size(key_size), signature_size::8,
+      _signature::binary-size(signature_size), encrypted_message::bitstring>> = rest
+
     {message_id, encrypted_message}
   end
 end

--- a/lib/mix/tasks/regression.ex
+++ b/lib/mix/tasks/regression.ex
@@ -26,6 +26,8 @@ defmodule Mix.Tasks.Archethic.Regression do
 
   @impl Mix.Task
   def run(args) do
+    Application.ensure_all_started(:telemetry)
+
     case OptionParser.parse!(args,
            strict: [
              help: :boolean,


### PR DESCRIPTION
# Description

Fixes error while running P2P benchmark:
- message decryption failure (due to bad deserialization)
- telemetry application not started

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run benchmark command `mix archethic.regression --bench localhost`

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
