### PR TITLE
Run election on current node view in self repair

### DIFF
--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -286,10 +286,7 @@ defmodule Archethic.SelfRepair.Sync do
       ) do
     start_time = System.monotonic_time()
 
-    previous_available_nodes = P2P.authorized_and_available_nodes()
-
-    nodes_including_self =
-      [P2P.get_node_info() | previous_available_nodes] |> P2P.distinct_nodes()
+    nodes_including_self = [P2P.get_node_info() | download_nodes] |> P2P.distinct_nodes()
 
     attestations_to_sync =
       attestations
@@ -304,6 +301,8 @@ defmodule Archethic.SelfRepair.Sync do
     )
 
     availability_update = DateTime.add(summary_time, availability_adding_time)
+
+    previous_available_nodes = P2P.authorized_and_available_nodes()
 
     p2p_availabilities
     |> Enum.reduce(%{}, fn {subset,


### PR DESCRIPTION
# Description

Fixes an issue in self repair where a node which is bootstrapping from start run the election based on the P2P view of the latest summary repaired while it should be on the current P2P view of the network (from the latest summary available)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
