### PR TITLE
Handle p2p update from self repair in network view

### DIFF
--- a/lib/archethic/self_repair/network_view.ex
+++ b/lib/archethic/self_repair/network_view.ex
@@ -1,7 +1,7 @@
 defmodule Archethic.SelfRepair.NetworkView do
   @moduledoc """
   The network view is 2 things:
-  - the P2P view (list of available & authorized nodes)
+  - the P2P view (list of all nodes)
   - the Network chains view (oracle/origin/nodesharedsecrets)
 
   It is useful to compare with other nodes to detect desynchronization.
@@ -174,7 +174,7 @@ defmodule Archethic.SelfRepair.NetworkView do
   #
   # ------------------------------------------------------
   defp do_get_p2p_hash() do
-    P2P.authorized_and_available_nodes()
+    P2P.list_nodes()
     |> Enum.map(& &1.last_public_key)
     |> Enum.sort()
     |> then(&:crypto.hash(:sha256, &1))


### PR DESCRIPTION
# Description

The network view is not updated when a new node is available after a self repair. So it was causing error as if a node restarts, it doesn't have the same view as the one that didn't restarted.

To fix this we have a new function `NetworkView.update_p2p_view` which is called at the end of a summary repair.
Also in the state of the network view we can have 2 hashes, a current one and a next one that will replace the current one once the threashold time (availability update) is passed. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

Start 2 nodes, wait them to be authorized and available.
Restart one, the view should be the same on both nodes

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
