### PR TITLE
Increase add mining context timeout to max_timeout

### DIFF
--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -15,6 +15,7 @@ defmodule Archethic.Mining do
   alias __MODULE__.WorkflowRegistry
 
   alias Archethic.P2P
+  alias Archethic.P2P.Message
   alias Archethic.P2P.Message.ReplicationError
 
   alias Archethic.TransactionChain.Transaction
@@ -104,7 +105,7 @@ defmodule Archethic.Mining do
         io_storage_nodes_view
       ) do
     tx_address
-    |> get_mining_process!()
+    |> get_mining_process!(Message.get_max_timeout())
     |> DistributedWorkflow.add_mining_context(
       validation_node_public_key,
       P2P.get_nodes_info(previous_storage_nodes_keys),
@@ -199,7 +200,7 @@ defmodule Archethic.Mining do
   end
 
   defp get_mining_process!(tx_address, timeout \\ 3_000) do
-    retry_while with: exponential_backoff(100, 2) |> expiry(timeout) do
+    retry_while with: constant_backoff(100) |> expiry(timeout) do
       case Registry.lookup(WorkflowRegistry, tx_address) do
         [{pid, _}] ->
           {:halt, pid}

--- a/lib/archethic/p2p/message/add_mining_context.ex
+++ b/lib/archethic/p2p/message/add_mining_context.ex
@@ -22,7 +22,9 @@ defmodule Archethic.P2P.Message.AddMiningContext do
 
   alias Archethic.Crypto
   alias Archethic.Mining
+  alias Archethic.P2P.Message
   alias Archethic.P2P.Message.Ok
+  alias Archethic.TaskSupervisor
   alias Archethic.Utils
 
   @type t :: %__MODULE__{
@@ -46,15 +48,21 @@ defmodule Archethic.P2P.Message.AddMiningContext do
         },
         _
       ) do
-    :ok =
-      Mining.add_mining_context(
-        tx_address,
-        validation_node,
-        previous_storage_nodes_public_keys,
-        chain_storage_nodes_view,
-        beacon_storage_nodes_view,
-        io_storage_nodes_view
-      )
+    Task.Supervisor.async_nolink(
+      TaskSupervisor,
+      fn ->
+        Mining.add_mining_context(
+          tx_address,
+          validation_node,
+          previous_storage_nodes_public_keys,
+          chain_storage_nodes_view,
+          beacon_storage_nodes_view,
+          io_storage_nodes_view
+        )
+      end,
+      timeout: Message.get_max_timeout(),
+      shutdown: :brutal_kill
+    )
 
     %Ok{}
   end


### PR DESCRIPTION
# Description

There is some possibility due to high network latency that a coordinator node receive a start mining message after the timeout of  processing the context received from cross validation nodes.
In this case the coordinator wait for the context it'll never receive and the cross validation node wait for the validation stamp they'll never receive.
The coordinator fall in timeout due to no context received and notify the welcome node of transaction failure. While the cross validation nodes elect a new coordinator node and continue the validation.

This PR fixes it by increasing the add mining context processing to the maximum time before changing the coordinator node

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
