### PR TITLE
Smart Contracts: Make the 'condition inherit' block mandatory

### DIFF
--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -15,11 +15,7 @@ defmodule Archethic.Contracts.Contract do
 
   defstruct triggers: %{},
             version: 0,
-            conditions: %{
-              transaction: %Conditions{},
-              inherit: %Conditions{},
-              oracle: %Conditions{}
-            },
+            conditions: %{},
             constants: %Constants{},
             next_transaction: %Transaction{data: %TransactionData{}}
 

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -485,11 +485,7 @@ defmodule Archethic.Contracts.Interpreter do
   end
 
   defp parse_contract(1, ast) do
-    # we need to force the initialization of conditions to an empty map
-    # to be able to detect that user did not omit some condition blocks
-    initial_contract = %Contract{conditions: %{}}
-
-    case parse_ast_block(ast, initial_contract) do
+    case parse_ast_block(ast, %Contract{}) do
       {:ok, contract} ->
         {:ok, %{contract | version: 1}}
 

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -486,7 +486,7 @@ defmodule Archethic.Contracts.Interpreter do
 
   defp parse_contract(1, ast) do
     # we need to force the initialization of conditions to an empty map
-    # to be able to detect that user did not omit the condition inherit block
+    # to be able to detect that user did not omit some condition blocks
     initial_contract = %Contract{conditions: %{}}
 
     case parse_ast_block(ast, initial_contract) do
@@ -539,15 +539,23 @@ defmodule Archethic.Contracts.Interpreter do
   # -----------------------------------------
   # contract validation
   # -----------------------------------------
-
   defp check_contract_blocks({:error, reason}), do: {:error, reason}
 
-  defp check_contract_blocks({:ok, contract = %Contract{conditions: conditions}}) do
-    # Only inherit condition are mandatory
-    if Map.has_key?(conditions, :inherit) do
-      {:ok, contract}
-    else
-      {:error, "missing inherit conditions"}
+  defp check_contract_blocks(
+         {:ok, contract = %Contract{triggers: triggers, conditions: conditions}}
+       ) do
+    cond do
+      Map.has_key?(triggers, :transaction) and !Map.has_key?(conditions, :transaction) ->
+        {:error, "missing 'condition transaction' block"}
+
+      Map.has_key?(triggers, :oracle) and !Map.has_key?(conditions, :oracle) ->
+        {:error, "missing 'condition oracle' block"}
+
+      !Map.has_key?(conditions, :inherit) ->
+        {:error, "missing 'condition inherit' block"}
+
+      true ->
+        {:ok, contract}
     end
   end
 end

--- a/lib/archethic/transaction_chain/mem_tables_loader.ex
+++ b/lib/archethic/transaction_chain/mem_tables_loader.ex
@@ -67,13 +67,19 @@ defmodule Archethic.TransactionChain.MemTablesLoader do
   defp handle_pending_transaction(%Transaction{data: %TransactionData{code: ""}}), do: :ok
 
   defp handle_pending_transaction(tx = %Transaction{address: address}) do
-    %Contract{conditions: %{transaction: transaction_conditions}} = Contract.from_transaction!(tx)
+    %Contract{conditions: conditions} = Contract.from_transaction!(tx)
 
-    # TODO: improve the criteria of pending detection
-    if ContractConditions.empty?(transaction_conditions) do
-      :ok
-    else
-      PendingLedger.add_address(address)
+    case Map.get(conditions, :transaction) do
+      nil ->
+        :ok
+
+      transaction_conditions ->
+        # TODO: improve the criteria of pending detection
+        if ContractConditions.empty?(transaction_conditions) do
+          :ok
+        else
+          PendingLedger.add_address(address)
+        end
     end
   end
 

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -119,8 +119,19 @@ defmodule Archethic.Contracts.InterpreterTest do
                |> Interpreter.parse()
     end
 
+    test "should return an human readable error if syntax is not elixir-valid" do
+      assert {:error, "Parse error: invalid language syntax"} =
+               """
+               @version 1
+               actions triggered_by:transaction do
+                x = "missing space above"
+               end
+               """
+               |> Interpreter.parse()
+    end
+
     test "should return an human readable error 'condition inherit' block is missing" do
-      assert {:error, "missing inherit conditions"} =
+      assert {:error, "missing 'condition inherit' block"} =
                """
                @version 1
                condition transaction: []
@@ -131,12 +142,25 @@ defmodule Archethic.Contracts.InterpreterTest do
                |> Interpreter.parse()
     end
 
-    test "should return an human readable error if syntax is not elixir-valid" do
-      assert {:error, "Parse error: invalid language syntax"} =
+    test "should return an human readable error 'condition transaction' block is missing" do
+      assert {:error, "missing 'condition transaction' block"} =
                """
                @version 1
-               actions triggered_by:transaction do
-                 x = "missing space above"
+               condition inherit: []
+               actions triggered_by: transaction do
+                Contract.set_content "snobbish chameleon"
+               end
+               """
+               |> Interpreter.parse()
+    end
+
+    test "should return an human readable error 'condition oracle' block is missing" do
+      assert {:error, "missing 'condition oracle' block"} =
+               """
+               @version 1
+               condition inherit: []
+               actions triggered_by: oracle do
+                Contract.set_content "wise cow"
                end
                """
                |> Interpreter.parse()
@@ -375,6 +399,8 @@ defmodule Archethic.Contracts.InterpreterTest do
           content: true
         ]
 
+        condition transaction: []
+
         actions triggered_by: transaction do
           x = 10 / 0
           Contract.set_content x
@@ -408,6 +434,8 @@ defmodule Archethic.Contracts.InterpreterTest do
         condition inherit: [
           content: true
         ]
+
+        condition transaction: []
 
         actions triggered_by: transaction do
           Contract.add_uco_transfer amount: -1, to: "0000BFEF73346D20771614449D6BE9C705BF314067A0CF0ACBBF5E617EF5C978D0A1"

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -47,6 +47,9 @@ defmodule Archethic.Contracts.InterpreterTest do
       assert {:error, _} =
                """
                @version 1
+               condition inherit: [
+                content: true
+               ]
                condition transaction: [
                 uco_transfers: List.size() > 0
                ]
@@ -64,10 +67,12 @@ defmodule Archethic.Contracts.InterpreterTest do
       assert {:ok, %Contract{}} =
                """
                @version 1
+               condition inherit: [
+                content: true
+               ]
                condition transaction: [
                 uco_transfers: List.size() > 0
                ]
-
                actions triggered_by: transaction do
                 Contract.set_content "hello"
                end
@@ -76,9 +81,10 @@ defmodule Archethic.Contracts.InterpreterTest do
     end
 
     test "should return an human readable error if lib fn is called with bad arg" do
-      assert {:error, "invalid function arguments - List.empty?(12) - L4"} =
+      assert {:error, "invalid function arguments - List.empty?(12) - L5"} =
                """
                @version 1
+               condition inherit: []
                condition transaction: []
                actions triggered_by: transaction do
                  x = List.empty?(12)
@@ -88,9 +94,10 @@ defmodule Archethic.Contracts.InterpreterTest do
     end
 
     test "should return an human readable error if lib fn is called with bad arity" do
-      assert {:error, "invalid function arity - List.empty?([1], \"foobar\") - L4"} =
+      assert {:error, "invalid function arity - List.empty?([1], \"foobar\") - L5"} =
                """
                @version 1
+               condition inherit: []
                condition transaction: []
                actions triggered_by: transaction do
                  x = List.empty?([1], "foobar")
@@ -100,12 +107,25 @@ defmodule Archethic.Contracts.InterpreterTest do
     end
 
     test "should return an human readable error if lib fn does not exists" do
-      assert {:error, "unknown function - List.non_existing([1, 2, 3]) - L4"} =
+      assert {:error, "unknown function - List.non_existing([1, 2, 3]) - L5"} =
+               """
+               @version 1
+               condition inherit: []
+               condition transaction: []
+               actions triggered_by: transaction do
+                 x = List.non_existing([1,2,3])
+               end
+               """
+               |> Interpreter.parse()
+    end
+
+    test "should return an human readable error 'condition inherit' block is missing" do
+      assert {:error, "missing inherit conditions"} =
                """
                @version 1
                condition transaction: []
                actions triggered_by: transaction do
-                 x = List.non_existing([1,2,3])
+                Contract.set_content "symptomatic grizzly bear"
                end
                """
                |> Interpreter.parse()
@@ -143,6 +163,9 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should return the contract if format is OK" do
       assert {:ok, %Contract{}} =
                """
+               condition inherit: [
+                content: true
+               ]
                condition transaction: [
                 uco_transfers: size() > 0
                ]

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -21,6 +21,8 @@ defmodule Archethic.ContractsTest do
         content: "hello"
       ]
 
+      condition transaction: []
+
       actions triggered_by: transaction do
         add_uco_transfer to: "3265CCD78CD74984FAB3CC6984D30C8C82044EBBAB1A4FFFB683BDB2D8C5BCF9", amount: 1000000000
       end
@@ -58,6 +60,8 @@ defmodule Archethic.ContractsTest do
       condition inherit: [
         content: regex_match?(\"hello\")
       ]
+
+      condition transaction: []
 
       actions triggered_by: transaction do
         set_content "hello"

--- a/test/archethic/transaction_chain/mem_tables_loader_test.exs
+++ b/test/archethic/transaction_chain/mem_tables_loader_test.exs
@@ -43,6 +43,8 @@ defmodule Archethic.TransactionChain.MemTablesLoaderTest do
                  previous_public_key: "Contract1",
                  data: %TransactionData{
                    code: """
+                   condition inherit: []
+
                    condition transaction: [
                      content: regex_match?(\"hello\")
                    ]


### PR DESCRIPTION
# Description

The `condition inherit` always were mandatory, but there was a bug in the code. 
This resulted in the ability to create smart contracts without the block but the contracts were unable to produce any next_tx because they would all fail the inherit constraints. (empty condition inherit block ==> refusing all transactions).

ps: the `condition inherit` block will become optional in a later release.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test 
![Screenshot_2023-05-03_18-17-35](https://user-images.githubusercontent.com/74045243/235977627-a302606f-df80-4386-9f49-89ab104e4cbe.png)
+ Unit test added


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
