### PR TITLE
Fix slot on summary time to be deleted

### DIFF
--- a/lib/archethic/beacon_chain/subset/summary_cache.ex
+++ b/lib/archethic/beacon_chain/subset/summary_cache.ex
@@ -84,10 +84,10 @@ defmodule Archethic.BeaconChain.Subset.SummaryCache do
     |> stream_current_slots()
     |> Stream.filter(fn
       {%Slot{slot_time: slot_time}, _} ->
-        DateTime.compare(slot_time, previous_summary_time) == :lt
+        DateTime.compare(slot_time, previous_summary_time) != :gt
 
       %Slot{slot_time: slot_time} ->
-        DateTime.compare(slot_time, previous_summary_time) == :lt
+        DateTime.compare(slot_time, previous_summary_time) != :gt
     end)
     |> Stream.each(fn item ->
       :ets.delete_object(@table_name, {subset, item})

--- a/test/archethic/beacon_chain/subset/summary_cache_test.exs
+++ b/test/archethic/beacon_chain/subset/summary_cache_test.exs
@@ -28,6 +28,11 @@ defmodule Archethic.BeaconChain.Subset.SummaryCacheTest do
       subset: subset
     }
 
+    slot_pre_summary2 = %Slot{
+      slot_time: ~U[2023-01-01 08:00:00Z],
+      subset: subset
+    }
+
     slot_post_summary = %Slot{
       slot_time: ~U[2023-01-01 08:00:20Z],
       subset: subset
@@ -37,6 +42,7 @@ defmodule Archethic.BeaconChain.Subset.SummaryCacheTest do
 
     first_slot_time = SlotTimer.next_slot(previous_summary_time)
     SummaryCache.add_slot(subset, slot_pre_summary, "node_key")
+    SummaryCache.add_slot(subset, slot_pre_summary2, "node_key")
     SummaryCache.add_slot(subset, slot_post_summary, "node_key")
 
     send(pid, {:current_epoch_of_slot_timer, first_slot_time})


### PR DESCRIPTION
# Description

Fixes an issue where the slot created on the same time of a summary where not deleted from the ets table

Fixes #1027 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
