### PR TITLE
Smart Contracts: Allow a contract without trigger:transaction to receive calls

### DIFF
--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -94,4 +94,12 @@ defmodule Archethic.Contracts.Contract do
       ) do
     Map.update!(contract, :conditions, &Map.put(&1, condition_name, conditions))
   end
+
+  @doc """
+  Return wether or not a contract accepts calls.
+  """
+  @spec can_receive_calls?(t()) :: boolean()
+  def can_receive_calls?(%__MODULE__{conditions: conditions}) do
+    Map.has_key?(conditions, :transaction)
+  end
 end

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -94,12 +94,4 @@ defmodule Archethic.Contracts.Contract do
       ) do
     Map.update!(contract, :conditions, &Map.put(&1, condition_name, conditions))
   end
-
-  @doc """
-  Return wether or not a contract accepts calls.
-  """
-  @spec can_receive_calls?(t()) :: boolean()
-  def can_receive_calls?(%__MODULE__{conditions: conditions}) do
-    Map.has_key?(conditions, :transaction)
-  end
 end

--- a/lib/archethic/p2p/message/validate_smart_contract_call.ex
+++ b/lib/archethic/p2p/message/validate_smart_contract_call.ex
@@ -172,7 +172,6 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCall do
     valid? =
       with {:ok, contract_tx} <- TransactionChain.get_transaction(contract_address),
            {:ok, contract} <- Contracts.from_transaction(contract_tx),
-           :ok <- check_can_receive_calls(contract),
            true <-
              Contracts.valid_condition?(:transaction, contract, transaction, datetime),
            :ok <- maybe_execute_trigger(contract, transaction, time_now: datetime) do
@@ -185,14 +184,6 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCall do
     %SmartContractCallValidation{
       valid?: valid?
     }
-  end
-
-  defp check_can_receive_calls(contract) do
-    if Contract.can_receive_calls?(contract) do
-      :ok
-    else
-      {:error, :contract_cannot_be_called}
-    end
   end
 
   defp maybe_execute_trigger(contract = %Contract{triggers: triggers}, transaction, opts) do

--- a/lib/archethic/p2p/message/validate_smart_contract_call.ex
+++ b/lib/archethic/p2p/message/validate_smart_contract_call.ex
@@ -7,6 +7,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCall do
   defstruct [:contract_address, :transaction, :inputs_before]
 
   alias Archethic.Contracts
+  alias Archethic.Contracts.Contract
   alias Archethic.Crypto
   alias Archethic.P2P.Message.SmartContractCallValidation
   alias Archethic.TransactionChain
@@ -171,12 +172,10 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCall do
     valid? =
       with {:ok, contract_tx} <- TransactionChain.get_transaction(contract_address),
            {:ok, contract} <- Contracts.from_transaction(contract_tx),
+           :ok <- check_can_receive_calls(contract),
            true <-
              Contracts.valid_condition?(:transaction, contract, transaction, datetime),
-           {:ok, _} <-
-             Contracts.execute_trigger(:transaction, contract, transaction, [transaction],
-               time_now: datetime
-             ) do
+           :ok <- maybe_execute_trigger(contract, transaction, time_now: datetime) do
         true
       else
         _ ->
@@ -186,5 +185,27 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCall do
     %SmartContractCallValidation{
       valid?: valid?
     }
+  end
+
+  defp check_can_receive_calls(contract) do
+    if Contract.can_receive_calls?(contract) do
+      :ok
+    else
+      {:error, :contract_cannot_be_called}
+    end
+  end
+
+  defp maybe_execute_trigger(contract = %Contract{triggers: triggers}, transaction, opts) do
+    if Map.has_key?(triggers, :transaction) do
+      case Contracts.execute_trigger(:transaction, contract, transaction, [transaction], opts) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      :ok
+    end
   end
 end

--- a/test/archethic/p2p/message/validate_smart_contract_call_test.exs
+++ b/test/archethic/p2p/message/validate_smart_contract_call_test.exs
@@ -65,7 +65,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
                |> ValidateSmartContractCall.process(:crypto.strong_rand_bytes(32))
     end
 
-    test "should validate smart contract that does not have a transaction trigger but has a condition transaction" do
+    test "should validate smart contract that does not have a transaction trigger" do
       MockDB
       |> expect(:get_transaction, fn "@SC1", _, _ ->
         {:ok,
@@ -73,8 +73,6 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
            data: %TransactionData{
              code: ~s"""
              @version 1
-
-             condition transaction: []
 
              actions triggered_by: datetime, at: 1687874880 do
                calls = Contract.get_calls
@@ -92,39 +90,6 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
       }
 
       assert %SmartContractCallValidation{valid?: true} =
-               %ValidateSmartContractCall{
-                 contract_address: "@SC1",
-                 transaction: incoming_tx,
-                 inputs_before: DateTime.utc_now()
-               }
-               |> ValidateSmartContractCall.process(:crypto.strong_rand_bytes(32))
-    end
-
-    test "should not validate smart contract that does not have a condition transaction" do
-      MockDB
-      |> expect(:get_transaction, fn "@SC1", _, _ ->
-        {:ok,
-         %Transaction{
-           data: %TransactionData{
-             code: ~s"""
-             @version 1
-
-             actions triggered_by: datetime, at: 1687874880 do
-               calls = Contract.get_calls
-               Contract.set_content List.size(calls)
-             end
-             """
-           }
-         }}
-      end)
-
-      incoming_tx = %Transaction{
-        data: %TransactionData{
-          content: "hola"
-        }
-      }
-
-      assert %SmartContractCallValidation{valid?: false} =
                %ValidateSmartContractCall{
                  contract_address: "@SC1",
                  transaction: incoming_tx,


### PR DESCRIPTION
# Description

Due to the verification of the recipients introduced in v1.2, it is now impossible to send calls to a contract that does not have a `trigger transaction`. This PR change the logic to: A contract must have a `condition transaction` to receive a call.

## Type of change

- Regression 

# How Has This Been Tested?

Unit tested & tested with playbook "Faucet" 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
