### PR TITLE
Change stats serialization

### DIFF
--- a/lib/archethic/db/embedded_impl/stats_info.ex
+++ b/lib/archethic/db/embedded_impl/stats_info.ex
@@ -91,9 +91,9 @@ defmodule Archethic.DB.EmbeddedImpl.StatsInfo do
   end
 
   defp load_from_file(fd, acc \\ {0.0, 0, 0}) do
-    # Read each stats entry 20 bytes: 4(timestamp) + 8(tps) + 4(nb transactions) + 4(burned_fees)
-    case :file.read(fd, 20) do
-      {:ok, <<_timestamp::32, tps::float-64, nb_transactions::32, burned_fees::32>>} ->
+    # Read each stats entry 28 bytes: 4(timestamp) + 8(tps) + 8(nb transactions) + 8(burned_fees)
+    case :file.read(fd, 28) do
+      {:ok, <<_timestamp::32, tps::float-64, nb_transactions::64, burned_fees::64>>} ->
         {_, prev_nb_transactions, _} = acc
         load_from_file(fd, {tps, prev_nb_transactions + nb_transactions, burned_fees})
 
@@ -129,7 +129,7 @@ defmodule Archethic.DB.EmbeddedImpl.StatsInfo do
   defp append_to_file(fd, date, tps, nb_transactions, burned_fees) do
     IO.binwrite(
       fd,
-      <<DateTime.to_unix(date)::32, tps::float-64, nb_transactions::32, burned_fees::32>>
+      <<DateTime.to_unix(date)::32, tps::float-64, nb_transactions::64, burned_fees::64>>
     )
   end
 end

--- a/priv/migration_tasks/prod/1.2.2@stats_info.exs
+++ b/priv/migration_tasks/prod/1.2.2@stats_info.exs
@@ -1,0 +1,40 @@
+defmodule Migration_1_2_2 do
+  @moduledoc """
+  Serialize burned_fees & nb_transactions on 8 bytes instead of 4.
+  """
+
+  alias Archethic.Utils
+
+  def run() do
+    db_path = Utils.mut_dir()
+    filepath = Path.join(db_path, "stats")
+    filepath_backup = Path.join(db_path, "stats.backup")
+
+    # make a backup
+    :ok = File.rename(filepath, filepath_backup)
+
+    # open 2 file descriptors
+    fd_old = File.open!(filepath_backup, [:binary, :read])
+    fd_new = File.open!(filepath, [:binary, :append])
+
+    :ok = migrate_line(fd_old, fd_new)
+    File.close(fd_old)
+    File.close(fd_new)
+
+    # remove backup
+    File.rm(filepath_backup)
+  end
+
+  defp migrate_line(fd_old, fd_new) do
+    # Read 20 bytes from old
+    case :file.read(fd_old, 20) do
+      {:ok, <<timestamp::32, tps::float-64, nb_transactions::32, burned_fees::32>>} ->
+        # Write 28 bytes to new
+        :ok = IO.binwrite(fd_new, <<timestamp::32, tps::float-64, nb_transactions::64, burned_fees::64>>)
+        migrate_line(fd_old, fd_new)
+
+      :eof ->
+        :ok
+    end
+  end
+end


### PR DESCRIPTION
# Description

Serialize nb_transaction & burned_fees on 64 bits instead of 32 bits.
Fixes #1059 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested with data from mainnet
- Tested with hotreload after a benchmark

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
