### PR TITLE
Fix bootsrap p2p view

### DIFF
--- a/lib/archethic/bootstrap.ex
+++ b/lib/archethic/bootstrap.ex
@@ -117,9 +117,9 @@ defmodule Archethic.Bootstrap do
         network_patch,
         reward_address
       )
-    else
-      post_bootstrap()
     end
+
+    post_bootstrap()
 
     Logger.info("Bootstrapping finished!")
   end
@@ -170,7 +170,6 @@ defmodule Archethic.Bootstrap do
 
         Sync.initialize_network(tx)
 
-        post_bootstrap()
         SelfRepair.put_last_sync_date(DateTime.utc_now())
 
       Crypto.first_node_public_key() == Crypto.previous_node_public_key() ->
@@ -185,8 +184,6 @@ defmodule Archethic.Bootstrap do
           bootstrapping_seeds,
           configured_reward_address
         )
-
-        post_bootstrap()
 
       true ->
         Logger.info("Update node chain...")
@@ -208,8 +205,6 @@ defmodule Archethic.Bootstrap do
           bootstrapping_seeds,
           last_reward_address
         )
-
-        post_bootstrap()
     end
   end
 

--- a/lib/archethic/bootstrap/transaction_handler.ex
+++ b/lib/archethic/bootstrap/transaction_handler.ex
@@ -3,8 +3,6 @@ defmodule Archethic.Bootstrap.TransactionHandler do
 
   alias Archethic.Crypto
 
-  alias Archethic.Election
-
   alias Archethic.P2P
   alias Archethic.P2P.Message.Ok
   alias Archethic.P2P.Message.NewTransaction
@@ -32,7 +30,7 @@ defmodule Archethic.Bootstrap.TransactionHandler do
   end
 
   defp do_send_transaction(
-         [node | rest],
+         nodes = [node | rest],
          tx = %Transaction{address: address, type: type, data: transaction_data}
        ) do
     case P2P.send_message(node, %NewTransaction{
@@ -45,15 +43,7 @@ defmodule Archethic.Bootstrap.TransactionHandler do
           transaction_type: type
         )
 
-        storage_nodes =
-          Election.chain_storage_nodes_with_type(
-            address,
-            type,
-            P2P.authorized_and_available_nodes()
-          )
-          |> Enum.reject(&(&1.first_public_key == Crypto.first_node_public_key()))
-
-        case Utils.await_confirmation(address, storage_nodes) do
+        case Utils.await_confirmation(address, nodes) do
           {:ok, validated_transaction = %Transaction{address: ^address, data: ^transaction_data}} ->
             {:ok, validated_transaction}
 

--- a/lib/archethic/p2p/message/get_bootstraping_nodes.ex
+++ b/lib/archethic/p2p/message/get_bootstraping_nodes.ex
@@ -28,7 +28,8 @@ defmodule Archethic.P2P.Message.GetBootstrappingNodes do
 
     %BootstrappingNodes{
       new_seeds: Enum.take_random(top_nodes, 5),
-      closest_nodes: closest_nodes
+      closest_nodes: closest_nodes,
+      first_enrolled_node: P2P.get_first_enrolled_node()
     }
   end
 

--- a/lib/archethic/p2p/message/list_nodes.ex
+++ b/lib/archethic/p2p/message/list_nodes.ex
@@ -6,22 +6,27 @@ defmodule Archethic.P2P.Message.ListNodes do
   alias Archethic.P2P
   alias Archethic.P2P.Message.NodeList
 
-  defstruct []
+  defstruct [:authorized_and_available?]
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          authorized_and_available?: boolean()
+        }
 
   @spec process(__MODULE__.t(), Crypto.key()) :: NodeList.t()
-  def process(%__MODULE__{}, _) do
-    %NodeList{nodes: P2P.list_nodes()}
-  end
+  def process(%__MODULE__{authorized_and_available?: false}, _),
+    do: %NodeList{nodes: P2P.list_nodes()}
+
+  def process(%__MODULE__{authorized_and_available?: true}, _),
+    do: %NodeList{nodes: P2P.authorized_and_available_nodes()}
 
   @spec serialize(t()) :: bitstring()
-  def serialize(%__MODULE__{}), do: <<>>
+  def serialize(%__MODULE__{authorized_and_available?: false}), do: <<0::8>>
+  def serialize(%__MODULE__{authorized_and_available?: true}), do: <<1::8>>
 
   @spec deserialize(bitstring()) :: {t(), bitstring}
-  def deserialize(<<rest::bitstring>>),
-    do: {
-      %__MODULE__{},
-      rest
-    }
+  def deserialize(<<0::8, rest::bitstring>>),
+    do: {%__MODULE__{authorized_and_available?: false}, rest}
+
+  def deserialize(<<1::8, rest::bitstring>>),
+    do: {%__MODULE__{authorized_and_available?: true}, rest}
 end

--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -45,35 +45,10 @@ defmodule Archethic.SelfRepair do
   @doc """
   Start the bootstrap's synchronization process using the last synchronization date
   """
-  @spec bootstrap_sync(last_sync_date :: DateTime.t()) :: :ok
-  def bootstrap_sync(date = %DateTime{}) do
-    # Loading transactions can take a lot of time to be achieve and can overpass an epoch.
-    # So to avoid missing a beacon summary epoch, we save the starting date and update the last sync date with it
-    # at the end of loading (in case there is a crash during self repair).
-
-    # Summary time after the the last synchronization date
-    summary_time = BeaconChain.next_summary_date(date)
-
-    # Before the first summary date, synchronization is useless
-    # as no data have been aggregated
-    if DateTime.diff(DateTime.utc_now(), summary_time) >= 0 do
-      loaded_missed_transactions? =
-        :ok ==
-          0..@max_retry_count
-          |> Enum.reduce_while(:error, fn _, _ ->
-            try do
-              :ok = Sync.load_missed_transactions(date)
-              {:halt, :ok}
-            catch
-              error, message ->
-                Logger.error("Error during self repair #{error} #{message}")
-                {:cont, :error}
-            end
-          end)
-
-      if loaded_missed_transactions? do
-        Logger.info("Bootstrap Sync succeded in loading missed transactions !")
-
+  @spec bootstrap_sync(last_sync_date :: DateTime.t()) :: :ok | :error
+  def bootstrap_sync(last_sync_date = %DateTime{}) do
+    case sync_with_retry(last_sync_date) do
+      :ok ->
         # At the end of self repair, if a new beacon summary as been created
         # we run bootstrap_sync again until the last beacon summary is loaded
         last_sync_date = last_sync_date()
@@ -87,16 +62,26 @@ defmodule Archethic.SelfRepair do
           _ ->
             :ok
         end
-      else
+
+      :error ->
         Logger.error(
           "Bootstrap Sync failed to load missed transactions after max retry of #{@max_retry_count} !"
         )
-
-        :error
-      end
-    else
-      Logger.info("Synchronization skipped (before first summary date)")
     end
+  end
+
+  defp sync_with_retry(last_sync_date) do
+    0..@max_retry_count
+    |> Enum.reduce_while(:error, fn _, _ ->
+      try do
+        :ok = Sync.load_missed_transactions(last_sync_date)
+        {:halt, :ok}
+      catch
+        error, message ->
+          Logger.error("Error during self repair #{inspect(error)} #{inspect(message)}")
+          {:cont, :error}
+      end
+    end)
   end
 
   @doc """

--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -45,9 +45,10 @@ defmodule Archethic.SelfRepair do
   @doc """
   Start the bootstrap's synchronization process using the last synchronization date
   """
-  @spec bootstrap_sync(last_sync_date :: DateTime.t()) :: :ok | :error
-  def bootstrap_sync(last_sync_date = %DateTime{}) do
-    case sync_with_retry(last_sync_date) do
+  @spec bootstrap_sync(last_sync_date :: DateTime.t(), download_nodes :: list(Node.t())) ::
+          :ok | :error
+  def bootstrap_sync(last_sync_date, download_nodes) do
+    case sync_with_retry(last_sync_date, download_nodes) do
       :ok ->
         # At the end of self repair, if a new beacon summary as been created
         # we run bootstrap_sync again until the last beacon summary is loaded
@@ -57,7 +58,7 @@ defmodule Archethic.SelfRepair do
              |> BeaconChain.previous_summary_time()
              |> DateTime.compare(last_sync_date) do
           :gt ->
-            bootstrap_sync(last_sync_date)
+            bootstrap_sync(last_sync_date, download_nodes)
 
           _ ->
             :ok
@@ -70,11 +71,11 @@ defmodule Archethic.SelfRepair do
     end
   end
 
-  defp sync_with_retry(last_sync_date) do
+  defp sync_with_retry(last_sync_date, download_nodes) do
     0..@max_retry_count
     |> Enum.reduce_while(:error, fn _, _ ->
       try do
-        :ok = Sync.load_missed_transactions(last_sync_date)
+        :ok = Sync.load_missed_transactions(last_sync_date, download_nodes)
         {:halt, :ok}
       catch
         error, message ->

--- a/lib/archethic/self_repair/network_chain.ex
+++ b/lib/archethic/self_repair/network_chain.ex
@@ -50,7 +50,7 @@ defmodule Archethic.SelfRepair.NetworkChain do
   def synchronous_resync(:node) do
     :telemetry.execute([:archethic, :self_repair, :resync], %{count: 1}, %{network_chain: :node})
 
-    case P2P.fetch_nodes_list() do
+    case P2P.fetch_nodes_list(false, P2P.authorized_and_available_nodes()) do
       {:ok, nodes} ->
         nodes_to_resync = Enum.filter(nodes, &node_require_resync?/1)
 

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -102,9 +102,9 @@ defmodule Archethic.SelfRepair.Sync do
 
   Once retrieved, the transactions are downloaded and stored if not exists locally
   """
-  @spec load_missed_transactions(last_sync_date :: DateTime.t()) ::
+  @spec load_missed_transactions(last_sync_date :: DateTime.t(), download_nodes :: list(Node.t())) ::
           :ok | {:error, :unreachable_nodes}
-  def load_missed_transactions(last_sync_date = %DateTime{}) do
+  def load_missed_transactions(last_sync_date, download_nodes) do
     last_summary_time = BeaconChain.previous_summary_time(DateTime.utc_now())
 
     if DateTime.compare(last_summary_time, last_sync_date) == :gt do
@@ -112,7 +112,7 @@ defmodule Archethic.SelfRepair.Sync do
         "Fetch missed transactions from last sync date: #{DateTime.to_string(last_sync_date)}"
       )
 
-      do_load_missed_transactions(last_sync_date, last_summary_time)
+      do_load_missed_transactions(last_sync_date, last_summary_time, download_nodes)
     else
       Logger.info("Already synchronized for #{DateTime.to_string(last_sync_date)}")
 
@@ -121,10 +121,8 @@ defmodule Archethic.SelfRepair.Sync do
     end
   end
 
-  defp do_load_missed_transactions(last_sync_date, last_summary_time) do
+  defp do_load_missed_transactions(last_sync_date, last_summary_time, download_nodes) do
     start = System.monotonic_time()
-
-    download_nodes = P2P.authorized_and_available_nodes(last_summary_time, true)
 
     # Process first the old aggregates
     fetch_summaries_aggregates(last_sync_date, last_summary_time, download_nodes)

--- a/test/archethic/bootstrap/sync_test.exs
+++ b/test/archethic/bootstrap/sync_test.exs
@@ -10,6 +10,7 @@ defmodule Archethic.Bootstrap.SyncTest do
   alias Archethic.Crypto
 
   alias Archethic.P2P
+  alias Archethic.P2P.Client
   alias Archethic.P2P.Message.GetTransactionChainLength
   alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.EncryptedStorageNonce
@@ -46,6 +47,7 @@ defmodule Archethic.Bootstrap.SyncTest do
   @moduletag :capture_log
 
   import Mox
+  import Mock
 
   setup do
     MockClient
@@ -332,7 +334,13 @@ defmodule Archethic.Bootstrap.SyncTest do
     end
   end
 
-  test "load_node_list/0 should request node list from the closest nodes" do
+  test_with_mock "connect_current_node/1 should request node list from the closest nodes and connect to them",
+                 Client,
+                 [:passthrough],
+                 new_connection: fn _, _, _, public_key ->
+                   P2P.MemTable.increase_node_availability(public_key)
+                   {:ok, make_ref()}
+                 end do
     node = %Node{
       ip: {80, 10, 101, 202},
       port: 4390,
@@ -347,7 +355,7 @@ defmodule Archethic.Bootstrap.SyncTest do
       network_patch: "AAA"
     }
 
-    :ok = P2P.add_and_connect_node(node)
+    :ok = P2P.connect_node(node)
 
     first_public_key = Crypto.first_node_public_key()
 
@@ -358,43 +366,33 @@ defmodule Archethic.Bootstrap.SyncTest do
       first_public_key: first_public_key,
       last_public_key: Crypto.last_node_public_key(),
       enrollment_date: DateTime.utc_now(),
-      authorized?: false,
+      authorized?: true,
+      available?: true,
+      availability_history: <<1::1>>,
       network_patch: "AAA"
     }
 
-    :ok = P2P.add_and_connect_node(node2)
+    node3 = %Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      http_port: 4000,
+      first_public_key: "key2",
+      last_public_key: "key2",
+      authorized?: true,
+      availability_history: <<1::1>>,
+      available?: true
+    }
 
     MockClient
     |> stub(:send_message, fn
-      _, %ListNodes{}, _ ->
-        {:ok,
-         %NodeList{
-           nodes: [
-             %Node{
-               ip: {127, 0, 0, 1},
-               port: 3000,
-               http_port: 4000,
-               first_public_key: "key2",
-               last_public_key: "key2"
-             }
-           ]
-         }}
+      _, %ListNodes{authorized_and_available?: true}, _ ->
+        {:ok, %NodeList{nodes: [node, node2, node3]}}
     end)
 
-    assert :ok = Sync.load_node_list()
+    assert {:ok, [^node, ^node2, ^node3]} = Sync.connect_current_node([node])
 
-    assert [
-             %Node{first_public_key: ^first_public_key},
-             %Node{first_public_key: "key1"},
-             %Node{
-               ip: {127, 0, 0, 1},
-               port: 3000,
-               http_port: 4000,
-               first_public_key: "key2",
-               last_public_key: "key2",
-               availability_history: <<2::2>>
-             }
-           ] = P2P.list_nodes()
+    assert_called_exactly(Client.new_connection(:_, :_, :_, "key1"), 2)
+    assert_called(Client.new_connection(:_, :_, :_, "key2"))
   end
 
   test "load_storage_nonce/1 should fetch the storage nonce, decrypt it with the node key" do

--- a/test/archethic/bootstrap/transaction_handler_test.exs
+++ b/test/archethic/bootstrap/transaction_handler_test.exs
@@ -46,7 +46,8 @@ defmodule Archethic.Bootstrap.TransactionHandlerTest do
       available?: true,
       authorized?: true,
       authorization_date: DateTime.utc_now() |> DateTime.add(-10),
-      enrollment_date: DateTime.utc_now()
+      enrollment_date: DateTime.utc_now(),
+      availability_history: <<1::1>>
     }
 
     :ok = P2P.add_and_connect_node(node)

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -16,7 +16,6 @@ defmodule Archethic.BootstrapTest do
   alias Archethic.P2P.Message.{
     BootstrappingNodes,
     EncryptedStorageNonce,
-    GenesisAddress,
     GetBootstrappingNodes,
     GetGenesisAddress,
     GetLastTransactionAddress,
@@ -42,7 +41,6 @@ defmodule Archethic.BootstrapTest do
   alias Archethic.Reward.MemTablesLoader, as: RewardTableLoader
 
   alias Archethic.SelfRepair.Scheduler, as: SelfRepairScheduler
-  alias Archethic.SelfRepair.NetworkChain
 
   alias Archethic.SharedSecrets
 
@@ -50,7 +48,6 @@ defmodule Archethic.BootstrapTest do
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
-  alias Archethic.TransactionFactory
 
   import Mox
   import Mock
@@ -274,7 +271,8 @@ defmodule Archethic.BootstrapTest do
              ],
              closest_nodes: [
                Enum.at(nodes, 1)
-             ]
+             ],
+             first_enrolled_node: Enum.at(nodes, 0)
            }}
 
         _, %GetStorageNonce{}, _ ->
@@ -443,203 +441,6 @@ defmodule Archethic.BootstrapTest do
       assert_called_exactly(Replication.sync_transaction_chain(:_, :_), 1)
 
       Process.sleep(100)
-    end
-  end
-
-  describe "synchronous_resync/1 nss_chain" do
-    setup do
-      p2p_context()
-
-      curr_time = DateTime.utc_now()
-
-      txn0 =
-        TransactionFactory.create_network_tx(:node_shared_secrets,
-          index: 0,
-          timestamp: curr_time |> DateTime.add(-14_400, :second),
-          prev_txn: []
-        )
-
-      txn1 =
-        TransactionFactory.create_network_tx(:node_shared_secrets,
-          index: 1,
-          timestamp: curr_time |> DateTime.add(-14_400, :second),
-          prev_txn: [txn0]
-        )
-
-      txn2 =
-        TransactionFactory.create_network_tx(:node_shared_secrets,
-          index: 2,
-          timestamp: curr_time |> DateTime.add(-7_200, :second),
-          prev_txn: [txn1]
-        )
-
-      txn3 =
-        TransactionFactory.create_network_tx(:node_shared_secrets,
-          index: 3,
-          timestamp: curr_time |> DateTime.add(-3_600, :second),
-          prev_txn: [txn2]
-        )
-
-      txn4 =
-        TransactionFactory.create_network_tx(:node_shared_secrets,
-          index: 4,
-          timestamp: curr_time,
-          prev_txn: [txn3]
-        )
-
-      :persistent_term.put(:node_shared_secrets_gen_addr, txn0.address)
-      %{txn0: txn0, txn1: txn1, txn2: txn2, txn3: txn3, txn4: txn4}
-    end
-
-    test "Should return :ok when Genesis Address are not loaded", _nss_chain do
-      # first time boot no txns exits yet
-      :persistent_term.put(:node_shared_secrets_gen_addr, nil)
-
-      assert :ok = NetworkChain.synchronous_resync(:node_shared_secrets)
-    end
-
-    test "Should return :ok when last address match (locally and remotely)", nss_chain do
-      # node restart but within renewal interval
-      me = self()
-      addr0 = nss_chain.txn0.address
-
-      MockDB
-      |> stub(:get_last_chain_address, fn ^addr0 ->
-        send(me, :local_last_addr_request)
-        {nss_chain.txn4.address, DateTime.utc_now()}
-      end)
-
-      MockClient
-      |> stub(:send_message, fn
-        _, %GetLastTransactionAddress{address: ^addr0}, _ ->
-          send(me, :remote_last_addr_request)
-          {:ok, %LastTransactionAddress{address: nss_chain.txn4.address}}
-
-        _, %GetTransaction{}, _ ->
-          send(me, :fetch_last_txn)
-      end)
-
-      assert :ok = NetworkChain.synchronous_resync(:node_shared_secrets)
-
-      assert_receive(:local_last_addr_request)
-      assert_receive(:remote_last_addr_request)
-      refute_receive(:fetch_last_txn)
-    end
-
-    test "should Retrieve and Store Network tx's, when last tx's not available", nss_chain do
-      # scenario nss chain
-      # addr0 -> addr1 -> addr2 -> addr3  -> addr4
-      # node1 =>  addr0 -> addr1 -> addr2
-      # node2 => addr0 -> addr1 -> addr2 -> addr3  -> addr4
-      addr0 = nss_chain.txn0.address
-      addr1 = nss_chain.txn1.address
-      addr2 = nss_chain.txn2.address
-      addr3 = nss_chain.txn3.address
-      addr4 = nss_chain.txn4.address
-
-      me = self()
-
-      now = DateTime.utc_now()
-
-      MockDB
-      |> stub(:list_chain_addresses, fn
-        ^addr0 -> [{addr1, now}, {addr2, now}, {addr3, now}, {addr4, now}]
-      end)
-      |> stub(:transaction_exists?, fn
-        ^addr4, _ -> false
-        ^addr3, _ -> false
-        ^addr2, _ -> true
-        ^addr1, _ -> true
-      end)
-      |> stub(:write_transaction, fn tx, _ ->
-        # to know this fx executed or not we use send
-        send(me, {:write_transaction, tx.address})
-        :ok
-      end)
-
-      MockClient
-      |> stub(:send_message, fn
-        _, %GetLastTransactionAddress{address: ^addr0}, _ ->
-          {:ok, %LastTransactionAddress{address: addr4}}
-
-        _, %GetTransaction{address: ^addr4}, _ ->
-          {:ok, nss_chain.txn4}
-
-        _, %GetTransaction{address: ^addr3}, _ ->
-          {:ok, nss_chain.txn3}
-
-        _, %GetTransactionInputs{address: ^addr3}, _ ->
-          {:ok, %TransactionInputList{inputs: []}}
-
-        _, %GetGenesisAddress{address: ^addr3}, _ ->
-          {:ok, %GenesisAddress{address: addr0, timestamp: DateTime.utc_now()}}
-
-        _, %GetTransactionChain{address: ^addr3, paging_state: ^addr2}, _ ->
-          {:ok,
-           %TransactionList{
-             transactions: [nss_chain.txn3, nss_chain.txn4],
-             more?: false,
-             paging_state: nil
-           }}
-      end)
-
-      assert :ok = NetworkChain.synchronous_resync(:node_shared_secrets)
-
-      # flow
-      # get_gen_addr(:pers_term) -> resolve_last_address ->   get_last_address
-      #                                                         |
-      # validate_and_store_transaction_chain <-   fetch_transaction_remotely
-      #    |
-      # transaction_exists? -> fetch_context(tx) -> get_last_txn (db then -> remote check)
-      #                                                                 |
-      # transaction_exists?(prev_txn\tx3) <- stream_previous_chain <- fetch_inputs_remotely
-      #    |
-      # stream_transaction_chain(addr3/prev-tx) -> fetch_genesis_address_remotely ->
-      #                                                                 |
-      # &TransactionChain.write/1 <- stream_remotely(addr3,addr2) <- get_last_address(locally)
-      #    |
-      #   write_transaction(tx4) -> ingest txn4
-      assert_receive({:write_transaction, ^addr3})
-      assert_receive({:write_transaction, ^addr4})
-    end
-
-    defp p2p_context() do
-      pb_key3 = Crypto.derive_keypair("key33", 0) |> elem(0)
-
-      SharedSecrets.add_origin_public_key(:software, Crypto.first_node_public_key())
-
-      coordinator_node = %Node{
-        first_public_key: Crypto.first_node_public_key(),
-        last_public_key: Crypto.last_node_public_key(),
-        authorized?: true,
-        available?: true,
-        authorization_date: DateTime.add(DateTime.utc_now(), -86_400, :second),
-        geo_patch: "AAA",
-        network_patch: "AAA",
-        enrollment_date: DateTime.add(DateTime.utc_now(), -86_400, :second),
-        reward_address: Crypto.derive_address(Crypto.last_node_public_key())
-      }
-
-      storage_nodes = [
-        %Node{
-          ip: {127, 0, 0, 1},
-          port: 3000,
-          first_public_key: pb_key3,
-          last_public_key: pb_key3,
-          available?: true,
-          authorized?: true,
-          geo_patch: "BBB",
-          network_patch: "BBB",
-          authorization_date: DateTime.add(DateTime.utc_now(), -86_400, :second),
-          reward_address: Crypto.derive_address(pb_key3),
-          enrollment_date: DateTime.add(DateTime.utc_now(), -86_400, :second)
-        }
-      ]
-
-      Enum.each(storage_nodes, &P2P.add_and_connect_node(&1))
-
-      # P2P.add_and_connect_node(welcome_node)
-      P2P.add_and_connect_node(coordinator_node)
     end
   end
 end

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -85,8 +85,14 @@ defmodule Archethic.P2P.MessageTest do
     end
 
     test "ListNodes message" do
-      assert %ListNodes{} =
-               %ListNodes{}
+      assert %ListNodes{authorized_and_available?: true} =
+               %ListNodes{authorized_and_available?: true}
+               |> Message.encode()
+               |> Message.decode()
+               |> elem(0)
+
+      assert %ListNodes{authorized_and_available?: false} =
+               %ListNodes{authorized_and_available?: false}
                |> Message.encode()
                |> Message.decode()
                |> elem(0)
@@ -716,7 +722,34 @@ defmodule Archethic.P2P.MessageTest do
               <<0, 0, 76, 168, 99, 61, 84, 206, 158, 226, 212, 161, 60, 62, 55, 101, 249, 142,
                 174, 178, 157, 241, 148, 35, 19, 177, 109, 40, 224, 179, 31, 66, 129, 4>>
           }
-        ]
+        ],
+        first_enrolled_node: %Node{
+          ip: {127, 0, 0, 1},
+          port: 3000,
+          http_port: 4000,
+          first_public_key:
+            <<0, 0, 182, 67, 168, 252, 227, 203, 142, 164, 142, 248, 159, 209, 249, 247, 86, 64,
+              92, 224, 91, 182, 122, 49, 209, 169, 96, 111, 219, 204, 57, 250, 59, 226>>,
+          last_public_key:
+            <<0, 0, 182, 67, 168, 252, 227, 203, 142, 164, 142, 248, 159, 209, 249, 247, 86, 64,
+              92, 224, 91, 182, 122, 49, 209, 169, 96, 111, 219, 204, 57, 250, 59, 226>>,
+          geo_patch: "FA9",
+          network_patch: "AVC",
+          available?: true,
+          average_availability: 0.8,
+          enrollment_date: ~U[2020-06-26 08:36:11Z],
+          authorization_date: ~U[2020-06-26 08:36:11Z],
+          authorized?: true,
+          reward_address:
+            <<0, 0, 163, 237, 233, 93, 14, 241, 241, 8, 144, 218, 105, 16, 138, 243, 223, 17, 182,
+              87, 9, 7, 53, 146, 174, 125, 5, 244, 42, 35, 209, 142, 24, 164>>,
+          last_address:
+            <<0, 0, 165, 32, 187, 102, 112, 133, 38, 17, 232, 54, 228, 173, 254, 94, 179, 32, 173,
+              88, 122, 234, 88, 139, 82, 26, 113, 42, 8, 183, 190, 163, 221, 112>>,
+          origin_public_key:
+            <<0, 0, 76, 168, 99, 61, 84, 206, 158, 226, 212, 161, 60, 62, 55, 101, 249, 142, 174,
+              178, 157, 241, 148, 35, 19, 177, 109, 40, 224, 179, 31, 66, 129, 4>>
+        }
       }
 
       assert msg ==

--- a/test/archethic/self_repair/sync_test.exs
+++ b/test/archethic/self_repair/sync_test.exs
@@ -236,7 +236,11 @@ defmodule Archethic.SelfRepair.SyncTest do
       MockDB
       |> stub(:register_stats, fn _, _, _, _ -> :ok end)
 
-      assert :ok = Sync.load_missed_transactions(DateTime.utc_now() |> DateTime.add(-86_400))
+      assert :ok =
+               Sync.load_missed_transactions(
+                 DateTime.utc_now() |> DateTime.add(-86_400),
+                 P2P.authorized_and_available_nodes()
+               )
 
       assert_received :storage
     end
@@ -403,7 +407,10 @@ defmodule Archethic.SelfRepair.SyncTest do
         {:ok, %NotFound{}}
     end)
 
-    Sync.load_missed_transactions(DateTime.utc_now() |> DateTime.add(-1, :hour))
+    Sync.load_missed_transactions(
+      DateTime.utc_now() |> DateTime.add(-1, :hour),
+      P2P.authorized_and_available_nodes()
+    )
 
     assert_receive {:new_replication_attestation, ^attestation2}
     assert_receive :should_request


### PR DESCRIPTION
# Description

Improve the way a node load the nodes into the memtable.

Currently when a node bootstraps, it request the node view from the bootstrapping nodes and add this view into the memtable. But if the node needs to do a bootstrap sync to repair the missed beacon summaries, this view may not be the good one and the self repair verification crashes. Also the node may have into its memtable some nodes that doesn't exists according to the last beacon summaries the node has synchronized.

To fix this I assumed that a node or its informations should be in the memtable only if the according transaction has been replicated. So when a node bootstrap it now request the current node view to be able to download what it needs, but only connect to these node but doesn't add them into the memtable. The only needed node in the memtable is the first enrolled node (to pass the self repair verification)

Here is major changes:
- During all bootstrap we now pass a list of connected node and doesn't use `P2P.authorized_and_available_nodes` (since the memtable is empty)
- When getting closest node we also get the first enrolled node and add it into memtable (used to synchronize first summaries)
- The message `ListNodes` now has an parameter to return only the authorized and available nodes (do not need other node when bootstrapping)
- A node always restore its last P2P view from the DB doesn't matter if it missed a self repair or not

/!\ Attention: This PR breaks a control that avoid an already connected node to overwrite the node connection informations and restart the connection with old informations. This will be fixed in other PR (to simplify review)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

- Starts 4 nodes and wait authorized and available
- Stop one in beginning of summary (the transaction of this summary will be signed by the other 3 nodes)
- At beginning of next summary stop another node
- When the other node goes globally unavailable, restart the first stopped node

Without the fix the restarted node cannot do its bootstrap_sync as it has only 2 available nodes in it's view (the 2 remaining up node)  but the summary contains transaction signed by 3 nodes

With the fix it restart using it's last known P2P view (3 nodes) but use only the 2 remaining nodes to download thing. And the self repair verification works well

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
