### PR TITLE
Add geo patch as default network patch

### DIFF
--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -387,7 +387,7 @@ defmodule Archethic.SelfRepair.Sync do
     |> Enum.reduce(acc, fn {available_bit, index}, acc ->
       node = Enum.at(subset_node_list, index)
       avg_availability = Enum.at(node_average_availabilities, index)
-      network_patch = Enum.at(network_patches, index)
+      network_patch = Enum.at(network_patches, index, node.geo_patch)
       available? = available_bit == 1 and node.synced?
 
       Map.put(acc, node, %{
@@ -415,10 +415,7 @@ defmodule Archethic.SelfRepair.Sync do
     end
 
     P2P.set_node_average_availability(node_key, avg_availability)
-
-    if network_patch do
-      P2P.update_node_network_patch(node_key, network_patch)
-    end
+    P2P.update_node_network_patch(node_key, network_patch)
 
     %Node{availability_update: availability_update} = P2P.get_node_info!(node_key)
 


### PR DESCRIPTION
# Description

There is some possibilities that the network patch in a beacon summary aggregate is nil.
In that case, when doing the self repair,  we add a default network patch with the node geo patch

Fixes #1136 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

Also add logs in function `update_p2p_availabilities` when running a single node (it create an aggregate with empty network patch list

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
