### PR TITLE
remove warnings about 'not a directory'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ all: compile_c_programs
 
 compile_c_programs:
 	mkdir -p priv/c_dist
-	$(CC) src/c/crypto/stdio_helpers.c src/c/crypto/ed25519.c -o priv/c_dist/libsodium_port -I src/c/crypto/stdio_helpers.h -lsodium
+	$(CC) src/c/crypto/stdio_helpers.c src/c/crypto/ed25519.c -o priv/c_dist/libsodium_port -I src/c/crypto -lsodium
 	$(CC) src/c/hypergeometric_distribution.c -o priv/c_dist/hypergeometric_distribution -lgmp
 
 ifeq ($(TPM_INSTALLED),0)
-	$(CC) src/c/crypto/stdio_helpers.c src/c/crypto/tpm/lib.c src/c/crypto/tpm/port.c -o priv/c_dist/tpm_port -I src/c/crypto/stdio_helpers.h -I src/c/crypto/tpm/lib.h $(TPMFLAGS)
-	$(CC) src/c/crypto/tpm/keygen.c src/c/crypto/tpm/lib.c -o priv/c_dist/tpm_keygen -I src/c/crypto/tpm/lib.h $(TPMFLAGS)
+	$(CC) src/c/crypto/stdio_helpers.c src/c/crypto/tpm/lib.c src/c/crypto/tpm/port.c -o priv/c_dist/tpm_port -I src/c/crypto -I src/c/crypto/tpm $(TPMFLAGS)
+	$(CC) src/c/crypto/tpm/keygen.c src/c/crypto/tpm/lib.c -o priv/c_dist/tpm_keygen -I src/c/crypto/tpm $(TPMFLAGS)
 endif
 
 clean:


### PR DESCRIPTION
```
mkdir -p priv/c_dist
/usr/bin/gcc src/c/crypto/stdio_helpers.c src/c/crypto/ed25519.c -o priv/c_dist/libsodium_port -I src/c/crypto/stdio_helpers.h -lsodium
cc1: warning: src/c/crypto/stdio_helpers.h: not a directory
cc1: warning: src/c/crypto/stdio_helpers.h: not a directory
/usr/bin/gcc src/c/hypergeometric_distribution.c -o priv/c_dist/hypergeometric_distribution -lgmp
/usr/bin/gcc src/c/crypto/stdio_helpers.c src/c/crypto/tpm/lib.c src/c/crypto/tpm/port.c -o priv/c_dist/tpm_port -I src/c/crypto/stdio_helpers.h -I src/c/crypto/tpm/lib.h -ltss2-esys -ltss2-rc -ltss2-mu -lcrypto
cc1: warning: src/c/crypto/stdio_helpers.h: not a directory
cc1: warning: src/c/crypto/tpm/lib.h: not a directory
cc1: warning: src/c/crypto/stdio_helpers.h: not a directory
cc1: warning: src/c/crypto/tpm/lib.h: not a directory
cc1: warning: src/c/crypto/stdio_helpers.h: not a directory
cc1: warning: src/c/crypto/tpm/lib.h: not a directory
/usr/bin/gcc src/c/crypto/tpm/keygen.c src/c/crypto/tpm/lib.c -o priv/c_dist/tpm_keygen -I src/c/crypto/tpm/lib.h -ltss2-esys -ltss2-rc -ltss2-mu -lcrypto
cc1: warning: src/c/crypto/tpm/lib.h: not a directory
cc1: warning: src/c/crypto/tpm/lib.h: not a directory
```

to 

```
/usr/bin/gcc src/c/crypto/stdio_helpers.c src/c/crypto/ed25519.c -o priv/c_dist/libsodium_port -I src/c/crypto -lsodium
/usr/bin/gcc src/c/hypergeometric_distribution.c -o priv/c_dist/hypergeometric_distribution -lgmp
/usr/bin/gcc src/c/crypto/stdio_helpers.c src/c/crypto/tpm/lib.c src/c/crypto/tpm/port.c -o priv/c_dist/tpm_port -I src/c/crypto -I src/c/crypto/tpm -ltss2-esys -ltss2-rc -ltss2-mu -lcrypto
/usr/bin/gcc src/c/crypto/tpm/keygen.c src/c/crypto/tpm/lib.c -o priv/c_dist/tpm_keygen -I src/c/crypto/tpm -ltss2-esys -ltss2-rc -ltss2-mu -lcrypto
```