### PR TITLE
Add miniupnpc to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ FROM elixir:1.14.1-alpine
 ARG USER_ID 
 ARG GROUP_ID
 
-RUN apk add --no-cache --update bash git openssl libsodium libexecinfo
+RUN apk add --no-cache --update bash git openssl libsodium libexecinfo miniupnpc
 
 COPY --from=build /opt/app /opt/app
 COPY --from=build /opt/code/.git /opt/code/.git


### PR DESCRIPTION
required since the application do not build it itsef anymore

```
2023-06-20 07:49:46.360 [notice] Application archethic exited: exited in: Archethic.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (ErlangError) Erlang error: :enoent
            (elixir 1.14.1) lib/system.ex:1060: System.cmd("upnpc", ["-s"], [])
            (archethic 1.1.2) lib/archethic/networking/ip_lookup/nat_discovery/miniupnp.ex:32: Archethic.Networking.IPLookup.NATDiscovery.MiniUPNP.get_local_ip/0
            (archethic 1.1.2) lib/archethic/networking/ip_lookup/nat_discovery/miniupnp.ex:25: Archethic.Networking.IPLookup.NATDiscovery.MiniUPNP.open_port/1
            (archethic 1.1.2) lib/archethic/networking/port_forwarding.ex:21: Archethic.Networking.PortForwarding.try_open_port/2
            (archethic 1.1.2) lib/archethic/application.ex:63: Archethic.Application.start/2
            (kernel 8.5.1) application_master.erl:347: :application_master.start_supervisor/3
            (kernel 8.5.1) application_master.erl:329: :application_master.start_the_app/5
            (kernel 8.5.1) application_master.erl:315: :application_master.start_it_new/7
[os_mon] memory supervisor port (memsup): Erlang has closed
```