### PR TITLE
Smart Contracts: determinist Time.now()

### DIFF
--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -152,13 +152,17 @@ defmodule Archethic.Contracts.Interpreter do
         {:error, :invalid_triggers_execution}
 
       trigger_code ->
+        timestamp_now =
+          time_now(trigger_type, maybe_trigger_tx)
+          |> DateTime.to_unix()
+
         do_execute(
           trigger_type,
           trigger_code,
           contract,
           maybe_trigger_tx,
           calls,
-          time_now(trigger_type, maybe_trigger_tx),
+          timestamp_now,
           opts
         )
     end
@@ -265,22 +269,22 @@ defmodule Archethic.Contracts.Interpreter do
          },
          trigger_tx = %Transaction{},
          calls,
-         datetime_now,
+         timestamp_now,
          opts
        ) do
     constants = %{
       "transaction" => Constants.from_transaction(trigger_tx),
       "contract" => contract_constants,
-      "_time_now" => datetime_now
+      "_time_now" => timestamp_now
     }
 
     if valid_conditions?(version, conditions.transaction, constants) do
-      case execute_trigger(version, trigger_code, contract, trigger_tx, calls, datetime_now) do
+      case execute_trigger(version, trigger_code, contract, trigger_tx, calls, timestamp_now) do
         nil ->
           {:ok, nil}
 
         next_tx ->
-          if valid_inherit_condition?(contract, next_tx, datetime_now, opts) do
+          if valid_inherit_condition?(contract, next_tx, timestamp_now, opts) do
             {:ok, next_tx}
           else
             {:error, :invalid_inherit_constraints}
@@ -303,22 +307,22 @@ defmodule Archethic.Contracts.Interpreter do
          },
          trigger_tx = %Transaction{},
          calls,
-         datetime_now,
+         timestamp_now,
          opts
        ) do
     constants = %{
       "transaction" => Constants.from_transaction(trigger_tx),
       "contract" => contract_constants,
-      "_time_now" => datetime_now
+      "_time_now" => timestamp_now
     }
 
     if valid_conditions?(version, conditions.oracle, constants) do
-      case execute_trigger(version, trigger_code, contract, trigger_tx, calls, datetime_now) do
+      case execute_trigger(version, trigger_code, contract, trigger_tx, calls, timestamp_now) do
         nil ->
           {:ok, nil}
 
         next_tx ->
-          if valid_inherit_condition?(contract, next_tx, datetime_now, opts) do
+          if valid_inherit_condition?(contract, next_tx, timestamp_now, opts) do
             {:ok, next_tx}
           else
             {:error, :invalid_inherit_constraints}
@@ -335,15 +339,15 @@ defmodule Archethic.Contracts.Interpreter do
          contract = %Contract{version: version},
          nil,
          calls,
-         datetime_now,
+         timestamp_now,
          opts
        ) do
-    case execute_trigger(version, trigger_code, contract, nil, calls, datetime_now) do
+    case execute_trigger(version, trigger_code, contract, nil, calls, timestamp_now) do
       nil ->
         {:ok, nil}
 
       next_tx ->
-        if valid_inherit_condition?(contract, next_tx, datetime_now, opts) do
+        if valid_inherit_condition?(contract, next_tx, timestamp_now, opts) do
           {:ok, next_tx}
         else
           {:error, :invalid_inherit_constraints}
@@ -357,7 +361,7 @@ defmodule Archethic.Contracts.Interpreter do
          contract,
          maybe_trigger_tx,
          calls,
-         datetime_now
+         timestamp_now
        ) do
     constants_trigger = %{
       "calls" => Enum.map(calls, &Constants.from_transaction/1),
@@ -371,7 +375,7 @@ defmodule Archethic.Contracts.Interpreter do
             Constants.from_transaction(trigger_tx)
         end,
       "contract" => contract.constants.contract,
-      "_time_now" => datetime_now
+      "_time_now" => timestamp_now
     }
 
     execute_trigger_code(version, trigger_code, constants_trigger)
@@ -384,7 +388,7 @@ defmodule Archethic.Contracts.Interpreter do
            constants: %{contract: contract_constants}
          },
          next_tx,
-         datetime_now,
+         timestamp_now,
          opts
        ) do
     if Keyword.get(opts, :skip_inherit_check?, false) do
@@ -393,7 +397,7 @@ defmodule Archethic.Contracts.Interpreter do
       constants_inherit = %{
         "previous" => contract_constants,
         "next" => Constants.from_transaction(next_tx),
-        "_time_now" => datetime_now
+        "_time_now" => timestamp_now
       }
 
       valid_conditions?(version, condition_inherit, constants_inherit)

--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -62,6 +62,8 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
     #   - "calls": the transactions that called this exact contract version
     #   - "contract": current contract transaction
     #   - "transaction": the incoming transaction (when trigger=transaction|oracle)
+    #   - "_time_now": the time returned by Time.now()
+
     Scope.init(
       constants
       |> Map.put("next_transaction", initial_next_tx)

--- a/lib/archethic/contracts/interpreter/library/common/time.ex
+++ b/lib/archethic/contracts/interpreter/library/common/time.ex
@@ -11,7 +11,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Time do
   @spec now() :: integer()
   def now() do
     Scope.read_global(["_time_now"])
-    |> DateTime.to_unix()
   end
 
   @spec check_types(atom(), list()) :: boolean()

--- a/lib/archethic/contracts/interpreter/library/common/time.ex
+++ b/lib/archethic/contracts/interpreter/library/common/time.ex
@@ -2,13 +2,16 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Time do
   @moduledoc false
   @behaviour Archethic.Contracts.Interpreter.Library
 
+  alias Archethic.Contracts.Interpreter.Scope
+
   @doc """
-  Returns current time in unix timestamp format.
-  (number of seconds since epoch)
+  Returns the Unix timestamp of the trigger (it is approximately the same as current time).
+  We cannot use "now" because it is not determinist.
   """
   @spec now() :: integer()
   def now() do
-    DateTime.utc_now() |> DateTime.to_unix()
+    Scope.read_global(["_time_now"])
+    |> DateTime.to_unix()
   end
 
   @spec check_types(atom(), list()) :: boolean()

--- a/lib/archethic/transaction_chain/transaction/validation_stamp.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp.ex
@@ -350,6 +350,21 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
     Crypto.verify?(signature, raw_stamp, public_key)
   end
 
+  @doc """
+  Generates a dummy ValidationStamp.
+  This should only be used in very specific cases
+  """
+  @spec generate_dummy() :: t()
+  def generate_dummy() do
+    %__MODULE__{
+      timestamp: DateTime.utc_now(),
+      protocol_version: 1,
+      proof_of_work: :crypto.strong_rand_bytes(32),
+      proof_of_election: :crypto.strong_rand_bytes(32),
+      proof_of_integrity: :crypto.strong_rand_bytes(32)
+    }
+  end
+
   defp serialize_error(nil), do: 0
   defp serialize_error(:invalid_pending_transaction), do: 1
   defp serialize_error(:invalid_inherit_constraints), do: 2

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -17,6 +17,8 @@ defmodule Archethic.Utils do
 
   use Retry
 
+  @extended_mode? Mix.env() != :prod
+
   @type bigint() :: integer()
 
   @doc """
@@ -69,6 +71,26 @@ defmodule Archethic.Utils do
       |> DateTime.from_naive!("Etc/UTC")
 
     DateTime.diff(next_slot, ref_time, :second)
+  end
+
+  @doc """
+  Return the closest interval tick before now
+  """
+  @spec get_current_time_for_interval(binary(), boolean()) :: DateTime.t()
+  def get_current_time_for_interval(interval, extended_mode? \\ @extended_mode?) do
+    rounded_now =
+      if extended_mode? do
+        DateTime.utc_now()
+      else
+        # if it's not extended we want to remove the seconds and micro seconds from the time.
+        # we are adding 1 microsecond here because the previous_date function
+        # would return the previous tick if we have the exact trigger time
+        %DateTime{DateTime.utc_now() | second: 0, microsecond: {1, 0}}
+      end
+
+    interval
+    |> CronParser.parse!(extended_mode?)
+    |> previous_date(rounded_now)
   end
 
   @doc """

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -5,14 +5,11 @@ defmodule ArchethicWeb.API.TransactionController do
 
   alias Archethic
 
-  alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.TransactionData
 
-  alias Archethic.Crypto
   alias Archethic.Mining
-  alias Archethic.Election
   alias Archethic.OracleChain
 
   alias ArchethicWeb.API.TransactionPayload
@@ -155,19 +152,9 @@ defmodule ArchethicWeb.API.TransactionController do
           |> TransactionPayload.to_map()
           |> Transaction.cast()
           |> then(fn tx ->
-            # We add a fake ValidationStamp to the transaction
-            # because the Interpreter requires a timestamp
-            %Transaction{
-              tx
-              | validation_stamp: %ValidationStamp{
-                  timestamp: DateTime.utc_now(),
-                  protocol_version: Mining.protocol_version(),
-                  proof_of_work: Crypto.origin_node_public_key(),
-                  proof_of_election:
-                    Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-                  proof_of_integrity: TransactionChain.proof_of_integrity([tx])
-                }
-            }
+            # We add a dummy ValidationStamp to the transaction
+            # because the Interpreter requires a validated transaction
+            %Transaction{tx | validation_stamp: ValidationStamp.generate_dummy()}
           end)
 
         results =

--- a/test/archethic/contracts/interpreter/library/common/time_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/time_test.exs
@@ -1,12 +1,13 @@
 defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
   @moduledoc """
-  Here we test the module within the action block. Because there is AST modification (such as keywords to maps)
-  in the ActionInterpreter and we want to test the whole thing.
+  We test via the Interpreter.execute because it's where we define the time to use
   """
 
   use ArchethicCase
-  import ArchethicCase
 
+  alias Archethic.TransactionFactory
+  alias Archethic.Contracts.Contract
+  alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.Library.Common.Time
 
   alias Archethic.TransactionChain.Transaction
@@ -14,23 +15,186 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
 
   doctest Time
 
-  # ----------------------------------------
   describe "now/0" do
-    test "should work" do
-      now = DateTime.to_unix(DateTime.utc_now())
+    test "should work in the action block" do
+      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      timestamp = DateTime.to_unix(datetime)
 
       code = ~s"""
-      actions triggered_by: transaction do
-        now = Time.now()
-        Contract.set_content now
+      @version 1
+
+      condition inherit: [
+        content: true
+      ]
+
+      actions triggered_by: datetime, at: #{timestamp} do
+        Contract.set_content Time.now()
       end
       """
 
-      assert %Transaction{data: %TransactionData{content: timestamp}} =
-               sanitize_parse_execute(code)
+      contract_tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :contract,
+          code: code
+        )
 
-      # we validate the test if now is approximately now
-      assert String.to_integer(timestamp) - now < 10
+      {:ok, tx} =
+        Interpreter.execute(
+          {:datetime, datetime},
+          Contract.from_transaction!(contract_tx),
+          nil,
+          []
+        )
+
+      assert %Transaction{data: %TransactionData{content: content}} = tx
+      assert String.to_integer(content) == timestamp
+    end
+
+    test "should run the contract if condition is truthy" do
+      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      timestamp = DateTime.to_unix(datetime)
+
+      code = ~s"""
+      @version 1
+
+      condition inherit: [
+        content: true
+      ]
+
+      condition transaction: [
+        timestamp: Time.now() == #{timestamp}
+      ]
+
+      actions triggered_by: transaction do
+        Contract.set_content "hallo"
+      end
+      """
+
+      contract_tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :contract,
+          code: code
+        )
+
+      trigger_tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :data,
+          timestamp: datetime
+        )
+
+      assert {:ok, tx} =
+               Interpreter.execute(
+                 :transaction,
+                 Contract.from_transaction!(contract_tx),
+                 trigger_tx,
+                 [trigger_tx]
+               )
+
+      assert %Transaction{data: %TransactionData{content: "hallo"}} = tx
+    end
+
+    test "should fail the contract if condition is falsy" do
+      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      timestamp = DateTime.to_unix(datetime)
+
+      code = ~s"""
+      @version 1
+
+      condition inherit: [
+        content: true
+      ]
+
+      condition transaction: [
+        timestamp: Time.now() < #{timestamp}
+      ]
+
+      actions triggered_by: transaction do
+        Contract.set_content "hei"
+      end
+      """
+
+      contract_tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :contract,
+          code: code
+        )
+
+      trigger_tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :data,
+          timestamp: datetime
+        )
+
+      assert {:error, :invalid_transaction_constraints} =
+               Interpreter.execute(
+                 :transaction,
+                 Contract.from_transaction!(contract_tx),
+                 trigger_tx,
+                 [trigger_tx]
+               )
+    end
+
+    test "should run the contract if condition inherit is truthy" do
+      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      timestamp = DateTime.to_unix(datetime)
+
+      code = ~s"""
+      @version 1
+
+      condition inherit: [
+        timestamp: Time.now() == #{timestamp},
+        content: true
+      ]
+
+      actions triggered_by: datetime, at: #{timestamp} do
+        Contract.set_content "konnichiwa"
+      end
+      """
+
+      contract_tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :contract,
+          code: code
+        )
+
+      assert {:ok, %Transaction{}} =
+               Interpreter.execute(
+                 {:datetime, datetime},
+                 Contract.from_transaction!(contract_tx),
+                 nil,
+                 []
+               )
+    end
+
+    test "should fail the contract if condition inherit is falsy" do
+      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      timestamp = DateTime.to_unix(datetime)
+
+      code = ~s"""
+      @version 1
+
+      condition inherit: [
+        timestamp: Time.now() < #{timestamp}
+      ]
+
+      actions triggered_by: datetime, at: #{timestamp} do
+        Contract.set_content "ciao"
+      end
+      """
+
+      contract_tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :contract,
+          code: code
+        )
+
+      assert {:error, :invalid_inherit_constraints} =
+               Interpreter.execute(
+                 {:datetime, datetime},
+                 Contract.from_transaction!(contract_tx),
+                 nil,
+                 []
+               )
     end
   end
 end

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -7,6 +7,7 @@ defmodule Archethic.Contracts.InterpreterTest do
   alias Archethic.ContractFactory
 
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.TransactionData
 
   doctest Interpreter
@@ -226,7 +227,8 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       incoming_tx = %Transaction{
         type: :transfer,
-        data: %TransactionData{}
+        data: %TransactionData{},
+        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
       }
 
       assert {:ok, %Transaction{}} =
@@ -263,7 +265,8 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       incoming_tx = %Transaction{
         type: :transfer,
-        data: %TransactionData{}
+        data: %TransactionData{},
+        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
       }
 
       assert {:ok, nil} =
@@ -299,7 +302,8 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       incoming_tx = %Transaction{
         type: :transfer,
-        data: %TransactionData{}
+        data: %TransactionData{},
+        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
       }
 
       assert match?(
@@ -338,7 +342,8 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       incoming_tx = %Transaction{
         type: :transfer,
-        data: %TransactionData{}
+        data: %TransactionData{},
+        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
       }
 
       assert match?(
@@ -378,7 +383,8 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       oracle_tx = %Transaction{
         type: :oracle,
-        data: %TransactionData{}
+        data: %TransactionData{},
+        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
       }
 
       assert match?(
@@ -416,7 +422,8 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       incoming_tx = %Transaction{
         type: :transfer,
-        data: %TransactionData{}
+        data: %TransactionData{},
+        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
       }
 
       assert match?(
@@ -539,7 +546,8 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       oracle_tx = %Transaction{
         type: :oracle,
-        data: %TransactionData{}
+        data: %TransactionData{},
+        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
       }
 
       assert {:ok, %Transaction{}} =
@@ -575,7 +583,8 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       incoming_tx = %Transaction{
         type: :transfer,
-        data: %TransactionData{}
+        data: %TransactionData{},
+        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
       }
 
       calls = [

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -228,7 +228,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       incoming_tx = %Transaction{
         type: :transfer,
         data: %TransactionData{},
-        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+        validation_stamp: ValidationStamp.generate_dummy()
       }
 
       assert {:ok, %Transaction{}} =
@@ -266,7 +266,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       incoming_tx = %Transaction{
         type: :transfer,
         data: %TransactionData{},
-        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+        validation_stamp: ValidationStamp.generate_dummy()
       }
 
       assert {:ok, nil} =
@@ -303,7 +303,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       incoming_tx = %Transaction{
         type: :transfer,
         data: %TransactionData{},
-        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+        validation_stamp: ValidationStamp.generate_dummy()
       }
 
       assert match?(
@@ -343,7 +343,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       incoming_tx = %Transaction{
         type: :transfer,
         data: %TransactionData{},
-        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+        validation_stamp: ValidationStamp.generate_dummy()
       }
 
       assert match?(
@@ -384,7 +384,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       oracle_tx = %Transaction{
         type: :oracle,
         data: %TransactionData{},
-        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+        validation_stamp: ValidationStamp.generate_dummy()
       }
 
       assert match?(
@@ -423,7 +423,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       incoming_tx = %Transaction{
         type: :transfer,
         data: %TransactionData{},
-        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+        validation_stamp: ValidationStamp.generate_dummy()
       }
 
       assert match?(
@@ -547,7 +547,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       oracle_tx = %Transaction{
         type: :oracle,
         data: %TransactionData{},
-        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+        validation_stamp: ValidationStamp.generate_dummy()
       }
 
       assert {:ok, %Transaction{}} =
@@ -584,7 +584,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       incoming_tx = %Transaction{
         type: :transfer,
         data: %TransactionData{},
-        validation_stamp: %ValidationStamp{timestamp: DateTime.utc_now()}
+        validation_stamp: ValidationStamp.generate_dummy()
       }
 
       calls = [

--- a/test/archethic/utils_test.exs
+++ b/test/archethic/utils_test.exs
@@ -28,4 +28,48 @@ defmodule Archethic.UtilsTest do
     assert_receive :bar, 100
     refute_receive :bar, 100
   end
+
+  describe "get_current_time_for_interval/2" do
+    test "should return a value truncated to the minute (* minute)" do
+      now = DateTime.utc_now()
+      now_minus_1 = now |> DateTime.add(-1, :minute)
+      datetime = Utils.get_current_time_for_interval("* * * * *", false)
+
+      assert %DateTime{second: 0, microsecond: {0, 0}} = datetime
+      assert DateTime.compare(datetime, now) == :lt
+      assert DateTime.compare(datetime, now_minus_1) == :gt
+    end
+
+    test "should return a value truncated to the minute (*/5 minute)" do
+      now = DateTime.utc_now()
+      now_minus_1 = now |> DateTime.add(-5, :minute)
+      datetime = Utils.get_current_time_for_interval("*/5 * * * *", false)
+
+      assert %DateTime{minute: minute, second: 0, microsecond: {0, 0}} = datetime
+      assert 0 == rem(minute, 5)
+      assert DateTime.compare(datetime, now) == :lt
+      assert DateTime.compare(datetime, now_minus_1) == :gt
+    end
+
+    test "should return a value truncated to the second (* second)" do
+      now = DateTime.utc_now()
+      now_minus_1 = now |> DateTime.add(-1, :second)
+      datetime = Utils.get_current_time_for_interval("* * * * *", true)
+
+      assert %DateTime{microsecond: {0, 0}} = datetime
+      assert DateTime.compare(datetime, now) == :lt
+      assert DateTime.compare(datetime, now_minus_1) == :gt
+    end
+
+    test "should return a value truncated to the second (*/2 second)" do
+      now = DateTime.utc_now()
+      now_minus_1 = now |> DateTime.add(-2, :second)
+      datetime = Utils.get_current_time_for_interval("*/2 * * * *", true)
+
+      assert %DateTime{second: second, microsecond: {0, 0}} = datetime
+      assert 0 == rem(second, 2)
+      assert DateTime.compare(datetime, now) == :lt
+      assert DateTime.compare(datetime, now_minus_1) == :gt
+    end
+  end
 end


### PR DESCRIPTION
# Description

Make the `Time.now()` function determinist. We need it because in #925 we will run the contracts on many nodes and we will compare the resulting transaction. 

Fixes #921 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Tests added

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
