### PR TITLE
Require upnpc as external executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN apk add --no-cache --update \
   wget \
   openssl \
   libsodium-dev \
-  gmp-dev 
+  gmp-dev \
+  miniupnpc
 
 
 # Install hex and rebar

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,6 @@ compile_c_programs:
 	$(CC) src/c/crypto/stdio_helpers.c src/c/crypto/ed25519.c -o priv/c_dist/libsodium_port -I src/c/crypto/stdio_helpers.h -lsodium
 	$(CC) src/c/hypergeometric_distribution.c -o priv/c_dist/hypergeometric_distribution -lgmp
 
-	git submodule update --force --recursive --init --remote
-	$(MAKE) -C src/c/nat/miniupnp/miniupnpc
-	cp src/c/nat/miniupnp/miniupnpc/build/upnpc-static priv/c_dist/upnpc
-
-
 ifeq ($(TPM_INSTALLED),0)
 	$(CC) src/c/crypto/stdio_helpers.c src/c/crypto/tpm/lib.c src/c/crypto/tpm/port.c -o priv/c_dist/tpm_port -I src/c/crypto/stdio_helpers.h -I src/c/crypto/tpm/lib.h $(TPMFLAGS)
 	$(CC) src/c/crypto/tpm/keygen.c src/c/crypto/tpm/lib.c -o priv/c_dist/tpm_keygen -I src/c/crypto/tpm/lib.h $(TPMFLAGS)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Requirements:
 - Erlang OTP 25
 - Elixir 1.14
 - GMP (https://gmplib.org/)
+- MiniUPnP used for port forwarding & IP lookup (https://miniupnp.tuxfamily.org/)
 
 Platforms supported:
 

--- a/lib/archethic/networking/ip_lookup/nat_discovery/miniupnp.ex
+++ b/lib/archethic/networking/ip_lookup/nat_discovery/miniupnp.ex
@@ -3,11 +3,11 @@ defmodule Archethic.Networking.IPLookup.NATDiscovery.MiniUPNP do
 
   require Logger
 
-  @upnpc Application.app_dir(:archethic, "priv/c_dist/upnpc")
+  @upnp_command "upnpc"
 
   @spec get_node_ip() :: {:ok, :inet.ip_address()} | {:error, any()}
   def get_node_ip do
-    case System.cmd(@upnpc, ["-s"]) do
+    case System.cmd(@upnp_command, ["-s"]) do
       {output, 0} ->
         [[_, ip]] = Regex.scan(~r/ExternalIPAddress = ([0-9.]*)/, output, capture: :all)
 
@@ -29,7 +29,7 @@ defmodule Archethic.Networking.IPLookup.NATDiscovery.MiniUPNP do
   end
 
   defp get_local_ip do
-    case System.cmd(@upnpc, ["-s"]) do
+    case System.cmd(@upnp_command, ["-s"]) do
       {output, 0} ->
         [[_, ip]] = Regex.scan(~r/Local LAN ip address : ([0-9.]*)/, output, capture: :all)
 
@@ -49,7 +49,7 @@ defmodule Archethic.Networking.IPLookup.NATDiscovery.MiniUPNP do
   defp do_open_port(_local_ip, _port, 0), do: :error
 
   defp do_open_port(local_ip, port, retries) do
-    case System.cmd(@upnpc, map_query(local_ip, port)) do
+    case System.cmd(@upnp_command, map_query(local_ip, port)) do
       {_, 0} ->
         :ok
 
@@ -87,7 +87,7 @@ defmodule Archethic.Networking.IPLookup.NATDiscovery.MiniUPNP do
   defp handle_error(reason, _local_ip, port) do
     if Regex.scan(~r/ConflictInMappingEntry/, reason, capture: :all) != [] do
       Logger.warning("Port is employed to another host.")
-      System.cmd(@upnpc, revoke_query(port))
+      System.cmd(@upnp_command, revoke_query(port))
     end
   end
 


### PR DESCRIPTION
# Description

This PR aims to make miniupnp as externalize dependency

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
