### PR TITLE
Add new option to forward transaction

### DIFF
--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -293,11 +293,7 @@ defmodule Archethic.Contracts.Worker do
 
     # The first storage node of the contract initiate the sending of the new transaction
     if trigger_node?(validation_nodes) do
-      Archethic.send_new_transaction(
-        next_transaction,
-        Crypto.first_node_public_key(),
-        contract_context
-      )
+      Archethic.send_new_transaction(next_transaction, contract_context: contract_context)
     else
       DetectNodeResponsiveness.start_link(
         next_transaction.address,
@@ -306,11 +302,7 @@ defmodule Archethic.Contracts.Worker do
           Logger.info("contract transaction ...attempt #{count}")
 
           if trigger_node?(validation_nodes, count) do
-            Archethic.send_new_transaction(
-              next_transaction,
-              Crypto.first_node_public_key(),
-              contract_context
-            )
+            Archethic.send_new_transaction(next_transaction, contract_context: contract_context)
           end
         end
       )

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -66,14 +66,9 @@ defmodule Archethic.Mining do
   end
 
   @doc """
-  Determines if the election of validation nodes performed by the welcome node is valid
+  Elect validation nodes for a transaction
   """
-  @spec valid_election?(Transaction.t(), list(Crypto.key())) :: boolean()
-  def valid_election?(
-        tx = %Transaction{address: tx_address, validation_stamp: nil},
-        validation_node_public_keys
-      )
-      when is_list(validation_node_public_keys) do
+  def get_validation_nodes(tx = %Transaction{address: tx_address, validation_stamp: nil}) do
     current_date = DateTime.utc_now()
     sorting_seed = Election.validation_nodes_election_seed_sorting(tx, current_date)
 
@@ -81,15 +76,22 @@ defmodule Archethic.Mining do
 
     storage_nodes = Election.chain_storage_nodes(tx_address, node_list)
 
-    validation_nodes =
-      Election.validation_nodes(
-        tx,
-        sorting_seed,
-        node_list,
-        storage_nodes,
-        Election.get_validation_constraints()
-      )
+    Election.validation_nodes(
+      tx,
+      sorting_seed,
+      node_list,
+      storage_nodes,
+      Election.get_validation_constraints()
+    )
+  end
 
+  @doc """
+  Determines if the election of validation nodes performed by the welcome node is valid
+  """
+  @spec valid_election?(Transaction.t(), list(Crypto.key())) :: boolean()
+  def valid_election?(tx, validation_node_public_keys)
+      when is_list(validation_node_public_keys) do
+    validation_nodes = get_validation_nodes(tx)
     validation_node_public_keys == Enum.map(validation_nodes, & &1.last_public_key)
   end
 

--- a/lib/archethic/networking/scheduler.ex
+++ b/lib/archethic/networking/scheduler.ex
@@ -120,7 +120,7 @@ defmodule Archethic.Networking.Scheduler do
             )
         })
 
-      Archethic.send_new_transaction(tx)
+      Archethic.send_new_transaction(tx, forward?: true)
       handle_new_ip(tx)
     else
       :error ->

--- a/lib/archethic/p2p/message/new_transaction.ex
+++ b/lib/archethic/p2p/message/new_transaction.ex
@@ -29,7 +29,12 @@ defmodule Archethic.P2P.Message.NewTransaction do
         },
         _
       ) do
-    :ok = Archethic.send_new_transaction(tx, node_pbkey, contract_context)
+    Archethic.send_new_transaction(tx,
+      welcome_node_key: node_pbkey,
+      contract_context: contract_context,
+      forward?: true
+    )
+
     %Ok{}
   end
 

--- a/lib/archethic_web/controllers/api/origin_key_controller.ex
+++ b/lib/archethic_web/controllers/api/origin_key_controller.ex
@@ -71,7 +71,7 @@ defmodule ArchethicWeb.API.OriginKeyController do
   end
 
   defp send_transaction(tx = %Transaction{}) do
-    :ok = Archethic.send_new_transaction(tx)
+    :ok = Archethic.send_new_transaction(tx, forward?: true)
     TransactionSubscriber.register(tx.address, System.monotonic_time())
 
     {201,

--- a/lib/archethic_web/controllers/api/transaction_controller.ex
+++ b/lib/archethic_web/controllers/api/transaction_controller.ex
@@ -53,7 +53,7 @@ defmodule ArchethicWeb.API.TransactionController do
   end
 
   defp send_transaction(conn, tx = %Transaction{}) do
-    :ok = Archethic.send_new_transaction(tx)
+    :ok = Archethic.send_new_transaction(tx, forward?: true)
     TransactionSubscriber.register(tx.address, System.monotonic_time())
 
     conn

--- a/lib/archethic_web/controllers/faucet_controller.ex
+++ b/lib/archethic_web/controllers/faucet_controller.ex
@@ -119,8 +119,7 @@ defmodule ArchethicWeb.FaucetController do
     tx_address = tx.address
     TransactionSubscriber.register(tx_address, System.monotonic_time())
 
-    # case Archethic.send_new_transaction(tx) do
-    :ok = Archethic.send_new_transaction(tx)
+    :ok = Archethic.send_new_transaction(tx, forward?: true)
 
     receive do
       {:new_transaction, ^tx_address} ->

--- a/lib/archethic_web/live/settings_live.ex
+++ b/lib/archethic_web/live/settings_live.ex
@@ -194,7 +194,7 @@ defmodule ArchethicWeb.SettingsLive do
 
     TransactionSubscriber.register(tx.address, System.monotonic_time())
 
-    Archethic.send_new_transaction(tx)
+    Archethic.send_new_transaction(tx, forward?: true)
   end
 
   defp get_token_transfers(previous_reward_address, next_reward_address) do


### PR DESCRIPTION
# Description

Fixes an issue where a transaction which is forwarded because validation nodes are not responding or returns an synchronization, can create a loop of death between node if this transaction is also catched by node responsivness.

Now all transaction created by GenServer that also spawn a node responsivness, are not forwarded since node responsivness will do it

Fixes #1134 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
