### PR TITLE
Fix p2p view on bootstrap

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -140,7 +140,7 @@ config :archethic, Archethic.Reward.MemTablesLoader, enabled: false
 
 config :archethic, Archethic.SelfRepair.Scheduler,
   enabled: false,
-  interval: "0 0 * * * * *",
+  interval: "5 * * * * * *",
   availability_application: 1
 
 config :archethic, Archethic.SelfRepair.NetworkView, enabled: false

--- a/test/archethic/bootstrap/transaction_handler_test.exs
+++ b/test/archethic/bootstrap/transaction_handler_test.exs
@@ -6,16 +6,15 @@ defmodule Archethic.Bootstrap.TransactionHandlerTest do
   alias Archethic.Bootstrap.TransactionHandler
 
   alias Archethic.P2P
-  alias Archethic.P2P.Message.GetTransactionSummary
-  alias Archethic.P2P.Message.TransactionSummaryMessage
+  alias Archethic.P2P.Message.GetTransaction
   alias Archethic.P2P.Message.NewTransaction
   alias Archethic.P2P.Message.Ok
 
   alias Archethic.P2P.Node
 
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.TransactionData
-  alias Archethic.TransactionChain.TransactionSummary
 
   import Mox
 
@@ -66,14 +65,12 @@ defmodule Archethic.Bootstrap.TransactionHandlerTest do
       _, %NewTransaction{}, _ ->
         {:ok, %Ok{}}
 
-      _, %GetTransactionSummary{}, _ ->
+      _, %GetTransaction{address: address}, _ ->
         {:ok,
-         %TransactionSummaryMessage{
-           transaction_summary: %TransactionSummary{
-             address: tx.address,
-             type: :node,
-             timestamp: DateTime.utc_now()
-           }
+         %Transaction{
+           address: address,
+           validation_stamp: %ValidationStamp{},
+           cross_validation_stamps: [%{}]
          }}
     end)
 

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -1,27 +1,56 @@
 defmodule Archethic.BootstrapTest do
   use ArchethicCase
 
-  alias Archethic.{Bootstrap, Crypto, Replication, SharedSecrets, TransactionChain}
-  alias Archethic.{P2P, P2P.BootstrappingSeeds, P2P.Node, TransactionChain, P2P.Message}
-  alias Archethic.{TransactionFactory}
-
-  alias Message.{GetGenesisAddress, GetTransactionChainLength, GetBootstrappingNodes, Ok}
-  alias Message.{GetTransactionSummary, GetTransactionInputs, GetGenesisAddress, GetStorageNonce}
-  alias Message.{GetLastTransactionAddress, GetTransactionChain, GetTransaction, NotFound}
-  alias Message.{GenesisAddress, LastTransactionAddress, NewTransaction, NotifyEndOfNodeSync}
-  alias Message.{TransactionList, TransactionInputList, TransactionSummaryMessage, NodeList}
-  alias Message.{TransactionChainLength, BootstrappingNodes, EncryptedStorageNonce, ListNodes}
-
-  alias TransactionChain.{Transaction, TransactionSummary}
-  alias Transaction.{ValidationStamp, ValidationStamp.LedgerOperations}
-
   alias Archethic.BeaconChain.SlotTimer, as: BeaconSlotTimer
   alias Archethic.BeaconChain.SummaryTimer, as: BeaconSummaryTimer
-  alias Archethic.SelfRepair.Scheduler, as: SelfRepairScheduler
-  alias Archethic.SelfRepair.NetworkChain
+
+  alias Archethic.Bootstrap
+
+  alias Archethic.Crypto
+
+  alias Archethic.P2P
+  alias Archethic.P2P.BootstrappingSeeds
+  alias Archethic.P2P.Node
+
+  alias Archethic.P2P.Message.{
+    BootstrappingNodes,
+    EncryptedStorageNonce,
+    GenesisAddress,
+    GetBootstrappingNodes,
+    GetGenesisAddress,
+    GetLastTransactionAddress,
+    GetStorageNonce,
+    GetTransaction,
+    GetTransactionChain,
+    GetTransactionChainLength,
+    GetTransactionInputs,
+    LastTransactionAddress,
+    ListNodes,
+    NewTransaction,
+    NodeList,
+    NotFound,
+    NotifyEndOfNodeSync,
+    Ok,
+    TransactionChainLength,
+    TransactionInputList,
+    TransactionList
+  }
+
+  alias Archethic.Replication
 
   alias Archethic.Reward.MemTables.RewardTokens, as: RewardMemTable
   alias Archethic.Reward.MemTablesLoader, as: RewardTableLoader
+
+  alias Archethic.SelfRepair.Scheduler, as: SelfRepairScheduler
+  alias Archethic.SelfRepair.NetworkChain
+
+  alias Archethic.SharedSecrets
+
+  alias Archethic.TransactionChain
+  alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ValidationStamp
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
+  alias Archethic.TransactionFactory
 
   import Mox
 
@@ -250,22 +279,12 @@ defmodule Archethic.BootstrapTest do
         _, %NotifyEndOfNodeSync{}, _ ->
           {:ok, %Ok{}}
 
-        # _, %GetTransaction{address: address}, _ ->
-        #   {:ok,
-        #    %Transaction{
-        #      address: address,
-        #      validation_stamp: %ValidationStamp{},
-        #      cross_validation_stamps: [%{}]
-        #    }}
-        _, %GetTransaction{}, _ ->
-          {:ok, %NotFound{}}
-
-        _, %GetTransactionSummary{address: address}, _ ->
+        _, %GetTransaction{address: address}, _ ->
           {:ok,
-           %TransactionSummaryMessage{
-             transaction_summary: %TransactionSummary{
-               address: address
-             }
+           %Transaction{
+             address: address,
+             validation_stamp: %ValidationStamp{},
+             cross_validation_stamps: [%{}]
            }}
 
         _, %GetTransactionChainLength{}, _ ->

--- a/test/archethic/self_repair/self_repair_test.exs
+++ b/test/archethic/self_repair/self_repair_test.exs
@@ -4,19 +4,19 @@ defmodule Archethic.SelfRepairTest do
 
   alias Archethic.BeaconChain.SummaryTimer
 
-  alias Archethic.P2P.Client.DefaultImpl
-
   alias Archethic.Crypto
+
   alias Archethic.P2P
+  alias Archethic.P2P.Client.DefaultImpl
   alias Archethic.P2P.Node
   alias Archethic.P2P.Message.GetNextAddresses
   alias Archethic.P2P.Message.GetTransaction
 
-  alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.Transaction.ValidationStamp
-
   alias Archethic.Replication
   alias Archethic.SelfRepair
+
+  alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ValidationStamp
 
   import ArchethicCase
   import Mox
@@ -162,5 +162,14 @@ defmodule Archethic.SelfRepairTest do
       assert {:error, :transaction_already_exists} =
                SelfRepair.replicate_transaction(address, false)
     end
+  end
+
+  test "missed_sync?/1 should return false" do
+    refute DateTime.utc_now() |> SelfRepair.missed_sync?()
+  end
+
+  test "missed_sync?/1 should return true" do
+    # Scheduler each minutes
+    assert DateTime.utc_now() |> DateTime.add(-2, :minute) |> SelfRepair.missed_sync?()
   end
 end


### PR DESCRIPTION
# Description

There is an issue when multiple nodes are running authorized and available.
If we quickly restart one, its P2P view is not good as the new date stored for last sync date is the summary time and not the time of the self repair.
Fixes it using a new function `SelfRepair.missed_sync?`

Also fix an issue where sometime a node does not add itself in the P2P memtable.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Start 2 nodes and wait to be authorized and available.
Restart one, it should have the right P2P view (before there where error on beacon slot and election)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
