### PR TITLE
Set Nx backend to EXLA

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,6 +50,9 @@ config :archethic, :faucet_rate_limit_expiry, 3_600_000
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# Set nx backend to EXLA
+config :nx, default_backend: EXLA.Backend
+
 config :archethic, :src_dir, File.cwd!()
 
 config :archethic, :mut_dir, "data"

--- a/lib/archethic/beacon_chain/network_coordinates.ex
+++ b/lib/archethic/beacon_chain/network_coordinates.ex
@@ -52,9 +52,9 @@ defmodule Archethic.BeaconChain.NetworkCoordinates do
       ...>  [150, 200, 0]
       ...> ], names: [:line, :column], type: {:f, 64}))
       [
-        "B8",
-        "08",
-        "C8"
+        "28",
+        "48",
+        "F8"
       ]
   """
   @spec get_patch_from_latencies(Nx.Tensor.t()) :: list(String.t())

--- a/test/archethic/beacon_chain/network_coordinates_test.exs
+++ b/test/archethic/beacon_chain/network_coordinates_test.exs
@@ -68,14 +68,14 @@ defmodule Archethic.BeaconChain.NetworkCoordinatesTest do
            }}
       end)
 
-      assert Nx.tensor([
+      assert [
                [0, 0, 0, 100, 100, 90],
                [0, 0, 0, 110, 105, 105],
                [0, 0, 0, 90, 90, 90],
                [100, 110, 90, 0, 0, 0],
                [100, 105, 90, 0, 0, 0],
                [90, 105, 90, 0, 0, 0]
-             ]) == NetworkCoordinates.fetch_network_stats(DateTime.utc_now())
+             ] == NetworkCoordinates.fetch_network_stats(DateTime.utc_now()) |> Nx.to_list()
     end
   end
 end


### PR DESCRIPTION
# Description

Update config to set Nx default backend to EXLA.
This speed up network patch calculation by 2 - 3 times

# How Has This Been Tested?

Getting mainnet network patch matrix :
[test.txt](https://github.com/archethic-foundation/archethic-node/files/11957075/test.txt)

Run these command with and without the conf : 
```elixir
  nx = File.read!("/home/neylix/Archethic/archethic-node/test.txt") |> :erlang.binary_to_term()
  start = System.monotonic_time(:millisecond)
  Archethic.BeaconChain.NetworkCoordinates.get_patch_from_latencies(nx)
  System.monotonic_time(:millisecond) - start
```

result on my computer is 2800ms without config and 800ms with the new config

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
