### PR TITLE
Add release/* branch in Github action ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Elixir CI
 
 on:
   push:
-    branches: [master, develop, testnet]
+    branches: [master, develop, testnet, "release/*"]
   pull_request:
-    branches: [master, develop, testnet]
+    branches: [master, develop, testnet, "release/*"]
 
 env:
   MIX_ENV: test


### PR DESCRIPTION
# Description

Since we use release branch there is no ci that  runs on these branch.
I propose to name the release branch as `release/[version]` so we can add this pattern in the ci.yml

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
