### PR TITLE
Fix service error when not data is fetched

### DIFF
--- a/lib/archethic/oracle_chain/services.ex
+++ b/lib/archethic/oracle_chain/services.ex
@@ -15,7 +15,7 @@ defmodule Archethic.OracleChain.Services do
       {service, handler.fetch()}
     end)
     |> Enum.filter(fn
-      {service, {:ok, data}} ->
+      {service, {:ok, data}} when map_size(data) > 0 ->
         Logger.debug("Oracle data for #{service}: #{inspect(data)}")
 
         previous_digest =
@@ -30,6 +30,13 @@ defmodule Archethic.OracleChain.Services do
           |> Crypto.hash()
 
         new_digest != previous_digest
+
+      {service, {:ok, _data}} ->
+        Logger.warning(
+          "Cannot request the Oracle provider #{service} - reason: no value returned by the service"
+        )
+
+        false
 
       {service, {:error, reason}} ->
         Logger.warning(

--- a/lib/archethic/oracle_chain/services.ex
+++ b/lib/archethic/oracle_chain/services.ex
@@ -31,7 +31,7 @@ defmodule Archethic.OracleChain.Services do
 
         new_digest != previous_digest
 
-      {service, reason} ->
+      {service, {:error, reason}} ->
         Logger.warning(
           "Cannot request the Oracle provider #{service} - reason: #{inspect(reason)}"
         )

--- a/lib/archethic/oracle_chain/services/uco_price.ex
+++ b/lib/archethic/oracle_chain/services/uco_price.ex
@@ -50,7 +50,11 @@ defmodule Archethic.OracleChain.Services.UCOPrice do
         Map.put(acc, currency, price)
       end)
 
-    {:ok, prices}
+    if prices == %{} do
+      {:error, "no data fetched from any service"}
+    else
+      {:ok, prices}
+    end
   end
 
   defp agregate_providers_data(provider_results, acc) do
@@ -71,8 +75,8 @@ defmodule Archethic.OracleChain.Services.UCOPrice do
   @spec verify?(%{required(String.t()) => any()}) :: boolean
   def verify?(prices_prior = %{}) do
     case fetch() do
-      {:ok, prices_now} when prices_now == %{} ->
-        Logger.error("Cannot fetch UCO price - reason: no data from any service.")
+      {:error, reason} ->
+        Logger.error("Cannot fetch UCO price - reason: #{reason}.")
         false
 
       {:ok, prices_now} ->

--- a/test/archethic/oracle_chain/services_test.exs
+++ b/test/archethic/oracle_chain/services_test.exs
@@ -33,6 +33,15 @@ defmodule Archethic.OracleChain.ServicesTest do
       assert %{uco: %{"eur" => 0.20, "usd" => 0.12}} =
                Services.fetch_new_data(%{"uco" => %{"eur" => 0.19, "usd" => 0.15}})
     end
+
+    test "should return not return new data when the service return an error" do
+      MockUCOPrice
+      |> expect(:fetch, fn ->
+        {:error, "error reason"}
+      end)
+
+      assert %{} = Services.fetch_new_data(%{"uco" => %{"eur" => 0.19, "usd" => 0.15}})
+    end
   end
 
   test "verify_correctness?/1 should true when the data is correct" do

--- a/test/archethic/oracle_chain/services_test.exs
+++ b/test/archethic/oracle_chain/services_test.exs
@@ -42,6 +42,15 @@ defmodule Archethic.OracleChain.ServicesTest do
 
       assert %{} = Services.fetch_new_data(%{"uco" => %{"eur" => 0.19, "usd" => 0.15}})
     end
+
+    test "should return not return new data when the service return an empty map" do
+      MockUCOPrice
+      |> expect(:fetch, fn ->
+        {:ok, %{}}
+      end)
+
+      assert %{} = Services.fetch_new_data(%{"uco" => %{"eur" => 0.19, "usd" => 0.15}})
+    end
   end
 
   test "verify_correctness?/1 should true when the data is correct" do


### PR DESCRIPTION
# Description

There is a issue when any service return a value, the scheduler request for the new datas and the services return a map `%{"uco" => %{}}`
So the oracle scheduler create a new transaction with no data for a service which lead to multiple errors afterward.

This PR fixes it, when a service don't have any value, it return an error and this service is not added to the final map of all the services. Then if all services return an error, the oracle scheduler receive an empty map, so no transaction is created

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
