### PR TITLE
Smart Contracts: Catch the invalid elixir syntax error in smart contracts

### DIFF
--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -41,6 +41,9 @@ defmodule Archethic.Contracts.Interpreter do
               |> check_contract_blocks()
           end
 
+        {:error, :invalid_syntax} ->
+          {:error, "Parse error: invalid language syntax"}
+
         {:error, {[line: line, column: column], _msg_info, _token}} ->
           {:error, "Parse error at line #{line} column #{column}"}
       end
@@ -77,9 +80,16 @@ defmodule Archethic.Contracts.Interpreter do
   """
   @spec sanitize_code(binary()) :: {:ok, Macro.t()} | {:error, any()}
   def sanitize_code(code) when is_binary(code) do
-    code
-    |> String.trim()
-    |> Code.string_to_quoted(static_atoms_encoder: &atom_encoder/2)
+    try do
+      code
+      |> String.trim()
+      |> Code.string_to_quoted(static_atoms_encoder: &atom_encoder/2)
+    rescue
+      _ ->
+        # catch the non-elixir syntax here
+        # example [key:value] is not valid
+        {:error, :invalid_syntax}
+    end
   end
 
   @doc """

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -110,6 +110,17 @@ defmodule Archethic.Contracts.InterpreterTest do
                """
                |> Interpreter.parse()
     end
+
+    test "should return an human readable error if syntax is not elixir-valid" do
+      assert {:error, "Parse error: invalid language syntax"} =
+               """
+               @version 1
+               actions triggered_by:transaction do
+                 x = "missing space above"
+               end
+               """
+               |> Interpreter.parse()
+    end
   end
 
   describe "parse code v0" do


### PR DESCRIPTION
# Description

When a smart contract was using non elixir-valid syntax, an error was raised and the start_mining process crashed without return an error to the end user. 

Following log happened when omitting a space in a keyword list: `triggered_by:transaction`
```
2023-05-03 12:45:48.137 [error] GenServer #PID<0.9153.0> terminating
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an atom

    :erlang.atom_to_list({:atom, "triggered_by"})
    (elixir 1.14.1) src/elixir_tokenizer.erl:669: :elixir_tokenizer.tokenize/5
    (elixir 1.14.1) src/elixir.erl:371: :elixir.string_to_tokens/5
    (elixir 1.14.1) lib/code.ex:965: Code.string_to_quoted/2
    (archethic 1.0.8-rc1) lib/archethic/contracts/interpreter.ex:32: Archethic.Contracts.Interpreter.parse/1
    (archethic 1.0.8-rc1) lib/archethic/mining/pending_transaction_validation.ex:137: Archethic.Mining.PendingTransactionValidation.validate_contract/1
    (archethic 1.0.8-rc1) lib/archethic/mining/pending_transaction_validation.ex:55: Archethic.Mining.PendingTransactionValidation.validate/2
    (archethic 1.0.8-rc1) lib/archethic/mining/standalone_workflow.ex:118: Archethic.Mining.StandaloneWorkflow.handle_continue/2
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- 
# How Has This Been Tested?

Manual test & unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
