### PR TITLE
Cancel slot timer before creating a new one

### DIFF
--- a/lib/archethic/beacon_chain/slot_timer.ex
+++ b/lib/archethic/beacon_chain/slot_timer.ex
@@ -102,6 +102,11 @@ defmodule Archethic.BeaconChain.SlotTimer do
   def handle_info(:node_up, state = %{interval: interval}) do
     Logger.info("Slot Timer: Starting...")
 
+    case Map.get(state, :timer, nil) do
+      nil -> :ok
+      timer -> Process.cancel_timer(timer)
+    end
+
     new_state =
       state
       |> Map.put(:timer, schedule_new_slot(interval))


### PR DESCRIPTION
# Description

Fixes an issue where the slot timer could have 2 timer in the same time

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
