### PR TITLE
Add resovled uco and token movements in the contract's constants

### DIFF
--- a/lib/archethic/contracts/contract/constants.ex
+++ b/lib/archethic/contracts/contract/constants.ex
@@ -107,7 +107,7 @@ defmodule Archethic.Contracts.ContractConstants do
             ledger_operations: %LedgerOperations{transaction_movements: transaction_movements}
           } ->
             transaction_movements
-            |> Enum.filter(&match?({:token, _}, &1.type))
+            |> Enum.filter(&match?({:token, _, _}, &1.type))
             |> Enum.reduce(%{}, fn %TransactionMovement{
                                      to: to,
                                      amount: amount,

--- a/test/archethic/contracts/contract/constants_test.exs
+++ b/test/archethic/contracts/contract/constants_test.exs
@@ -1,18 +1,110 @@
 defmodule Archethic.Contracts.ContractConstantsTest do
   use ArchethicCase
 
+  import ArchethicCase
+
   alias Archethic.TransactionFactory
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.TransactionData.Ledger
+  alias Archethic.TransactionChain.TransactionData.UCOLedger
+  alias Archethic.TransactionChain.TransactionData.UCOLedger.Transfer, as: UcoTransfer
+  alias Archethic.TransactionChain.TransactionData.TokenLedger
+  alias Archethic.TransactionChain.TransactionData.TokenLedger.Transfer, as: TokenTransfer
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
+
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.TransactionMovement
+
   alias Archethic.Contracts.ContractConstants
+  alias Archethic.Utils
 
-  test "from_transaction/1 should return a map" do
-    tx = TransactionFactory.create_valid_transaction()
+  describe "from_transaction/1" do
+    test "should return a map" do
+      tx = TransactionFactory.create_valid_transaction()
 
-    constant =
-      tx
-      |> ContractConstants.from_transaction()
+      constant =
+        tx
+        |> ContractConstants.from_transaction()
 
-    assert %{"type" => "transfer"} = constant
+      assert %{"type" => "transfer"} = constant
+    end
+
+    test "should return both uco transfer & movements" do
+      token_address = random_address()
+
+      uco_movement_address = random_address()
+      uco_movement_amount = Utils.to_bigint(2)
+      token_movement_address = random_address()
+      token_movement_amount = Utils.to_bigint(7)
+      uco_input_address = random_address()
+      uco_input_amount = Utils.to_bigint(5)
+      token_input_address = random_address()
+      token_input_amount = Utils.to_bigint(8)
+
+      ledger = %Ledger{
+        uco: %UCOLedger{
+          transfers: [
+            %UcoTransfer{
+              to: uco_input_address,
+              amount: uco_input_amount
+            }
+          ]
+        },
+        token: %TokenLedger{
+          transfers: [
+            %TokenTransfer{
+              to: token_input_address,
+              amount: token_input_amount,
+              token_address: token_address,
+              token_id: 1
+            }
+          ]
+        }
+      }
+
+      ledger_op = %LedgerOperations{
+        fee: Utils.to_bigint(1.337),
+        transaction_movements: [
+          %TransactionMovement{
+            to: uco_movement_address,
+            amount: uco_movement_amount,
+            type: :UCO
+          },
+          %TransactionMovement{
+            to: token_movement_address,
+            amount: token_movement_amount,
+            type: {:token, token_address, 2}
+          }
+        ]
+      }
+
+      # This won't produce a cryptographically valid transaction
+      # because we override some fields after the validation stamp has been set.
+      # But it's fine for testing purposes
+      constant =
+        TransactionFactory.create_valid_transaction([], ledger: ledger)
+        |> put_in([Access.key!(:validation_stamp), Access.key!(:ledger_operations)], ledger_op)
+        |> ContractConstants.from_transaction()
+
+      assert %{
+               "uco_movements" => uco_movements,
+               "token_movements" => token_movements,
+               "uco_transfers" => uco_transfers,
+               "token_transfers" => token_transfers
+             } = constant
+
+      assert ^uco_movement_amount = uco_movements[uco_movement_address]
+      assert ^uco_input_amount = uco_transfers[uco_input_address]
+
+      [token_movement_at_address] = token_movements[token_movement_address]
+      assert ^token_movement_amount = token_movement_at_address["amount"]
+      assert ^token_address = token_movement_at_address["token_address"]
+      assert 2 = token_movement_at_address["token_id"]
+
+      [token_transfers_at_address] = token_transfers[token_input_address]
+      assert ^token_input_amount = token_transfers_at_address["amount"]
+      assert ^token_address = token_transfers_at_address["token_address"]
+      assert 1 = token_transfers_at_address["token_id"]
+    end
   end
 
   test "to_transaction/1 should return a transaction" do

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -17,6 +17,7 @@ defmodule Archethic.TransactionFactory do
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.TransactionMovement
 
   alias Archethic.TransactionChain.TransactionData
+  alias Archethic.TransactionChain.TransactionData.Ledger
 
   def create_valid_transaction(
         inputs \\ [],
@@ -27,11 +28,18 @@ defmodule Archethic.TransactionFactory do
     index = Keyword.get(opts, :index, 0)
     content = Keyword.get(opts, :content, "")
     code = Keyword.get(opts, :code, "")
+    ledger = Keyword.get(opts, :ledger, %Ledger{})
 
     timestamp =
       Keyword.get(opts, :timestamp, DateTime.utc_now()) |> DateTime.truncate(:millisecond)
 
-    tx = Transaction.new(type, %TransactionData{content: content, code: code}, seed, index)
+    tx =
+      Transaction.new(
+        type,
+        %TransactionData{content: content, code: code, ledger: ledger},
+        seed,
+        index
+      )
 
     ledger_operations =
       %LedgerOperations{


### PR DESCRIPTION
# Description

Add resolved address for the uco and token transfers in the smart contract interpreter's constants

Fixes #741 

## Type of change

- Enhancements

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
