### PR TITLE
Fix ChainIndex get_genesis_address

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_index.ex
+++ b/lib/archethic/db/embedded_impl/chain_index.ex
@@ -570,7 +570,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainIndex do
 
         case :ets.select(@archethic_db_last_index, match_pattern, 1) do
           :"$end_of_table" -> address
-          genesis_address -> genesis_address
+          {[genesis_address], _} -> genesis_address
         end
     end
   end


### PR DESCRIPTION
# Description

Fix pattern matching when retrieving genesis public key from last_address_index ets table

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
