### PR TITLE
Do not cache ChainIndex when bootstrapping

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_index.ex
+++ b/lib/archethic/db/embedded_impl/chain_index.ex
@@ -66,14 +66,13 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
   end
 
   defp do_scan_summary_table(fd) do
-    with {:ok, <<current_curve_id::8, current_hash_type::8>>} <- :file.read(fd, 2),
+    with {:ok, <<_current_curve_id::8, current_hash_type::8>>} <- :file.read(fd, 2),
          hash_size <- Crypto.hash_size(current_hash_type),
-         {:ok, current_digest} <- :file.read(fd, hash_size),
+         {:ok, _current_digest} <- :file.read(fd, hash_size),
          {:ok, <<genesis_curve_id::8, genesis_hash_type::8>>} <- :file.read(fd, 2),
          hash_size <- Crypto.hash_size(genesis_hash_type),
          {:ok, genesis_digest} <- :file.read(fd, hash_size),
-         {:ok, <<size::32, offset::32>>} <- :file.read(fd, 8) do
-      current_address = <<current_curve_id::8, current_hash_type::8, current_digest::binary>>
+         {:ok, <<size::32, _offset::32>>} <- :file.read(fd, 8) do
       genesis_address = <<genesis_curve_id::8, genesis_hash_type::8, genesis_digest::binary>>
 
       :ets.update_counter(
@@ -85,13 +84,6 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
         ],
         {genesis_address, 0, 0}
       )
-
-      ## Store each transaction in the LRU cache. If cache is full, the oldest entries will be evicted
-      LRU.put(@archetic_db_tx_index_cache, current_address, %{
-        size: size,
-        offset: offset,
-        genesis_address: genesis_address
-      })
 
       do_scan_summary_table(fd)
     else

--- a/lib/archethic/db/embedded_impl/chain_index.ex
+++ b/lib/archethic/db/embedded_impl/chain_index.ex
@@ -150,13 +150,15 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
       [:binary, :append]
     )
 
-    # Write fast lookup entry for this transaction on LRU cache
-    :ok =
+    # pre-cache item (when node is not bootstrapping)
+    # so they are already cached when we'll need them
+    if Archethic.up?() do
       LRU.put(@archetic_db_tx_index_cache, tx_address, %{
         size: size,
         offset: last_offset,
         genesis_address: genesis_address
       })
+    end
 
     :ets.update_counter(
       @archethic_db_chain_stats,


### PR DESCRIPTION
# Description

Do not pre-cache chain index while bootstrapping. Because the LRU cache behind use a GenServer and become a memory problem when there are several millions `put` requests.

Fixes #1088

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually with logs:
- restart a node
- bootstrap a new node

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
