### PR TITLE
Fix invalid slot time

### DIFF
--- a/lib/archethic/beacon_chain/subset.ex
+++ b/lib/archethic/beacon_chain/subset.ex
@@ -88,6 +88,7 @@ defmodule Archethic.BeaconChain.Subset do
 
   def init([subset]) do
     PubSub.register_to_new_replication_attestations()
+    PubSub.register_to_current_epoch_of_slot_time()
 
     {:ok,
      %{
@@ -100,6 +101,13 @@ defmodule Archethic.BeaconChain.Subset do
        subscribed_nodes: []
      }}
   end
+
+  def code_change("1.2.3", state, _extra) do
+    PubSub.register_to_current_epoch_of_slot_time()
+    {:ok, state}
+  end
+
+  def code_change(_, state, _extra), do: {:ok, state}
 
   def handle_call(:get_current_slot, _from, state = %{current_slot: current_slot}) do
     {:reply, current_slot, state}
@@ -141,33 +149,49 @@ defmodule Archethic.BeaconChain.Subset do
   end
 
   def handle_info(
-        {:create_slot, time},
-        state = %{subset: subset, node_public_key: node_public_key, current_slot: current_slot}
-      ) do
-    nodes_availability_times =
-      P2PSampling.list_nodes_to_sample(subset)
-      |> Task.async_stream(
-        fn node ->
-          if node.first_public_key == Crypto.first_node_public_key() do
-            SlotTimer.get_time_interval()
-          else
-            Client.get_availability_timer(node.first_public_key, true)
-          end
-        end,
-        on_timeout: :kill_task
+        {:current_epoch_of_slot_timer, time},
+        state = %{
+          subset: subset,
+          node_public_key: node_public_key,
+          current_slot: current_slot = %Slot{slot_time: slot_time}
+        }
       )
-      |> Enum.map(fn
-        {:ok, res} -> res
-        _ -> 0
-      end)
+      when time == slot_time do
+    if P2P.authorized_and_available_node?(Crypto.first_node_public_key(), time, true) do
+      nodes_availability_times =
+        P2PSampling.list_nodes_to_sample(subset)
+        |> Task.async_stream(
+          fn node ->
+            if node.first_public_key == Crypto.first_node_public_key() do
+              SlotTimer.get_time_interval()
+            else
+              Client.get_availability_timer(node.first_public_key, true)
+            end
+          end,
+          on_timeout: :kill_task
+        )
+        |> Enum.map(fn
+          {:ok, res} -> res
+          _ -> 0
+        end)
 
-    if beacon_slot_node?(subset, time, node_public_key) do
-      handle_slot(time, current_slot, nodes_availability_times)
+      if beacon_slot_node?(subset, time, node_public_key) do
+        handle_slot(time, current_slot, nodes_availability_times)
+      end
 
       if summary_time?(time) and beacon_summary_node?(subset, time, node_public_key) do
         handle_summary(time, subset)
       end
     end
+
+    {:noreply, next_state(state, time)}
+  end
+
+  def handle_info(
+        {:current_epoch_of_slot_timer, time},
+        state = %{current_slot: %Slot{slot_time: slot_time}}
+      ) do
+    Logger.warning("Received new slot time #{time} while current slot_time is #{slot_time}")
 
     {:noreply, next_state(state, time)}
   end
@@ -319,8 +343,6 @@ defmodule Archethic.BeaconChain.Subset do
 
     # Avoid to store or dispatch an empty beacon's slot
     unless Slot.empty?(current_slot) do
-      current_slot = %{current_slot | slot_time: time}
-
       if summary_time?(time) do
         SummaryCache.add_slot(subset, current_slot, Crypto.first_node_public_key())
       else


### PR DESCRIPTION
# Description

Fixes an issue where a node keeps in Subset state the last slot it created before going down (event node_down), and send this slot after going up (event node_up).
This slot was then added to the beacon summary even if the data are from the previous summary

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run 2 nodes, create a transaction and send to one a node_down event before a the end of slot and send a node_up after the summary, a log warning informs that the slot was from a previous date and the first page of beacon summary does not contains the transaction of the previous summary

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
