### PR TITLE
Improve lru read concurrency

### DIFF
--- a/lib/archethic_cache/lru.ex
+++ b/lib/archethic_cache/lru.ex
@@ -25,9 +25,19 @@ defmodule ArchethicCache.LRU do
     GenServer.cast(server, {:put, key, value})
   end
 
-  @spec get(GenServer.server(), term()) :: nil | term()
-  def get(server, key) do
-    GenServer.call(server, {:get, key})
+  @spec get(GenServer.name(), term()) :: nil | term()
+  def get(server_name, key) do
+    case :ets.lookup(server_name, key) do
+      [{^key, {_size, value}}] ->
+        GenServer.cast(server_name, {:move_front, key})
+        get_fn = :persistent_term.get(server_name)
+        get_fn.(key, value)
+
+      [] ->
+        nil
+    end
+  rescue
+    _ -> nil
   end
 
   @spec purge(GenServer.server()) :: :ok
@@ -36,7 +46,9 @@ defmodule ArchethicCache.LRU do
   end
 
   def init([name, max_bytes, opts]) do
-    table = :ets.new(:"aecache_#{name}", [:set, {:read_concurrency, true}])
+    table = :ets.new(name, [:set, :named_table, {:read_concurrency, true}])
+
+    :persistent_term.put(name, Keyword.get(opts, :get_fn, fn _key, value -> value end))
 
     {:ok,
      %{
@@ -45,25 +57,8 @@ defmodule ArchethicCache.LRU do
        bytes_used: 0,
        keys: [],
        put_fn: Keyword.get(opts, :put_fn, fn _key, value -> value end),
-       get_fn: Keyword.get(opts, :get_fn, fn _key, value -> value end),
        evict_fn: Keyword.get(opts, :evict_fn, fn _key, _value -> :ok end)
      }}
-  end
-
-  def handle_call({:get, key}, _from, state = %{table: table, keys: keys, get_fn: get_fn}) do
-    {reply, new_state} =
-      case :ets.lookup(table, key) do
-        [{^key, {_size, value}}] ->
-          {
-            get_fn.(key, value),
-            %{state | keys: keys |> move_front(key)}
-          }
-
-        [] ->
-          {nil, state}
-      end
-
-    {:reply, reply, new_state}
   end
 
   def handle_call(:purge, _from, state = %{table: table, evict_fn: evict_fn}) do
@@ -79,6 +74,10 @@ defmodule ArchethicCache.LRU do
 
     :ets.delete_all_objects(table)
     {:reply, :ok, %{state | keys: [], bytes_used: 0}}
+  end
+
+  def handle_cast({:move_front, key}, state = %{keys: keys}) do
+    {:noreply, %{state | keys: keys |> move_front(key)}}
   end
 
   def handle_cast(

--- a/test/archethic/db/embedded_impl/chain_index_test.exs
+++ b/test/archethic/db/embedded_impl/chain_index_test.exs
@@ -40,6 +40,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndexTest do
 
     test "should load transactions tables", %{db_path: db_path} do
       {:ok, _pid} = ChainIndex.start_link(path: db_path)
+      LRU.start_link(:chain_index_cache, 30_000_000)
       tx_address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
       genesis_address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
 
@@ -58,7 +59,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndexTest do
       assert {^tx_address, _} = ChainIndex.get_last_chain_address(genesis_address, db_path)
 
       # Remove the transaction from the cache and try to fetch from the file instead
-      LRU.purge(Archethic.Db.ChainIndex.LRU)
+      LRU.purge(:chain_index_cache)
       assert true == ChainIndex.transaction_exists?(tx_address, db_path)
       assert false == ChainIndex.transaction_exists?(:crypto.strong_rand_bytes(32), db_path)
     end

--- a/test/archethic_cache/lru_test.exs
+++ b/test/archethic_cache/lru_test.exs
@@ -9,32 +9,37 @@ defmodule ArchethicCache.LRUTest do
 
   describe "single in memory cache" do
     test "should return nil when key is not in cache" do
-      {:ok, pid} = LRU.start_link(:my_cache, 10 * 1024)
+      {:ok, _pid} = LRU.start_link(:my_cache, 10 * 1024)
 
-      assert nil == LRU.get(pid, :key1)
+      assert nil == LRU.get(:my_cache, :key1)
     end
 
     test "should cache any term" do
       {:ok, pid} = LRU.start_link(:my_cache, 10 * 1024)
 
-      LRU.put(pid, :key1, 1)
-      LRU.put(pid, :key2, :atom)
-      LRU.put(pid, :key3, %{a: 1})
-      LRU.put(pid, {1, 2}, "binary")
+      LRU.put(:my_cache, :key1, 1)
+      LRU.put(:my_cache, :key2, :atom)
+      LRU.put(:my_cache, :key3, %{a: 1})
+      LRU.put(:my_cache, {1, 2}, "binary")
 
-      assert 1 == LRU.get(pid, :key1)
-      assert :atom == LRU.get(pid, :key2)
-      assert %{a: 1} == LRU.get(pid, :key3)
-      assert "binary" == LRU.get(pid, {1, 2})
+      # This get_state is used to wait for all messages in the GenServer to be processed
+      :sys.get_state(pid)
+
+      assert 1 == LRU.get(:my_cache, :key1)
+      assert :atom == LRU.get(:my_cache, :key2)
+      assert %{a: 1} == LRU.get(:my_cache, :key3)
+      assert "binary" == LRU.get(:my_cache, {1, 2})
     end
 
     test "should be able to replace a value" do
       {:ok, pid} = LRU.start_link(:my_cache, 10 * 1024)
 
-      LRU.put(pid, :key1, "value1a")
-      LRU.put(pid, :key1, "value1b")
+      LRU.put(:my_cache, :key1, "value1a")
+      LRU.put(:my_cache, :key1, "value1b")
 
-      assert "value1b" == LRU.get(pid, :key1)
+      :sys.get_state(pid)
+
+      assert "value1b" == LRU.get(:my_cache, :key1)
     end
 
     test "should evict some cached values when there is not enough space available" do
@@ -42,12 +47,14 @@ defmodule ArchethicCache.LRUTest do
 
       {:ok, pid} = LRU.start_link(:my_cache, 500)
 
-      LRU.put(pid, :key1, binary)
-      LRU.put(pid, :key2, binary)
-      LRU.put(pid, :key3, get_a_binary_of_bytes(400))
+      LRU.put(:my_cache, :key1, binary)
+      LRU.put(:my_cache, :key2, binary)
+      LRU.put(:my_cache, :key3, get_a_binary_of_bytes(400))
 
-      assert nil == LRU.get(pid, :key1)
-      assert nil == LRU.get(pid, :key2)
+      :sys.get_state(pid)
+
+      assert nil == LRU.get(:my_cache, :key1)
+      assert nil == LRU.get(:my_cache, :key2)
     end
 
     test "should evict the LRU" do
@@ -55,13 +62,18 @@ defmodule ArchethicCache.LRUTest do
 
       {:ok, pid} = LRU.start_link(:my_cache, 500)
 
-      LRU.put(pid, :key1, binary)
-      LRU.put(pid, :key2, binary)
-      LRU.get(pid, :key1)
-      LRU.put(pid, :key3, binary)
+      LRU.put(:my_cache, :key1, binary)
+      LRU.put(:my_cache, :key2, binary)
 
-      assert ^binary = LRU.get(pid, :key1)
-      assert nil == LRU.get(pid, :key2)
+      :sys.get_state(pid)
+
+      LRU.get(:my_cache, :key1)
+      LRU.put(:my_cache, :key3, binary)
+
+      :sys.get_state(pid)
+
+      assert ^binary = LRU.get(:my_cache, :key1)
+      assert nil == LRU.get(:my_cache, :key2)
     end
 
     test "should not cache a binary bigger than cache size" do
@@ -69,20 +81,23 @@ defmodule ArchethicCache.LRUTest do
 
       {:ok, pid} = LRU.start_link(:my_cache, 200)
 
-      assert :ok == LRU.put(pid, :key1, binary)
-      assert nil == LRU.get(pid, :key1)
+      assert :ok == LRU.put(:my_cache, :key1, binary)
+
+      :sys.get_state(pid)
+
+      assert nil == LRU.get(:my_cache, :key1)
     end
 
     test "should remove all when purged" do
       binary = get_a_binary_of_bytes(100)
 
-      {:ok, pid} = LRU.start_link(:my_cache, 500)
+      {:ok, _pid} = LRU.start_link(:my_cache, 500)
 
-      LRU.put(pid, :key1, binary)
-      LRU.put(pid, :key2, binary)
-      LRU.purge(pid)
-      assert nil == LRU.get(pid, :key1)
-      assert nil == LRU.get(pid, :key2)
+      LRU.put(:my_cache, :key1, binary)
+      LRU.put(:my_cache, :key2, binary)
+      LRU.purge(:my_cache)
+      assert nil == LRU.get(:my_cache, :key1)
+      assert nil == LRU.get(:my_cache, :key2)
     end
   end
 
@@ -92,11 +107,14 @@ defmodule ArchethicCache.LRUTest do
       assert {:error, _} = LRU.start_link(:my_cache, 10 * 1024)
 
       {:ok, pid2} = LRU.start_link(:my_cache2, 10 * 1024)
-      LRU.put(pid, :key1, "value1a")
-      LRU.put(pid2, :key1, "value1b")
+      LRU.put(:my_cache, :key1, "value1a")
+      LRU.put(:my_cache2, :key1, "value1b")
 
-      assert "value1a" == LRU.get(pid, :key1)
-      assert "value1b" == LRU.get(pid2, :key1)
+      :sys.get_state(pid)
+      :sys.get_state(pid2)
+
+      assert "value1a" == LRU.get(:my_cache, :key1)
+      assert "value1b" == LRU.get(:my_cache2, :key1)
     end
   end
 


### PR DESCRIPTION
# Description

Improve read concurrency on LRU cache. It now directly read the ets table instead of requesting it to the LRU GenServer. The GenServer is only used to manage the LRU workflow (monitor cache size, add value in ets table and remove old value when max size is reached).

Also move the ChainIndex LRU to be started in Embedded Supervisor instead of being linked to ChainIndex 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test + manual test on lot of datas

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
