### PR TITLE
Reduce concurrency while downloading aggregate

### DIFF
--- a/lib/archethic/beacon_chain.ex
+++ b/lib/archethic/beacon_chain.ex
@@ -136,8 +136,6 @@ defmodule Archethic.BeaconChain do
     end
   end
 
-  def load_transaction(_), do: :ok
-
   defp validate_slot(slot = %Slot{}) do
     cond do
       !SlotValidation.valid_transaction_attestations?(slot) ->


### PR DESCRIPTION
# Description

Decrease the concurrency while downloading the summary aggregate in self repair.
As they are processed one by one, there is no need to download more than 2 in a row

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
