### PR TITLE
Add appup transform to restart telemetry

### DIFF
--- a/lib/release/restart_telemetry.ex
+++ b/lib/release/restart_telemetry.ex
@@ -1,0 +1,23 @@
+defmodule Archethic.Release.RestartTelemetry do
+  @moduledoc false
+
+  alias Archethic.Telemetry
+
+  use Distillery.Releases.Appup.Transform
+
+  def up(:archethic, _v1, _v2, instructions, _opts),
+    do: add_telemetry_restart(instructions)
+
+  def up(_, _, _, instructions, _), do: instructions
+
+  def down(_, _, _, instructions, _), do: instructions
+
+  defp add_telemetry_restart(instructions) do
+    restart_instructions = [
+      {:apply, {:supervisor, :terminate_child, [Telemetry, :prometheus_metrics]}},
+      {:apply, {:supervisor, :restart_child, [Telemetry, :prometheus_metrics]}}
+    ]
+
+    instructions ++ restart_instructions
+  end
+end

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -59,6 +59,7 @@ release :archethic_node do
 
   set appup_transforms: [
     {Archethic.Release.TransformPurge, []},
+    {Archethic.Release.RestartTelemetry, []},
     {Archethic.Release.CallMigrateScript, []}
   ]
 end


### PR DESCRIPTION
# Description

When we update the telemetry metrics, we need to restart the telemetry process to update metrics with the updated ones.

To solve this I added an appup transform to restart the prometheus metrics started by supervisor Archethic.Telemetry

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Update project version, create a new appup with `mix distillery.gen.appup --app archethic`
instructions are just before the migration script

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
