### PR TITLE
Fix bootstrap sync restart

### DIFF
--- a/lib/archethic/bootstrap.ex
+++ b/lib/archethic/bootstrap.ex
@@ -236,7 +236,7 @@ defmodule Archethic.Bootstrap do
       Logger.info("Synchronization started")
       # Always load the current node list to have the current view for downloading transaction
       {:ok, current_nodes} = Sync.connect_current_node(closest_bootstrapping_nodes)
-      :ok = SelfRepair.bootstrap_sync(last_sync_date, current_nodes)
+      :ok = SelfRepair.bootstrap_sync(current_nodes)
       Logger.info("Synchronization finished")
     end
 

--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -68,6 +68,8 @@ defmodule Archethic.SelfRepair do
         Logger.error(
           "Bootstrap Sync failed to load missed transactions after max retry of #{@max_retry_count} !"
         )
+
+        :error
     end
   end
 


### PR DESCRIPTION
# Description

There is an issue in the bootstrap sync restart strategy.
Currently when a repair crash we restart it until 10 tries, but we restart it with the last sync date received in parameter but not the one the failed repair succeeded to reach. 
Fixes it by restarting from the last sync date stored in memory

Also fixes an issue where the function bootstrap_sync do not return the expected :error atom

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
