### PR TITLE
Fill 2 previous daily nonce on boostrap

### DIFF
--- a/lib/archethic/crypto/keystore/shared_secrets/software_impl.ex
+++ b/lib/archethic/crypto/keystore/shared_secrets/software_impl.ex
@@ -51,8 +51,8 @@ defmodule Archethic.Crypto.SharedSecretsKeystore.SoftwareImpl do
 
     :node_shared_secrets
     |> TransactionChain.list_addresses_by_type()
-    |> Enum.at(-1)
-    |> load_node_shared_secrets_tx()
+    |> Stream.take(-2)
+    |> Enum.each(&load_node_shared_secrets_tx/1)
 
     {:ok, %{}}
   end


### PR DESCRIPTION
# Description

Fixes an issue happening when an authorized node restart between a node_shared_secret transaction and it's application date (between xx:xx:40 and xx:xx:00 on dev / 23:55:00 and 00:00:00 on prod)
The implementation was filling the ets table with only the last node shared secret transaction, so after the node restart it cannot retrieve the daily nonce for the current day as it only filled the one of the next day

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Restart a node after a node shared secret and ask for a faucet, the transaction is now validated  without error

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
