### PR TITLE
Clean summary cache on node up and summary

### DIFF
--- a/lib/archethic/beacon_chain/subset.ex
+++ b/lib/archethic/beacon_chain/subset.ex
@@ -381,10 +381,7 @@ defmodule Archethic.BeaconChain.Subset do
         Task.Supervisor.async_nolink(TaskSupervisor, fn -> get_network_patches(subset, time) end)
 
       summary =
-        %Summary{
-          subset: subset,
-          summary_time: Utils.truncate_datetime(time, second?: true, microsecond?: true)
-        }
+        %Summary{subset: subset, summary_time: time}
         |> Summary.aggregate_slots(
           beacon_slots,
           P2PSampling.list_nodes_to_sample(subset)
@@ -411,9 +408,9 @@ defmodule Archethic.BeaconChain.Subset do
             []
         end
 
-      BeaconChain.write_beacon_summary(%{summary | network_patches: network_patches})
+      :ok = BeaconChain.write_beacon_summary(%{summary | network_patches: network_patches})
 
-      :ok
+      SummaryCache.clean_previous_summary_slots(subset, time)
     end
   end
 

--- a/lib/archethic/beacon_chain/subset/summary_cache.ex
+++ b/lib/archethic/beacon_chain/subset/summary_cache.ex
@@ -5,7 +5,6 @@ defmodule Archethic.BeaconChain.Subset.SummaryCache do
 
   alias Archethic.BeaconChain
   alias Archethic.BeaconChain.Slot
-  alias Archethic.BeaconChain.SlotTimer
   alias Archethic.BeaconChain.SummaryTimer
   alias Archethic.Crypto
 
@@ -34,33 +33,44 @@ defmodule Archethic.BeaconChain.Subset.SummaryCache do
     :ok = recover_slots(SummaryTimer.next_summary(DateTime.utc_now()))
 
     PubSub.register_to_current_epoch_of_slot_time()
+    PubSub.register_to_node_status()
 
     {:ok, %{}}
   end
 
+  def code_change("1.2.3", state, _extra) do
+    PubSub.register_to_node_status()
+    {:ok, state}
+  end
+
+  def code_change(_version, state, _extra), do: {:ok, state}
+
   def handle_info({:current_epoch_of_slot_timer, slot_time}, state) do
-    # Check if the slot in the first one of the summary interval
-    previous_summary_time = SummaryTimer.previous_summary(slot_time)
-    first_slot_time = SlotTimer.next_slot(previous_summary_time)
-
-    if slot_time == first_slot_time do
-      Enum.each(
-        BeaconChain.list_subsets(),
-        &clean_previous_summary_cache(&1, previous_summary_time)
-      )
-
-      next_summary_backup_path = SummaryTimer.next_summary(slot_time) |> recover_path()
-
-      Utils.mut_dir("slot_backup*")
-      |> Path.wildcard()
-      |> Enum.reject(&(&1 == next_summary_backup_path))
-      |> Enum.each(&File.rm/1)
-    end
+    if SummaryTimer.match_interval?(slot_time), do: delete_old_backup_file(slot_time)
 
     {:noreply, state}
   end
 
-  defp clean_previous_summary_cache(subset, previous_summary_time) do
+  def handle_info(:node_up, state) do
+    previous_summary_time = SummaryTimer.previous_summary(DateTime.utc_now())
+    delete_old_backup_file(previous_summary_time)
+
+    BeaconChain.list_subsets()
+    |> Enum.each(&clean_previous_summary_slots(&1, previous_summary_time))
+
+    {:noreply, state}
+  end
+
+  def handle_info(:node_down, state), do: {:noreply, state}
+
+  @doc """
+  Remove slots of previous summary time from ets table
+  """
+  @spec clean_previous_summary_slots(
+          subset :: binary(),
+          previous_summary_time :: DateTime.t()
+        ) :: :ok
+  def clean_previous_summary_slots(subset, previous_summary_time) do
     subset
     |> stream_current_slots()
     |> Stream.filter(fn
@@ -108,6 +118,16 @@ defmodule Archethic.BeaconChain.Subset.SummaryCache do
   def add_slot(subset, slot = %Slot{}, node_public_key) do
     true = :ets.insert(@table_name, {subset, {slot, node_public_key}})
     backup_slot(slot, node_public_key)
+  end
+
+  defp delete_old_backup_file(previous_summary_time) do
+    # We keep 2 backup, the current one and the last one
+    previous_backup_path = recover_path(previous_summary_time)
+
+    Utils.mut_dir("slot_backup*")
+    |> Path.wildcard()
+    |> Enum.filter(&(&1 < previous_backup_path))
+    |> Enum.each(&File.rm/1)
   end
 
   defp recover_path(summary_time = %DateTime{}),

--- a/test/archethic/beacon_chain/subset_test.exs
+++ b/test/archethic/beacon_chain/subset_test.exs
@@ -31,6 +31,7 @@ defmodule Archethic.BeaconChain.SubsetTest do
   alias Archethic.TransactionChain.TransactionSummary
 
   import Mox
+  import Mock
 
   setup do
     P2P.add_and_connect_node(%Node{
@@ -450,8 +451,11 @@ defmodule Archethic.BeaconChain.SubsetTest do
         DateTime.utc_now()
         |> DateTime.truncate(:millisecond)
 
-      send(pid, {:create_slot, now})
-      assert_receive :beacon_transaction_summary_stored, 2_000
+      with_mock SummaryCache, [:passthrough], clean_previous_summary_slots: fn _, _ -> :ok end do
+        send(pid, {:create_slot, now})
+        assert_receive :beacon_transaction_summary_stored, 2_000
+        assert_called(SummaryCache.clean_previous_summary_slots(:_, :_))
+      end
     end
   end
 


### PR DESCRIPTION
# Description

Fixes the issue where sometime the summary cache was not properly cleaned and so could create a summary with 2 summary inside.
Now 2 summary backup are kept, the current one and the previous one.
The previous summary slots in ets table are cleared right after being uses by subset.
On event node_up, backup file and ets table is cleaned.

Fixes #1138 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

Runned 2 nodes, send to one a node_down event before a summary and send a node_up after the summary, ets table is cleaned as expected.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
