### PR TITLE
Smart Contracts: datetime must be rounded to the minute

### DIFF
--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -89,11 +89,37 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                |> ActionInterpreter.parse()
 
       code = ~S"""
-      actions triggered_by: datetime, at: 1676282771 do
+      actions triggered_by: datetime, at: 1676282760 do
       end
       """
 
-      assert {:ok, {:datetime, ~U[2023-02-13 10:06:11Z]}, _} =
+      assert {:ok, {:datetime, ~U[2023-02-13 10:06:00Z]}, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionInterpreter.parse()
+    end
+
+    test "should not parse if datetime is not rounded" do
+      code = ~S"""
+      actions triggered_by: datetime, at: 1687164224 do
+      end
+      """
+
+      assert {:error, _, "Datetime triggers must be rounded to the minute"} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionInterpreter.parse()
+    end
+
+    test "should return a proper error message if trigger is invalid" do
+      code = ~S"""
+      actions triggered_by: datetime do
+      end
+      """
+
+      assert {:error, _, "Invalid trigger"} =
                code
                |> Interpreter.sanitize_code()
                |> elem(1)

--- a/test/archethic/contracts/interpreter/library/common/time_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/time_test.exs
@@ -17,7 +17,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
 
   describe "now/0" do
     test "should work in the action block" do
-      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      datetime = ~U[1970-01-01 00:00:00Z]
       timestamp = DateTime.to_unix(datetime)
 
       code = ~s"""
@@ -51,7 +51,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
     end
 
     test "should run the contract if condition is truthy" do
-      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      datetime = ~U[1970-01-01 00:00:00Z]
       timestamp = DateTime.to_unix(datetime)
 
       code = ~s"""
@@ -94,7 +94,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
     end
 
     test "should fail the contract if condition is falsy" do
-      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      datetime = ~U[1970-01-01 00:00:00Z]
       timestamp = DateTime.to_unix(datetime)
 
       code = ~s"""
@@ -135,7 +135,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
     end
 
     test "should run the contract if condition inherit is truthy" do
-      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      datetime = ~U[1970-01-01 00:00:00Z]
       timestamp = DateTime.to_unix(datetime)
 
       code = ~s"""
@@ -167,7 +167,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
     end
 
     test "should fail the contract if condition inherit is falsy" do
-      datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+      datetime = ~U[1970-01-01 00:00:00Z]
       timestamp = DateTime.to_unix(datetime)
 
       code = ~s"""

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -428,7 +428,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should be able to simulate a trigger: datetime" do
       code = """
         @version 1
-        actions triggered_by: datetime, at: 1678984136 do
+        actions triggered_by: datetime, at: 1678984140 do
           Contract.set_content "hello"
         end
       """
@@ -442,7 +442,7 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       assert {:ok, %Transaction{}} =
                Interpreter.execute(
-                 {:datetime, ~U[2023-03-16 16:28:56Z]},
+                 {:datetime, ~U[2023-03-16 16:29:00Z]},
                  Contract.from_transaction!(contract_tx),
                  nil,
                  []


### PR DESCRIPTION
# Description

With datetime trigger there is a possibility for a contract to run every second. This PR force the datetime to be on a minute.

Documentation included in https://github.com/archethic-foundation/archethic-docs/pull/43

Fixes #992

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests added.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
