### PR TITLE
Bugfix : CSS assets are not available in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM elixir:1.14.1-alpine AS archethic-ci
 
 ARG with_tests=1
 ARG MIX_ENV=prod
-ARG USER_ID 
+ARG USER_ID
 ARG GROUP_ID
 
 # CI
@@ -36,7 +36,7 @@ RUN apk add --no-cache --update \
   openssl \
   libsodium-dev \
   libexecinfo-dev \
-  gmp-dev 
+  gmp-dev
 
 # Install hex and rebar
 RUN mix local.rebar --force \
@@ -49,12 +49,10 @@ COPY mix.exs mix.lock ./
 COPY config ./config
 RUN mix do deps.get, deps.compile
 
-# build assets
-COPY priv ./priv
-COPY assets ./assets 
-RUN npm --prefix ./assets ci --progress=false --no-audit --loglevel=error 
-
 COPY . .
+
+# build assets
+RUN npm --prefix ./assets ci --progress=false --no-audit --loglevel=error
 
 RUN git config user.name aebot \
   && git config user.email aebot@archethic.net \
@@ -74,7 +72,7 @@ FROM archethic-ci as build
 
 FROM elixir:1.14.1-alpine
 
-ARG USER_ID 
+ARG USER_ID
 ARG GROUP_ID
 
 RUN apk add --no-cache --update bash git openssl libsodium libexecinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,13 @@ RUN apk add --no-cache --update \
 
 # https://github.com/cargosense/dart_sass#compatibility-with-alpine-linux-mix-sass-default-exited-with-2
 ENV GLIBC_VERSION=2.34-r0
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub &&
-  wget -q -O /tmp/glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk &&
-  apk add --force-overwrite /tmp/glibc.apk &&
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub &&\
+  wget -q -O /tmp/glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk &&\
+  apk add --force-overwrite /tmp/glibc.apk &&\
   rm -rf /tmp/glibc.apk
 
 # Install hex and rebar
-RUN mix local.rebar --force &&
+RUN mix local.rebar --force &&\
   mix local.hex --if-missing --force
 
 WORKDIR /opt/code
@@ -63,8 +63,8 @@ RUN npm --prefix ./assets ci --progress=false --no-audit --loglevel=error
 
 COPY . .
 
-RUN git config user.name aebot &&
-  git config user.email aebot@archethic.net &&
+RUN git config user.name aebot &&\
+  git config user.email aebot@archethic.net &&\
   git remote add origin https://github.com/archethic-foundation/archethic-node
 
 # build release
@@ -72,7 +72,7 @@ RUN mix assets.saas
 RUN mix assets.deploy
 RUN MIX_ENV=${MIX_ENV} mix distillery.release
 # Install
-RUN mkdir -p /opt/app &&
+RUN mkdir -p /opt/app &&\
   tar zxf /opt/code/_build/${MIX_ENV}/rel/archethic_node/releases/*/archethic_node.tar.gz -C /opt/app
 CMD /opt/app/bin/archethic_node foreground
 


### PR DESCRIPTION
Seems because app folder is copied over the built assets.

Looks like COPYing the app folder once is sufficient to be able to build everything after

(Rebased over today's develop branch)