### PR TITLE
Fix an error in the Logger

### DIFF
--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -66,7 +66,7 @@ defmodule Archethic.SelfRepair do
               {:halt, :ok}
             catch
               error, message ->
-                Logger.error("Error during self repair #{error} #{message}")
+                Logger.error("Error during self repair #{inspect(error)} #{inspect(message)}")
                 {:cont, :error}
             end
           end)


### PR DESCRIPTION
# Description

Fixes the following error I encountered:
```
2023-06-13 13:14:18.735 [error] Task #PID<0.1765.0> started from Archethic.Supervisor terminating
** (Protocol.UndefinedError) protocol String.Chars not implemented for %RuntimeError{message: "Cannot make the self repair - Last aggregate not fetched"} of type RuntimeError (a struct). This protocol is implemented for the following type(s): Atom, BitString, Cldr.Currency, Cldr.LanguageTag, Cldr.LanguageTag.T, Cldr.LanguageTag.U, Complex, Date, DateTime, Decimal, ExJsonSchema.Validator.Error.AdditionalItems, ExJsonSchema.Validator.Error.AdditionalProperties, ExJsonSchema.Validator.Error.AllOf, ExJsonSchema.Validator.Error.AnyOf, ExJsonSchema.Validator.Error.Const, ExJsonSchema.Validator.Error.Contains, ExJsonSchema.Validator.Error.ContentEncoding, ExJsonSchema.Validator.Error.ContentMediaType, ExJsonSchema.Validator.Error.Dependencies, ExJsonSchema.Validator.Error.Enum, ExJsonSchema.Validator.Error.False, ExJsonSchema.Validator.Error.Format, ExJsonSchema.Validator.Error.IfThenElse, ExJsonSchema.Validator.Error.ItemsNotAllowed, ExJsonSchema.Validator.Error.MaxItems, ExJsonSchema.Validator.Error.MaxLength, ExJsonSchema.Validator.Error.MaxProperties, ExJsonSchema.Validator.Error.Maximum, ExJsonSchema.Validator.Error.MinItems, ExJsonSchema.Validator.Error.MinLength, ExJsonSchema.Validator.Error.MinProperties, ExJsonSchema.Validator.Error.Minimum, ExJsonSchema.Validator.Error.MultipleOf, ExJsonSchema.Validator.Error.Not, ExJsonSchema.Validator.Error.OneOf, ExJsonSchema.Validator.Error.Pattern, ExJsonSchema.Validator.Error.PropertyNames, ExJsonSchema.Validator.Error.Required, ExJsonSchema.Validator.Error.Type, ExJsonSchema.Validator.Error.UniqueItems, Float, Floki.Selector, Floki.Selector.AttributeSelector, Floki.Selector.Combinator, Floki.Selector.Functional, Floki.Selector.PseudoClass, Hex.Solver.Assignment, Hex.Solver.Constraints.Empty, Hex.Solver.Constraints.Range, Hex.Solver.Constraints.Union, Hex.Solver.Incompatibility, Hex.Solver.PackageRange, Hex.Solver.Term, Integer, List, NaiveDateTime, Phoenix.LiveComponent.CID, Time, URI, Version, Version.Requirement
    (elixir 1.14.1) lib/string/chars.ex:3: String.Chars.impl_for!/1
    (elixir 1.14.1) lib/string/chars.ex:22: String.Chars.to_string/1
    (archethic 1.1.1) lib/archethic/self_repair.ex:69: anonymous fn/3 in Archethic.SelfRepair.bootstrap_sync/1
    (elixir 1.14.1) lib/range.ex:383: Enumerable.Range.reduce/5
    (elixir 1.14.1) lib/enum.ex:2514: Enum.reduce_while/3
    (archethic 1.1.1) lib/archethic/self_repair.ex:63: Archethic.SelfRepair.bootstrap_sync/1
    (archethic 1.1.1) lib/archethic/bootstrap.ex:223: Archethic.Bootstrap.post_bootstrap/0
    (archethic 1.1.1) lib/archethic/bootstrap.ex:111: Archethic.Bootstrap.run/7
    (elixir 1.14.1) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (stdlib 4.1.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: &Archethic.Bootstrap.run/7
    Args: [{127, 0, 0, 1}, 3003, 4001, :tcp, [%Archethic.P2P.Node{first_public_key: <<0, 1, 29, 150, 125, 113, 178, 225, 53, 200, 66, 6, 221, 209, 8, 181, 146, 90, 44, 217, 156, 142, 188, 90, 181, 216, 253, 46, 201, 64, 12, 227, 201, 138>>, last_public_key: <<0, 1, 29, 150, 125, 113, 178, 225, 53, 200, 66, 6, 221, 209, 8, 181, 146, 90, 44, 217, 156, 142, 188, 90, 181, 216, 253, 46, 201, 64, 12, 227, 201, 138>>, last_address: nil, reward_address: nil, ip: {127, 0, 0, 1}, port: 3002, http_port: nil, geo_patch: "000", network_patch: "000", enrollment_date: nil, available?: false, synced?: false, average_availability: 1.0, availability_history: <<0::size(1)>>, authorized?: false, authorization_date: nil, transport: :tcp, origin_public_key: nil, last_update_date: ~U[2019-07-14 00:00:00Z], availability_update: ~U[2008-10-31 00:00:00Z]}], nil, <<0, 0, 210, 215, 125, 252, 245, 205, 206, 163, 87, 19, 163, 20, 183, 2, 48, 171, 30, 145, 43, 19, 21, 144, 49, 168, 180, 86, 91, 194, 206, 64, 151, 42>>]
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

not tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
