### PR TITLE
Fix p2p node info on first enrolled node

### DIFF
--- a/lib/archethic/bootstrap/sync.ex
+++ b/lib/archethic/bootstrap/sync.ex
@@ -185,7 +185,14 @@ defmodule Archethic.Bootstrap.Sync do
        }} ->
         :ok = P2P.new_bootstrapping_seeds(new_seeds)
 
-        P2P.add_and_connect_node(first_enrolled_node)
+        # Replace values to match P2P view on network bootstrap
+        %Node{
+          first_enrolled_node
+          | last_update_date: ~U[2019-07-14 00:00:00Z],
+            availability_update: ~U[2008-10-31 00:00:00Z]
+        }
+        |> P2P.add_and_connect_node()
+
         Logger.info("First enrolled node added into P2P MemTable")
 
         closest_nodes =


### PR DESCRIPTION
# Description

Fixes an issue where the availability update of the first enrolled node wasn't the good one when a node bootstraps

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
