### PR TITLE
Fix backup slots not cleared

### DIFF
--- a/lib/archethic/beacon_chain/subset/summary_cache.ex
+++ b/lib/archethic/beacon_chain/subset/summary_cache.ex
@@ -49,7 +49,12 @@ defmodule Archethic.BeaconChain.Subset.SummaryCache do
         &clean_previous_summary_cache(&1, previous_summary_time)
       )
 
-      File.rm(recover_path(previous_summary_time))
+      next_summary_backup_path = SummaryTimer.next_summary(slot_time) |> recover_path()
+
+      Utils.mut_dir("slot_backup*")
+      |> Path.wildcard()
+      |> Enum.reject(&(&1 == next_summary_backup_path))
+      |> Enum.each(&File.rm/1)
     end
 
     {:noreply, state}


### PR DESCRIPTION
# Description

When nodes are not started on the time of the first slot of the current summary, the backup slot file are never cleared.
Now we delete all backup slot file except the one of the current summary.

Also fix a bug where the last slot of the day was not appended to the right backup file

Fixes #1026

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
