### PR TITLE
Smart Contracts: Refactor the next_tx changes detection to be able to clear the code

### DIFF
--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -2,6 +2,8 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
   use ArchethicCase
   use ExUnitProperties
 
+  import ArchethicCase
+
   alias Archethic.Contracts.ContractConstants, as: Constants
   alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.ActionInterpreter
@@ -680,7 +682,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       end
       """
 
-      assert nil == sanitize_parse_execute(code)
+      assert %Transaction{data: %TransactionData{content: ""}} = sanitize_parse_execute(code)
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -1004,6 +1006,26 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                })
     end
 
+    test "should keep the code by default" do
+      code = ~s"""
+      actions triggered_by: transaction do
+        Contract.set_content("exotic crow")
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{code: ^code}} = sanitize_parse_execute(code)
+    end
+
+    test "should be able to clear the code" do
+      code = ~s"""
+      actions triggered_by: transaction do
+        Contract.set_code("")
+      end
+      """
+
+      assert %Transaction{data: %TransactionData{code: ""}} = sanitize_parse_execute(code)
+    end
+
     test "maths are OK" do
       code = ~s"""
       actions triggered_by: transaction do
@@ -1189,12 +1211,5 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
               [_real, decimals] ->
                 String.length(decimals) <= 8
             end)
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
-    end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/chain_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/chain_test.exs
@@ -5,9 +5,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Common.Chain
 
   alias Archethic.Crypto
@@ -141,13 +140,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
 
       assert %Transaction{data: %TransactionData{content: content}} = sanitize_parse_execute(code)
       assert content == Base.encode16(genesis_pub_key)
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/crypto_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/crypto_test.exs
@@ -5,9 +5,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CryptoTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Common.Crypto
 
   alias Archethic.TransactionChain.Transaction
@@ -43,13 +42,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CryptoTest do
 
       assert %Transaction{data: %TransactionData{content: content}} = sanitize_parse_execute(code)
       assert content == Base.encode16(:crypto.hash(:sha512, text))
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/json_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/json_test.exs
@@ -5,9 +5,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Common.Json
 
   alias Archethic.TransactionChain.Transaction
@@ -194,8 +193,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
       end
       """
 
-      assert {:ok, sanitized_code} = Interpreter.sanitize_code(code)
-      assert {:error, _, _} = ActionInterpreter.parse(sanitized_code)
+      assert {:error, _, _} = sanitize_parse_execute(code)
     end
   end
 
@@ -212,13 +210,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
       """
 
       assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/list_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/list_test.exs
@@ -5,9 +5,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ListTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Common.List
 
   alias Archethic.TransactionChain.Transaction
@@ -195,13 +194,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ListTest do
 
       assert %Transaction{data: %TransactionData{content: "Emma, Joseph, Emily"}} =
                sanitize_parse_execute(code)
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/map_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/map_test.exs
@@ -5,9 +5,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.MapTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Common.Map
 
   alias Archethic.TransactionChain.Transaction
@@ -136,13 +135,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.MapTest do
       """
 
       assert %Transaction{data: %TransactionData{content: "[1,2]"}} = sanitize_parse_execute(code)
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/regex_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/regex_test.exs
@@ -5,9 +5,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.RegexTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Common.Regex
 
   alias Archethic.TransactionChain.Transaction
@@ -100,13 +99,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.RegexTest do
 
       assert %Transaction{data: %TransactionData{content: "[[\"Michael\",\"12\"]]"}} =
                sanitize_parse_execute(code)
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/string_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/string_test.exs
@@ -5,9 +5,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Common.String
 
   alias Archethic.TransactionChain.Transaction
@@ -133,13 +132,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
       """
 
       assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/time_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/time_test.exs
@@ -5,9 +5,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Common.Time
 
   alias Archethic.TransactionChain.Transaction
@@ -32,13 +31,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
 
       # we validate the test if now is approximately now
       assert String.to_integer(timestamp) - now < 10
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/token_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/token_test.exs
@@ -5,9 +5,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TokenTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Common.Token
 
   alias Archethic.Crypto
@@ -70,13 +69,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TokenTest do
 
       assert %Transaction{data: %TransactionData{content: content}} = sanitize_parse_execute(code)
       assert content == token_id
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/contract_test.exs
+++ b/test/archethic/contracts/interpreter/library/contract_test.exs
@@ -5,10 +5,9 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
   """
 
   use ArchethicCase
+  import ArchethicCase
 
   alias Archethic.Contracts.ContractConstants, as: Constants
-  alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.Library.Contract
 
   alias Archethic.TransactionChain.Transaction
@@ -614,13 +613,6 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
                      address: contract_address
                    })
                })
-    end
-  end
-
-  defp sanitize_parse_execute(code, constants \\ %{}) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
-      ActionInterpreter.execute(action_ast, constants)
     end
   end
 end

--- a/test/support/contract_factory.ex
+++ b/test/support/contract_factory.ex
@@ -1,6 +1,9 @@
 defmodule Archethic.ContractFactory do
   @moduledoc false
 
+  alias Archethic.Contracts.ContractConstants, as: Constants
+  alias Archethic.TransactionFactory
+
   def valid_version1_contract(opts \\ []) do
     code = ~S"""
     condition inherit: [
@@ -40,5 +43,23 @@ defmodule Archethic.ContractFactory do
       set_content "hello"
     end
     """
+  end
+
+  def append_contract_constant(constants, code, content \\ "") do
+    if Map.has_key?(constants, "contract") do
+      constants
+    else
+      Map.put(
+        constants,
+        "contract",
+        Constants.from_transaction(
+          TransactionFactory.create_valid_transaction([],
+            type: :contract,
+            code: code,
+            content: content
+          )
+        )
+      )
+    end
   end
 end

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -14,6 +14,11 @@ defmodule ArchethicCase do
   alias Archethic.Governance.Pools.MemTable, as: PoolsMemTable
   alias Archethic.OracleChain.MemTable, as: OracleMemTable
   alias Archethic.P2P.MemTable, as: P2PMemTable
+
+  alias Archethic.ContractFactory
+  alias Archethic.Contracts.Interpreter
+  alias Archethic.Contracts.Interpreter.ActionInterpreter
+
   import Mox
 
   def current_protocol_version(), do: Mining.protocol_version()
@@ -245,5 +250,15 @@ defmodule ArchethicCase do
   # sugar for readability
   def expect_not(mock, function_name, function) do
     expect(mock, function_name, 0, function)
+  end
+
+  def sanitize_parse_execute(code, constants \\ %{}) do
+    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
+         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
+      ActionInterpreter.execute(
+        action_ast,
+        constants |> ContractFactory.append_contract_constant(code)
+      )
+    end
   end
 end

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -26,11 +26,12 @@ defmodule Archethic.TransactionFactory do
     seed = Keyword.get(opts, :seed, "seed")
     index = Keyword.get(opts, :index, 0)
     content = Keyword.get(opts, :content, "")
+    code = Keyword.get(opts, :code, "")
 
     timestamp =
       Keyword.get(opts, :timestamp, DateTime.utc_now()) |> DateTime.truncate(:millisecond)
 
-    tx = Transaction.new(type, %TransactionData{content: content}, seed, index)
+    tx = Transaction.new(type, %TransactionData{content: content, code: code}, seed, index)
 
     ledger_operations =
       %LedgerOperations{


### PR DESCRIPTION
# Description

This is required for #929. I extracted this PR from there. 

**Before:**
We used to initialize the `next_tx` with an empty Transaction. Then at the end of contract execution, we check if the `next_tx` was different than at the initialization. This was not good because we could not detect someone that wanted to clear the code: `Contract.set_code("")`. 

**After:**
We added a boolean flag to detect the user used a function that would modify the `next_tx`. We also initialize the `next_tx` with current contract `code` & `ownerships` (instead of setting these after contract execution).  The change does not impact the legacy interpreter.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual tests & unit tests pass

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
