### PR TITLE
Fix connection infos overwrite

### DIFF
--- a/lib/archethic/bootstrap.ex
+++ b/lib/archethic/bootstrap.ex
@@ -228,6 +228,11 @@ defmodule Archethic.Bootstrap do
       Logger.info("Synchronization finished")
     end
 
+    # Connect nodes after all synchronization are finished
+    # so we have the latest connection infos available at this time
+    Logger.info("Try connection on all nodes")
+    P2P.list_nodes() |> P2P.connect_nodes()
+
     Archethic.Bootstrap.NetworkConstraints.persist_genesis_address()
 
     Logger.info("Enforced Resync: Started!")

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -56,7 +56,7 @@ defmodule Archethic.P2P do
       TaskSupervisor,
       not_connected_nodes,
       fn node = %Node{first_public_key: first_public_key} ->
-        do_connect_node(node)
+        do_connect_node(node, self())
 
         receive do
           :connected ->
@@ -73,16 +73,19 @@ defmodule Archethic.P2P do
     |> Stream.run()
   end
 
-  defp do_connect_node(%Node{
-         ip: ip,
-         port: port,
-         transport: transport,
-         first_public_key: first_public_key
-       }) do
+  defp do_connect_node(
+         %Node{
+           ip: ip,
+           port: port,
+           transport: transport,
+           first_public_key: first_public_key
+         },
+         from \\ nil
+       ) do
     if first_public_key == Crypto.first_node_public_key() do
       :ok
     else
-      {:ok, _pid} = Client.new_connection(ip, port, transport, first_public_key)
+      {:ok, _pid} = Client.new_connection(ip, port, transport, first_public_key, from)
       :ok
     end
   end

--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -45,6 +45,8 @@ defmodule Archethic.P2P do
 
   @doc """
   Establish a connection on a list of node in parallel
+  This function wait for the connections to be established
+  timeout for connection is 5 sec
   """
   @spec connect_nodes(list(Node.t())) :: :ok
   def connect_nodes(nodes) do

--- a/lib/archethic/p2p/client.ex
+++ b/lib/archethic/p2p/client.ex
@@ -12,10 +12,11 @@ defmodule Archethic.P2P.Client do
   use Knigge, otp_app: :archethic, default: DefaultImpl
 
   @callback new_connection(
-              :inet.ip_address(),
+              ip :: :inet.ip_address(),
               port :: :inet.port_number(),
-              P2P.supported_transport(),
-              Crypto.key()
+              transport :: P2P.supported_transport(),
+              node_first_public_key :: Crypto.key(),
+              from :: pid() | nil
             ) :: Supervisor.on_start()
 
   @callback send_message(

--- a/lib/archethic/p2p/client/connection/supervisor.ex
+++ b/lib/archethic/p2p/client/connection/supervisor.ex
@@ -26,7 +26,6 @@ defmodule Archethic.P2P.Client.ConnectionSupervisor do
 
   def add_connection(opts \\ []) do
     node_public_key = Keyword.get(opts, :node_public_key)
-    opts = Keyword.put(opts, :from, self())
 
     DynamicSupervisor.start_child(
       __MODULE__,

--- a/lib/archethic/p2p/mem_table.ex
+++ b/lib/archethic/p2p/mem_table.ex
@@ -283,26 +283,13 @@ defmodule Archethic.P2P.MemTable do
       {Keyword.fetch!(@discovery_index_position, :last_public_key), last_public_key},
       {Keyword.fetch!(@discovery_index_position, :reward_address), reward_address},
       {Keyword.fetch!(@discovery_index_position, :last_address), last_address},
-      {Keyword.fetch!(@discovery_index_position, :origin_public_key), origin_public_key}
+      {Keyword.fetch!(@discovery_index_position, :origin_public_key), origin_public_key},
+      {Keyword.fetch!(@discovery_index_position, :ip), ip},
+      {Keyword.fetch!(@discovery_index_position, :port), port},
+      {Keyword.fetch!(@discovery_index_position, :http_port), http_port},
+      {Keyword.fetch!(@discovery_index_position, :transport), transport},
+      {Keyword.fetch!(@discovery_index_position, :last_update_date), timestamp}
     ]
-
-    # We change connection informations only if these infos are newer than the actual ones
-    timestamp_pos = Keyword.fetch!(@discovery_index_position, :last_update_date)
-    last_update_date = :ets.lookup_element(@discovery_table, first_public_key, timestamp_pos)
-
-    changes =
-      if DateTime.compare(timestamp, last_update_date) != :lt do
-        changes ++
-          [
-            {Keyword.fetch!(@discovery_index_position, :ip), ip},
-            {Keyword.fetch!(@discovery_index_position, :port), port},
-            {Keyword.fetch!(@discovery_index_position, :http_port), http_port},
-            {Keyword.fetch!(@discovery_index_position, :transport), transport},
-            {timestamp_pos, timestamp}
-          ]
-      else
-        changes
-      end
 
     changes =
       if geo_patch != nil do

--- a/lib/archethic/p2p/mem_table_loader.ex
+++ b/lib/archethic/p2p/mem_table_loader.ex
@@ -8,7 +8,6 @@ defmodule Archethic.P2P.MemTableLoader do
 
   alias Archethic.DB
 
-  alias Archethic.P2P.Client
   alias Archethic.P2P.GeoPatch
   alias Archethic.P2P.MemTable
   alias Archethic.P2P.Node
@@ -148,14 +147,6 @@ defmodule Archethic.P2P.MemTableLoader do
     end
 
     Logger.info("Node loaded into in memory p2p tables", node: Base.encode16(first_public_key))
-
-    if first_public_key != Crypto.first_node_public_key() do
-      {:ok, %Node{ip: ip, port: port, transport: transport}} = MemTable.get_node(first_public_key)
-      {:ok, _pid} = Client.new_connection(ip, port, transport, first_public_key)
-      :ok
-    else
-      :ok
-    end
   end
 
   def load_transaction(%Transaction{

--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -77,9 +77,10 @@ defmodule Archethic.SelfRepair do
       try do
         :ok = Sync.load_missed_transactions(last_sync_date, download_nodes)
         {:halt, :ok}
-      catch
-        error, message ->
-          Logger.error("Error during self repair #{inspect(error)} #{inspect(message)}")
+      rescue
+        error ->
+          Logger.error("Error during bootstrap self repair")
+          Logger.error(Exception.format(:error, error, __STACKTRACE__))
           {:cont, :error}
       end
     end)

--- a/test/archethic/p2p/client/default_impl_test.exs
+++ b/test/archethic/p2p/client/default_impl_test.exs
@@ -1,0 +1,40 @@
+defmodule Archethic.P2P.Client.DefaultImplTest do
+  use ArchethicCase
+
+  alias Archethic.Crypto
+
+  alias Archethic.P2P.Client.ConnectionSupervisor
+  alias Archethic.P2P.Client.DefaultImpl
+
+  describe "new_connection/4" do
+    test "should not cancel connection if already connected even if infos are updated" do
+      ip = {127, 0, 0, 1}
+      port = 3002
+      transport = :tcp
+      node_public_key = Crypto.first_node_public_key()
+      {:ok, pid} = DefaultImpl.new_connection(ip, port, transport, node_public_key)
+
+      # get_state to wait connection process finished
+      :sys.get_state(pid)
+      ConnectionSupervisor.set_node_connected(node_public_key)
+
+      assert {:ok, ^pid} = DefaultImpl.new_connection(ip, 3003, transport, node_public_key)
+    end
+
+    test "should cancel connection and create new one if node not connected and infos are updated" do
+      ip = {127, 0, 0, 1}
+      port = 3002
+      transport = :tcp
+      node_public_key = Crypto.first_node_public_key()
+      {:ok, pid1} = DefaultImpl.new_connection(ip, port, transport, node_public_key)
+
+      # get_state to wait connection process finished
+      :sys.get_state(pid1)
+      ConnectionSupervisor.set_node_disconnected(node_public_key)
+
+      {:ok, pid2} = DefaultImpl.new_connection(ip, 3003, transport, node_public_key)
+
+      assert pid1 != pid2
+    end
+  end
+end


### PR DESCRIPTION
# Description

This issue fixes an problem when a node replicate an old node transaction with old connection informations (ip port, transport).
If this happen the active connection that may be good is killed and a new one is created with the old informations. So the node lose a good connection and may be stuck to download rest of summaries / transactions.

To fix this, there is a new control: if the connection status is connected we don't overwrite the current connection.

Also improve the connection when the node start, it was creating a new connection when loading all transaction in MemTableLoader init. Instead, we now wait for all synchronization to finish and then connect with the latest informations available

## Type of change

- Bug fix (non-breaking change which fixes an issue)

Unit test
Start nodes, stop one and change its p2p port.
Start an other node, it should not have warning log informing a node connection is closed

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
