### PR TITLE
Fix P2P availability_update on bootstrap

### DIFF
--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -166,9 +166,11 @@ defmodule Archethic.P2P do
           first_public_key :: Crypto.key(),
           availability_update :: DateTime.t()
         ) :: :ok
-  defdelegate set_node_globally_available(first_public_key, availability_update),
-    to: MemTable,
-    as: :set_node_available
+  def set_node_globally_available(first_public_key, availability_update) do
+    unless available_node?(first_public_key) do
+      MemTable.set_node_available(first_public_key, availability_update)
+    end
+  end
 
   @doc """
   Remove a node first public key to the list of nodes globally available.
@@ -177,9 +179,11 @@ defmodule Archethic.P2P do
           first_public_key :: Crypto.key(),
           availability_update :: DateTime.t()
         ) :: :ok
-  defdelegate set_node_globally_unavailable(first_public_key, availability_update),
-    to: MemTable,
-    as: :set_node_unavailable
+  def set_node_globally_unavailable(first_public_key, availability_update) do
+    if available_node?(first_public_key) do
+      MemTable.set_node_unavailable(first_public_key, availability_update)
+    end
+  end
 
   @doc """
   Add a node first public key to the list of nodes globally synced.

--- a/lib/archethic/p2p/mem_table_loader.ex
+++ b/lib/archethic/p2p/mem_table_loader.ex
@@ -72,10 +72,7 @@ defmodule Archethic.P2P.MemTableLoader do
         MemTable.set_node_synced(node_key)
         MemTable.set_node_available(node_key, availability_update)
         MemTable.update_node_average_availability(node_key, avg_availability)
-
-        if network_patch do
-          MemTable.update_node_network_patch(node_key, network_patch)
-        end
+        MemTable.update_node_network_patch(node_key, network_patch)
 
       [] ->
         MemTable.set_node_synced(node_key)
@@ -182,15 +179,14 @@ defmodule Archethic.P2P.MemTableLoader do
   defp load_p2p_summary(
          {node_public_key, available?, avg_availability, availability_update, network_patch}
        ) do
+    MemTable.update_node_average_availability(node_public_key, avg_availability)
+    MemTable.update_node_network_patch(node_public_key, network_patch)
+
     if available? do
       MemTable.set_node_synced(node_public_key)
       MemTable.set_node_available(node_public_key, availability_update)
-    end
-
-    MemTable.update_node_average_availability(node_public_key, avg_availability)
-
-    if network_patch do
-      MemTable.update_node_network_patch(node_public_key, network_patch)
+    else
+      MemTable.set_node_unavailable(node_public_key, availability_update)
     end
   end
 end


### PR DESCRIPTION
# Description

This PR fixes an issue when a node starts, it load the previous P2P view from DB but it does not set the availability_update field of a node with the latest value when the node was marked as unavailable.
This then lead to issue in self repair, mainly while verifying the replication attestation confirmations

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
