### PR TITLE
Smart contract functions without args

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -257,8 +257,7 @@ defmodule Archethic.Contracts do
          :inherit,
          %Contract{
            constants: %Constants{contract: contract_constant},
-           public_functions: public_functions,
-           private_functions: private_functions
+           functions: functions,
          },
          transaction,
          datetime
@@ -267,7 +266,7 @@ defmodule Archethic.Contracts do
       "previous" => contract_constant,
       "next" => Constants.from_transaction(transaction),
       "_time_now" => DateTime.to_unix(datetime),
-      "functions" => Map.merge(public_functions, private_functions)
+      "functions" => functions
     }
   end
 
@@ -275,8 +274,7 @@ defmodule Archethic.Contracts do
          _,
          %Contract{
            constants: %Constants{contract: contract_constant},
-           public_functions: public_functions,
-           private_functions: private_functions
+           functions: functions,
          },
          transaction,
          datetime
@@ -285,7 +283,7 @@ defmodule Archethic.Contracts do
       "transaction" => Constants.from_transaction(transaction),
       "contract" => contract_constant,
       "_time_now" => DateTime.to_unix(datetime),
-      "functions" => Map.merge(public_functions, private_functions)
+      "functions" => functions
     }
   end
 end

--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -257,7 +257,7 @@ defmodule Archethic.Contracts do
          :inherit,
          %Contract{
            constants: %Constants{contract: contract_constant},
-           functions: functions,
+           functions: functions
          },
          transaction,
          datetime
@@ -274,7 +274,7 @@ defmodule Archethic.Contracts do
          _,
          %Contract{
            constants: %Constants{contract: contract_constant},
-           functions: functions,
+           functions: functions
          },
          transaction,
          datetime

--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -267,7 +267,7 @@ defmodule Archethic.Contracts do
       "previous" => contract_constant,
       "next" => Constants.from_transaction(transaction),
       "_time_now" => DateTime.to_unix(datetime),
-      functions: Map.merge(public_functions, private_functions)
+      "functions" => Map.merge(public_functions, private_functions)
     }
   end
 
@@ -285,7 +285,7 @@ defmodule Archethic.Contracts do
       "transaction" => Constants.from_transaction(transaction),
       "contract" => contract_constant,
       "_time_now" => DateTime.to_unix(datetime),
-      functions: Map.merge(public_functions, private_functions)
+      "functions" => Map.merge(public_functions, private_functions)
     }
   end
 end

--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -255,27 +255,37 @@ defmodule Archethic.Contracts do
 
   defp get_condition_constants(
          :inherit,
-         %Contract{constants: %Constants{contract: contract_constant}},
+         %Contract{
+           constants: %Constants{contract: contract_constant},
+           public_functions: public_functions,
+           private_functions: private_functions
+         },
          transaction,
          datetime
        ) do
     %{
       "previous" => contract_constant,
       "next" => Constants.from_transaction(transaction),
-      "_time_now" => DateTime.to_unix(datetime)
+      "_time_now" => DateTime.to_unix(datetime),
+      functions: Map.merge(public_functions, private_functions)
     }
   end
 
   defp get_condition_constants(
          _,
-         %Contract{constants: %Constants{contract: contract_constant}},
+         %Contract{
+           constants: %Constants{contract: contract_constant},
+           public_functions: public_functions,
+           private_functions: private_functions
+         },
          transaction,
          datetime
        ) do
     %{
       "transaction" => Constants.from_transaction(transaction),
       "contract" => contract_constant,
-      "_time_now" => DateTime.to_unix(datetime)
+      "_time_now" => DateTime.to_unix(datetime),
+      functions: Map.merge(public_functions, private_functions)
     }
   end
 end

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -7,7 +7,6 @@ defmodule Archethic.Contracts.Contract do
   alias Archethic.Contracts.ContractConstants, as: Constants
 
   alias Archethic.Contracts.Interpreter
-  alias Archethic.Contracts.Interpreter.Scope
 
   alias Archethic.SharedSecrets
 
@@ -108,8 +107,7 @@ defmodule Archethic.Contracts.Contract do
         ast,
         args
       ) do
-    function_key = Scope.function_to_function_key(function_name, args)
-    Map.update!(contract, :public_functions, &Map.put(&1, function_key, %{ast: ast, args: args}))
+    Map.update!(contract, :public_functions, &Map.put(&1, {function_name, length(args)}, %{ast: ast, args: args}))
   end
 
   def add_function(
@@ -119,7 +117,6 @@ defmodule Archethic.Contracts.Contract do
         ast,
         args
       ) do
-    function_key = Scope.function_to_function_key(function_name, args)
-    Map.update!(contract, :private_functions, &Map.put(&1, function_key, %{ast: ast, args: args}))
+    Map.update!(contract, :private_functions, &Map.put(&1, {function_name, length(args)}, %{ast: ast, args: args}))
   end
 end

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -99,6 +99,13 @@ defmodule Archethic.Contracts.Contract do
   @doc """
   Add a public or private function to the contract
   """
+  @spec add_function(
+          contract :: t(),
+          function_name :: binary(),
+          ast :: any(),
+          args :: list(),
+          visibility :: atom()
+        ) :: t()
   def add_function(
         contract = %__MODULE__{},
         function_name,

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -105,9 +105,10 @@ defmodule Archethic.Contracts.Contract do
         :public,
         function_name,
         ast,
-        args = []
+        args
       ) do
-    Map.update!(contract, :public_functions, &Map.put(&1, function_name, [ast, args]))
+    function_key = function_name <> "/" <> Integer.to_string(length(args))
+    Map.update!(contract, :public_functions, &Map.put(&1, function_key, %{ast: ast, args: args}))
   end
 
   def add_function(
@@ -115,8 +116,9 @@ defmodule Archethic.Contracts.Contract do
         :private,
         function_name,
         ast,
-        args = []
+        args
       ) do
-    Map.update!(contract, :private_functions, &Map.put(&1, function_name, [ast, args]))
+    function_key = function_name <> "/" <> Integer.to_string(length(args))
+    Map.update!(contract, :private_functions, &Map.put(&1, function_key, %{ast: ast, args: args}))
   end
 end

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -14,8 +14,7 @@ defmodule Archethic.Contracts.Contract do
   alias Archethic.TransactionChain.TransactionData
 
   defstruct triggers: %{},
-            public_functions: %{},
-            private_functions: %{},
+            functions: %{},
             version: 0,
             conditions: %{},
             constants: %Constants{},
@@ -102,21 +101,12 @@ defmodule Archethic.Contracts.Contract do
   """
   def add_function(
         contract = %__MODULE__{},
-        :public,
         function_name,
         ast,
-        args
+        args,
+        visibility
       ) do
-    Map.update!(contract, :public_functions, &Map.put(&1, {function_name, length(args)}, %{ast: ast, args: args}))
+    Map.update!(contract, :functions, &Map.put(&1, {function_name, length(args)}, %{args: args, ast: ast, visibility: visibility}))
   end
 
-  def add_function(
-        contract = %__MODULE__{},
-        :private,
-        function_name,
-        ast,
-        args
-      ) do
-    Map.update!(contract, :private_functions, &Map.put(&1, {function_name, length(args)}, %{ast: ast, args: args}))
-  end
 end

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -106,7 +106,10 @@ defmodule Archethic.Contracts.Contract do
         args,
         visibility
       ) do
-    Map.update!(contract, :functions, &Map.put(&1, {function_name, length(args)}, %{args: args, ast: ast, visibility: visibility}))
+    Map.update!(
+      contract,
+      :functions,
+      &Map.put(&1, {function_name, length(args)}, %{args: args, ast: ast, visibility: visibility})
+    )
   end
-
 end

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -7,6 +7,7 @@ defmodule Archethic.Contracts.Contract do
   alias Archethic.Contracts.ContractConstants, as: Constants
 
   alias Archethic.Contracts.Interpreter
+  alias Archethic.Contracts.Interpreter.Scope
 
   alias Archethic.SharedSecrets
 
@@ -107,7 +108,7 @@ defmodule Archethic.Contracts.Contract do
         ast,
         args
       ) do
-    function_key = function_name <> "/" <> Integer.to_string(length(args))
+    function_key = Scope.function_to_function_key(function_name, args)
     Map.update!(contract, :public_functions, &Map.put(&1, function_key, %{ast: ast, args: args}))
   end
 
@@ -118,7 +119,7 @@ defmodule Archethic.Contracts.Contract do
         ast,
         args
       ) do
-    function_key = function_name <> "/" <> Integer.to_string(length(args))
+    function_key = Scope.function_to_function_key(function_name, args)
     Map.update!(contract, :private_functions, &Map.put(&1, function_key, %{ast: ast, args: args}))
   end
 end

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -14,6 +14,8 @@ defmodule Archethic.Contracts.Contract do
   alias Archethic.TransactionChain.TransactionData
 
   defstruct triggers: %{},
+            public_functions: %{},
+            private_functions: %{},
             version: 0,
             conditions: %{},
             constants: %Constants{},
@@ -93,5 +95,28 @@ defmodule Archethic.Contracts.Contract do
         conditions = %Conditions{}
       ) do
     Map.update!(contract, :conditions, &Map.put(&1, condition_name, conditions))
+  end
+
+  @doc """
+  Add a public or private function to the contract
+  """
+  def add_function(
+        contract = %__MODULE__{},
+        :public,
+        function_name,
+        ast,
+        args = []
+      ) do
+    Map.update!(contract, :public_functions, &Map.put(&1, function_name, [ast, args]))
+  end
+
+  def add_function(
+        contract = %__MODULE__{},
+        :private,
+        function_name,
+        ast,
+        args = []
+      ) do
+    Map.update!(contract, :private_functions, &Map.put(&1, function_name, [ast, args]))
   end
 end

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -7,7 +7,6 @@ defmodule Archethic.Contracts.Interpreter do
   alias __MODULE__.ActionInterpreter
   alias __MODULE__.ConditionInterpreter
   alias __MODULE__.FunctionInterpreter
-  alias __MODULE__.Scope
 
   alias __MODULE__.ConditionValidator
 
@@ -391,7 +390,7 @@ defmodule Archethic.Contracts.Interpreter do
   end
 
   defp get_functions([{{:atom, "fun"}, _, [{{:atom, function_name}, _, args} | _]} | rest]) do
-    [Scope.function_to_function_key(function_name, args) | get_functions(rest)]
+    [{function_name, length(args)} | get_functions(rest)]
   end
 
   defp get_functions([
@@ -399,7 +398,7 @@ defmodule Archethic.Contracts.Interpreter do
           [{{:atom, "fun"}, _, [{{:atom, function_name}, _, args} | _]} | _]}
          | rest
        ]) do
-    [Scope.function_to_function_key(function_name, args) | get_functions(rest)]
+    [{function_name, length(args)} | get_functions(rest)]
   end
 
   defp get_functions([_ | rest]), do: get_functions(rest)

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -3,6 +3,7 @@ defmodule Archethic.Contracts.Interpreter do
 
   require Logger
 
+  alias Archethic.Contracts.Interpreter.FunctionInterpreter
   alias __MODULE__.Legacy
   alias __MODULE__.ActionInterpreter
   alias __MODULE__.ConditionInterpreter
@@ -330,6 +331,26 @@ defmodule Archethic.Contracts.Interpreter do
     case ActionInterpreter.parse(ast) do
       {:ok, trigger_type, actions} ->
         {:ok, Contract.add_trigger(contract, trigger_type, actions)}
+
+      {:error, _, _} = e ->
+        e
+    end
+  end
+
+  defp parse_ast(ast = {{:atom, "fun"}, _, _}, contract) do
+    case FunctionInterpreter.parse(ast) do
+      {:ok, function_name, args, ast} ->
+        {:ok, Contract.add_function(contract, :private, function_name, ast, args)}
+
+      {:error, _, _} = e ->
+        e
+    end
+  end
+
+  defp parse_ast(ast = {{:atom, "export"}, _, [{:atom, "fun"}, _, _]}, contract) do
+    case FunctionInterpreter.parse(ast) do
+      {:ok, function_name, args, ast} ->
+        {:ok, Contract.add_function(contract, :public, function_name, ast, args)}
 
       {:error, _, _} = e ->
         e

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -3,10 +3,12 @@ defmodule Archethic.Contracts.Interpreter do
 
   require Logger
 
-  alias Archethic.Contracts.Interpreter.FunctionInterpreter
   alias __MODULE__.Legacy
   alias __MODULE__.ActionInterpreter
   alias __MODULE__.ConditionInterpreter
+  alias __MODULE__.FunctionInterpreter
+  alias __MODULE__.Scope
+
   alias __MODULE__.ConditionValidator
 
   alias Archethic.Contracts.Contract
@@ -388,13 +390,7 @@ defmodule Archethic.Contracts.Interpreter do
   end
 
   defp get_functions([{{:atom, "fun"}, _, [{{:atom, function_name}, _, args} | _]} | rest]) do
-    arity =
-      case args do
-        nil -> 0
-        _ -> length(args)
-      end
-
-    [function_name <> "/" <> Integer.to_string(arity) | get_functions(rest)]
+    [Scope.function_to_function_key(function_name, args) | get_functions(rest)]
   end
 
   defp get_functions([
@@ -402,13 +398,7 @@ defmodule Archethic.Contracts.Interpreter do
           [{{:atom, "fun"}, _, [{{:atom, function_name}, _, args} | _]} | _]}
          | rest
        ]) do
-    arity =
-      case args do
-        nil -> 0
-        _ -> length(args)
-      end
-
-    [function_name <> "/" <> Integer.to_string(arity) | get_functions(rest)]
+    [Scope.function_to_function_key(function_name, args) | get_functions(rest)]
   end
 
   defp get_functions([_ | rest]), do: get_functions(rest)

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -296,7 +296,7 @@ defmodule Archethic.Contracts.Interpreter do
   end
 
   defp parse_contract(1, ast) do
-    functions_keys = get_functions(ast)
+    functions_keys = get_function_keys(ast)
 
     case parse_ast_block(ast, %Contract{}, functions_keys) do
       {:ok, contract} ->
@@ -389,20 +389,20 @@ defmodule Archethic.Contracts.Interpreter do
     Utils.get_current_time_for_interval(interval)
   end
 
-  defp get_functions([{{:atom, "fun"}, _, [{{:atom, function_name}, _, args} | _]} | rest]) do
-    [{function_name, length(args)} | get_functions(rest)]
+  defp get_function_keys([{{:atom, "fun"}, _, [{{:atom, function_name}, _, args} | _]} | rest]) do
+    [{function_name, length(args)} | get_function_keys(rest)]
   end
 
-  defp get_functions([
+  defp get_function_keys([
          {{:atom, "export"}, _,
           [{{:atom, "fun"}, _, [{{:atom, function_name}, _, args} | _]} | _]}
          | rest
        ]) do
-    [{function_name, length(args)} | get_functions(rest)]
+    [{function_name, length(args)} | get_function_keys(rest)]
   end
 
-  defp get_functions([_ | rest]), do: get_functions(rest)
-  defp get_functions([]), do: []
+  defp get_function_keys([_ | rest]), do: get_function_keys(rest)
+  defp get_function_keys([]), do: []
 
   # -----------------------------------------
   # contract validation

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -141,7 +141,6 @@ defmodule Archethic.Contracts.Interpreter do
               time_now
           end
           |> DateTime.to_unix()
-
         constants = %{
           "transaction" =>
             case maybe_trigger_tx do
@@ -154,7 +153,7 @@ defmodule Archethic.Contracts.Interpreter do
             end,
           "contract" => contract_constants,
           "_time_now" => timestamp_now,
-          functions: public_functions ++ private_functions
+          functions: Map.merge(public_functions , private_functions)
         }
 
         result =

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -153,7 +153,7 @@ defmodule Archethic.Contracts.Interpreter do
             end,
           "contract" => contract_constants,
           "_time_now" => timestamp_now,
-          functions: Map.merge(public_functions , private_functions)
+          "functions" => Map.merge(public_functions , private_functions)
         }
 
         result =

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -120,7 +120,7 @@ defmodule Archethic.Contracts.Interpreter do
           version: version,
           triggers: triggers,
           constants: %Constants{contract: contract_constants},
-          functions: functions,
+          functions: functions
         },
         maybe_trigger_tx,
         opts \\ []

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -143,6 +143,7 @@ defmodule Archethic.Contracts.Interpreter do
               time_now
           end
           |> DateTime.to_unix()
+
         constants = %{
           "transaction" =>
             case maybe_trigger_tx do
@@ -155,7 +156,7 @@ defmodule Archethic.Contracts.Interpreter do
             end,
           "contract" => contract_constants,
           "_time_now" => timestamp_now,
-          "functions" => Map.merge(public_functions , private_functions)
+          "functions" => Map.merge(public_functions, private_functions)
         }
 
         result =

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -21,6 +21,7 @@ defmodule Archethic.Contracts.Interpreter do
 
   @type version() :: integer()
   @type execute_opts :: [time_now: DateTime.t()]
+  @type function_key() :: {String.t(), integer()}
 
   @doc """
   Dispatch through the correct interpreter.

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -120,8 +120,7 @@ defmodule Archethic.Contracts.Interpreter do
           version: version,
           triggers: triggers,
           constants: %Constants{contract: contract_constants},
-          public_functions: public_functions,
-          private_functions: private_functions
+          functions: functions,
         },
         maybe_trigger_tx,
         opts \\ []
@@ -155,7 +154,7 @@ defmodule Archethic.Contracts.Interpreter do
             end,
           "contract" => contract_constants,
           "_time_now" => timestamp_now,
-          "functions" => Map.merge(public_functions, private_functions)
+          "functions" => functions
         }
 
         result =
@@ -350,7 +349,7 @@ defmodule Archethic.Contracts.Interpreter do
        ) do
     case FunctionInterpreter.parse(ast, functions_keys) do
       {:ok, function_name, args, ast} ->
-        {:ok, Contract.add_function(contract, :public, function_name, ast, args)}
+        {:ok, Contract.add_function(contract, function_name, ast, args, :public)}
 
       {:error, _, _} = e ->
         e
@@ -360,7 +359,7 @@ defmodule Archethic.Contracts.Interpreter do
   defp parse_ast(ast = {{:atom, "fun"}, _, _}, contract, functions_keys) do
     case FunctionInterpreter.parse(ast, functions_keys) do
       {:ok, function_name, args, ast} ->
-        {:ok, Contract.add_function(contract, :private, function_name, ast, args)}
+        {:ok, Contract.add_function(contract, function_name, ast, args, :private)}
 
       {:error, _, _} = e ->
         e

--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -13,7 +13,8 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
   @doc """
   Parse the given node and return the trigger and the actions block.
   """
-  @spec parse(any(), list) :: {:ok, atom(), any()} | {:error, any(), String.t()}
+  @spec parse(any(), list(Interpreter.function_key())) ::
+          {:ok, atom(), any()} | {:error, any(), String.t()}
   def parse({{:atom, "actions"}, _, [keyword, [do: block]]}, functions_keys) do
     trigger_type = extract_trigger(keyword)
 

--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -14,8 +14,6 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
   Parse the given node and return the trigger and the actions block.
   """
   @spec parse(any(), list) :: {:ok, atom(), any()} | {:error, any(), String.t()}
-  def parse(_, _ \\ [])
-
   def parse({{:atom, "actions"}, _, [keyword, [do: block]]}, functions_keys) do
     trigger_type = extract_trigger(keyword)
 

--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -190,7 +190,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
          node =
            {{:., _meta, [{:__aliases__, _, [atom: "Contract"]}, {:atom, function_name}]}, _, args},
          acc,
-         function_keys
+         _
        ) do
     absolute_module_atom = Archethic.Contracts.Interpreter.Library.Contract
 
@@ -208,9 +208,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
     function_atom = String.to_existing_atom(function_name)
 
     # check the type of the args, and allow custom function call as args
-    function_key = function_name <> "/" <> Integer.to_string(length(args))
-
-    unless absolute_module_atom.check_types(function_atom, args) or !Enum.member?(function_keys, function_key) do
+    unless absolute_module_atom.check_types(function_atom, args) do
       throw({:error, node, "invalid function arguments"})
     end
 

--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -5,6 +5,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
   alias Archethic.TransactionChain.TransactionData
 
   alias Archethic.Contracts.ContractConstants, as: Constants
+  alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.Contracts.Interpreter.CommonInterpreter
   alias Archethic.Contracts.Interpreter.Library

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -341,7 +341,6 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
     {new_node, acc}
   end
 
-
   # for var in list
   def postwalk(
         _node =
@@ -353,7 +352,6 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
         acc,
         _
       ) do
-
     # FIXME: here acc is already the parent acc, it is not the acc of the do block
     # FIXME: this means that our `var_name` will live in the parent scope
     # FIXME: it works (since we can read from parent) but it will override the parent binding if there's one
@@ -379,7 +377,7 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
       true ->
         new_node =
           quote do
-              Scope.execute_function_ast(unquote(function_name), unquote(args))
+            Scope.execute_function_ast(unquote(function_name), unquote(args))
           end
 
         {new_node, acc}

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -371,9 +371,7 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   end
 
   def postwalk(node = {{:atom, function_name}, _, args}, acc, function_keys) when is_list(args) do
-    function_key = Scope.function_to_function_key(function_name, args)
-
-    if Enum.member?(function_keys, function_key) do
+    if Enum.member?(function_keys, {function_name, length(args)}) do
       new_node =
         quote do
           Scope.execute_function_ast(unquote(function_name), unquote(args))
@@ -381,7 +379,7 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
 
       {new_node, acc}
     else
-      throw({:error, node, "The function " <> function_key <> " does not exist"})
+      throw({:error, node, "The function " <> function_name <>  "/" <> Integer.to_string(length(args)) <> " does not exist"})
     end
   end
 

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -275,8 +275,6 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   #  |_|
   # ----------------------------------------------------------------------
   # exit block == set parent scope
-  def postwalk(_, _, function_keys \\ [])
-
   def postwalk(
         node = {:__block__, _, _},
         acc,

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -377,7 +377,11 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
 
       {new_node, acc}
     else
-      throw({:error, node, "The function " <> function_name <>  "/" <> Integer.to_string(length(args)) <> " does not exist"})
+      throw(
+        {:error, node,
+         "The function " <>
+           function_name <> "/" <> Integer.to_string(length(args)) <> " does not exist"}
+      )
     end
   end
 

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -373,17 +373,15 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   def postwalk(node = {{:atom, function_name}, _, args}, acc, function_keys) when is_list(args) do
     function_key = Scope.function_to_function_key(function_name, args)
 
-    case Enum.member?(function_keys, function_key) do
-      true ->
-        new_node =
-          quote do
-            Scope.execute_function_ast(unquote(function_name), unquote(args))
-          end
+    if Enum.member?(function_keys, function_key) do
+      new_node =
+        quote do
+          Scope.execute_function_ast(unquote(function_name), unquote(args))
+        end
 
-        {new_node, acc}
-
-      false ->
-        throw({:error, node, "The function " <> function_key <> " does not exist"})
+      {new_node, acc}
+    else
+      throw({:error, node, "The function " <> function_key <> " does not exist"})
     end
   end
 

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -371,7 +371,7 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   end
 
   def postwalk(node = {{:atom, function_name}, _, args}, acc, function_keys) when is_list(args) do
-    function_key = function_name <> "/" <> Integer.to_string(length(args))
+    function_key = Scope.function_to_function_key(function_name, args)
 
     case Enum.member?(function_keys, function_key) do
       true ->

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -101,6 +101,12 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
   def prewalk(node = {{:., _, [{:__aliases__, _, _}, _]}, _, _}, acc), do: {node, acc}
   def prewalk(node = {:., _, [{:__aliases__, _, _}, _]}, acc), do: {node, acc}
 
+  # function call
+  # no args
+  def prewalk(node = {{:atom, _}, _, []}, acc), do: {node, acc}
+  # with args
+  def prewalk(node = {{:atom, _}, _, [_]}, acc), do: {node, acc}
+
   # whitelisted modules
   def prewalk(node = {:__aliases__, _, [atom: module_name]}, acc)
       when module_name in @modules_whitelisted,

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -377,11 +377,9 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
 
       {new_node, acc}
     else
-      throw(
-        {:error, node,
-         "The function " <>
-           function_name <> "/" <> Integer.to_string(length(args)) <> " does not exist"}
-      )
+      reason = "The function #{function_name}/#{Integer.to_string(length(args))} does not exist"
+
+      throw({:error, node, reason})
     end
   end
 

--- a/lib/archethic/contracts/interpreter/common_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/common_interpreter.ex
@@ -350,6 +350,7 @@ defmodule Archethic.Contracts.Interpreter.CommonInterpreter do
           quote do
             Scope.get_function_ast(unquote(function_name), unquote(args))
             |> Code.eval_quoted()
+            |> elem(0)
           end
 
         {new_node, acc}

--- a/lib/archethic/contracts/interpreter/condition_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/condition_interpreter.ex
@@ -20,8 +20,6 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
   """
   @spec parse(any(), list) ::
           {:ok, condition_type(), Conditions.t()} | {:error, any(), String.t()}
-  def parse(_, _ \\ [])
-
   def parse(
         node = {{:atom, "condition"}, _, [[{{:atom, condition_name}, keyword}]]},
         functions_keys
@@ -155,7 +153,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
       cond do
         # check function is available with given arity
         Library.function_exists?(absolute_module_atom, function_name, arity) ->
-          {new_node, _} = CommonInterpreter.postwalk(node, acc)
+          {new_node, _} = CommonInterpreter.postwalk(node, acc, [])
           new_node
 
         # if function exist with arity+1 => prepend the key to args
@@ -170,7 +168,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
             {{:., meta, [{:__aliases__, meta, [atom: module_name]}, {:atom, function_name}]},
              meta, [ast | args]}
 
-          {new_node, _} = CommonInterpreter.postwalk(node_with_key_appended, acc)
+          {new_node, _} = CommonInterpreter.postwalk(node_with_key_appended, acc, [])
           new_node
 
         # check function exists

--- a/lib/archethic/contracts/interpreter/condition_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/condition_interpreter.ex
@@ -6,6 +6,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
   alias Archethic.Contracts.Interpreter.Scope
   alias Archethic.Contracts.ContractConditions, as: Conditions
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
+  alias Archethic.Contracts.Interpreter
 
   @modules_whitelisted Library.list_common_modules()
   @condition_fields Conditions.__struct__()
@@ -18,7 +19,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
   @doc """
   Parse the given node and return the trigger and the actions block.
   """
-  @spec parse(any(), list) ::
+  @spec parse(any(), list(Interpreter.function_key())) ::
           {:ok, condition_type(), Conditions.t()} | {:error, any(), String.t()}
   def parse(
         node = {{:atom, "condition"}, _, [[{{:atom, condition_name}, keyword}]]},

--- a/lib/archethic/contracts/interpreter/condition_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/condition_interpreter.ex
@@ -138,7 +138,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
          node =
            {{:., meta, [{:__aliases__, _, [atom: module_name]}, {:atom, function_name}]}, _, args},
          acc,
-         _
+         function_keys
        )
        when module_name in @modules_whitelisted do
     # if function exist with arity => node
@@ -153,7 +153,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
       cond do
         # check function is available with given arity
         Library.function_exists?(absolute_module_atom, function_name, arity) ->
-          {new_node, _} = CommonInterpreter.postwalk(node, acc, [])
+          {new_node, _} = CommonInterpreter.postwalk(node, acc, function_keys)
           new_node
 
         # if function exist with arity+1 => prepend the key to args
@@ -168,7 +168,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
             {{:., meta, [{:__aliases__, meta, [atom: module_name]}, {:atom, function_name}]},
              meta, [ast | args]}
 
-          {new_node, _} = CommonInterpreter.postwalk(node_with_key_appended, acc, [])
+          {new_node, _} = CommonInterpreter.postwalk(node_with_key_appended, acc, function_keys)
           new_node
 
         # check function exists

--- a/lib/archethic/contracts/interpreter/condition_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/condition_interpreter.ex
@@ -18,9 +18,14 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
   @doc """
   Parse the given node and return the trigger and the actions block.
   """
-  @spec parse(any()) ::
+  @spec parse(any(), list) ::
           {:ok, condition_type(), Conditions.t()} | {:error, any(), String.t()}
-  def parse(node = {{:atom, "condition"}, _, [[{{:atom, condition_name}, keyword}]]}) do
+  def parse(_, _ \\ [])
+
+  def parse(
+        node = {{:atom, "condition"}, _, [[{{:atom, condition_name}, keyword}]]},
+        functions_keys
+      ) do
     {condition_type, global_variable} =
       case condition_name do
         "transaction" -> {:transaction, "transaction"}
@@ -39,7 +44,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
           throw({:error, node, "invalid condition field: #{key}"})
         end
 
-        new_value = to_boolean_expression([global_variable, key], value)
+        new_value = to_boolean_expression([global_variable, key], value, functions_keys)
         Map.put(acc, String.to_existing_atom(key), new_value)
       end)
 
@@ -52,7 +57,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
       {:error, node, reason}
   end
 
-  def parse(node) do
+  def parse(node, _) do
     {:error, node, "unexpected term"}
   end
 
@@ -64,7 +69,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
   #  | .__/|_|  |_| \_/ \__,_|\__\___|
   #  |_|
   # ----------------------------------------------------------------------
-  defp to_boolean_expression(_subject, bool) when is_boolean(bool) do
+  defp to_boolean_expression(_subject, bool, _) when is_boolean(bool) do
     bool
   end
 
@@ -79,14 +84,14 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
   #   - `subject == ["next", "content"]`
   #   - `value == "ciao"`
   #
-  defp to_boolean_expression(subject, value)
+  defp to_boolean_expression(subject, value, _)
        when is_binary(value) or is_integer(value) or is_float(value) do
     quote do
       unquote(value) == Scope.read_global(unquote(subject))
     end
   end
 
-  defp to_boolean_expression(subject, ast) do
+  defp to_boolean_expression(subject, ast, functions_keys) do
     # here the accumulator is an list of parent scopes & current scope
     # where we can access variables from all of them
     # `acc = [ref1]` means read variable from scope.ref1 or scope
@@ -101,7 +106,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
           prewalk(subject, node, acc)
         end,
         fn node, acc ->
-          postwalk(subject, node, acc)
+          postwalk(subject, node, acc, functions_keys)
         end
       )
 
@@ -134,7 +139,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
          subject,
          node =
            {{:., meta, [{:__aliases__, _, [atom: module_name]}, {:atom, function_name}]}, _, args},
-         acc
+         acc,
+         _
        )
        when module_name in @modules_whitelisted do
     # if function exist with arity => node
@@ -178,7 +184,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
     {new_node, acc}
   end
 
-  defp postwalk(_subject, node, acc) do
-    CommonInterpreter.postwalk(node, acc)
+  defp postwalk(_subject, node, acc, functions_keys) do
+    CommonInterpreter.postwalk(node, acc, functions_keys)
   end
 end

--- a/lib/archethic/contracts/interpreter/function_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/function_interpreter.ex
@@ -122,39 +122,8 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   #  | .__/ \___/|___/\__| \_/\_/ \__,_|_|_|\_\
   #  |_|
   # ----------------------------------------------------------------------
-  # ------------- catch function call -----------
-  defp postwalk(
-         node = {{:atom, "export"}, _, [{{:atom, function_name}, _, args} | _]},
-         acc,
-         function_keys
-       )
-       when is_list(args) do
-    function_key = function_name <> "/" <> Integer.to_string(length(args))
-
-    case Enum.member?(function_keys, function_key) do
-      true ->
-        {node, acc}
-
-      false ->
-        throw({:error, node, "The function " <> function_key <> " does not exist"})
-    end
-  end
-
-  defp postwalk(node = {{:atom, function_name}, _, args}, acc, function_keys)
-       when is_list(args) do
-    function_key = function_name <> "/" <> Integer.to_string(length(args))
-
-    case Enum.member?(function_keys, function_key) do
-      true ->
-        {node, acc}
-
-      false ->
-        throw({:error, node, "The function " <> function_key <> " does not exist"})
-    end
-  end
-
   # --------------- catch all -------------------
-  defp postwalk(node, acc, _) do
-    CommonInterpreter.postwalk(node, acc)
+  defp postwalk(node, acc, function_keys) do
+    CommonInterpreter.postwalk(node, acc, function_keys)
   end
 end

--- a/lib/archethic/contracts/interpreter/function_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/function_interpreter.ex
@@ -1,0 +1,128 @@
+defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
+  @moduledoc false
+  alias Archethic.Contracts.Interpreter.Scope
+  alias Archethic.Contracts.Interpreter.CommonInterpreter
+  require Logger
+
+  @doc """
+  Parse the given node and return the function name it's args as strings and the AST block.
+  """
+  def parse({{:atom, "fun"}, _, [{{:atom, function_name}, _, args}, [do: block]]}) do
+
+    ast = parse_block(block)
+    args = parse_args(args)
+
+    {:ok, function_name, args, ast}
+  catch
+    {:error, node} ->
+      {:error, node, "unexpected term"}
+
+    {:error, node, reason} ->
+      {:error, node, reason}
+  end
+
+  def parse(
+        {{:atom, "export"}, _,
+         [{{:atom, "fun"}, _, [{{:atom, function_name}, _, args}]}, [do: block]]}
+      ) do
+    ast = parse_block(block)
+    args = parse_args(args)
+
+    {:ok, function_name, args, ast}
+  catch
+    {:error, node} ->
+      {:error, node, "unexpected term"}
+
+    {:error, node, reason} ->
+      {:error, node, reason}
+  end
+
+  def parse(node) do
+    {:error, node, "unexpected term"}
+  end
+
+  @doc """
+  Execute function code and returns the result
+  """
+  def execute(ast) do
+    #FIXME:
+    # perturbant voir process
+    Scope.init()
+    {result, _} = Code.eval_quoted(ast)
+    result
+  end
+
+  # ----------------------------------------------------------------------
+  #              _            _
+  #   _ __  _ __(___   ____ _| |_ ___
+  #  | '_ \| '__| \ \ / / _` | __/ _ \
+  #  | |_) | |  | |\ V | (_| | ||  __/
+  #  | .__/|_|  |_| \_/ \__,_|\__\___|
+  #  |_|
+  # ----------------------------------------------------------------------
+  defp parse_block(ast) do
+    # here the accumulator is an list of parent scopes & current scope
+    # where we can access variables from all of them
+    # `acc = [ref1]` means read variable from scope.ref1 or scope
+    # `acc = [ref1, ref2]` means read variable from scope.ref1.ref2 or scope.ref1 or scope
+    # function's args are added to the acc by the interpreter
+    acc = []
+
+    {new_ast, _} =
+      Macro.traverse(
+        ast,
+        acc,
+        fn node, acc ->
+          prewalk(node, acc)
+        end,
+        fn node, acc ->
+          postwalk(node, acc)
+        end
+      )
+
+    new_ast
+  end
+
+  defp parse_args(nil), do: []
+
+  defp parse_args(args) do
+    Enum.map(args, fn {{:atom, arg}, _, _} -> arg end)
+  end
+
+  # ----------------------------------------------------------------------
+  #                                _ _
+  #   _ __  _ __ _____      ____ _| | | __
+  #  | '_ \| '__/ _ \ \ /\ / / _` | | |/ /
+  #  | |_) | | |  __/\ V  V | (_| | |   <
+  #  | .__/|_|  \___| \_/\_/ \__,_|_|_|\_\
+  #  |_|
+  # ----------------------------------------------------------------------
+
+  # Ban access to Contract module
+  defp prewalk(
+         node = {:__aliases__, _, [atom: "Contract"]},
+         _
+       ) do
+    throw({:error, node, "Contract is not allowed in function"})
+  end
+
+  defp prewalk(
+         node,
+         acc
+       ) do
+    CommonInterpreter.prewalk(node, acc)
+  end
+
+  # ----------------------------------------------------------------------
+  #                   _                 _ _
+  #   _ __   ___  ___| |___      ____ _| | | __
+  #  | '_ \ / _ \/ __| __\ \ /\ / / _` | | |/ /
+  #  | |_) | (_) \__ | |_ \ V  V | (_| | |   <
+  #  | .__/ \___/|___/\__| \_/\_/ \__,_|_|_|\_\
+  #  |_|
+  # ----------------------------------------------------------------------
+  # --------------- catch all -------------------
+  defp postwalk(node, acc) do
+    CommonInterpreter.postwalk(node, acc)
+  end
+end

--- a/lib/archethic/contracts/interpreter/function_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/function_interpreter.ex
@@ -1,5 +1,6 @@
 defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @moduledoc false
+  alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.Contracts.Interpreter.Scope
   alias Archethic.Contracts.Interpreter.CommonInterpreter
@@ -8,8 +9,9 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @doc """
   Parse the given node and return the function name it's args as strings and the AST block.
   """
-  @spec parse(any(), list(Interpreter.function_key())) ::
-          {:ok, atom(), any()} | {:error, any(), String.t()}
+  @spec parse(ast :: any(), function_keys :: list(Interpreter.function_key())) ::
+          {:ok, function_name :: binary(), args :: list(), function_ast :: any()}
+          | {:error, node :: any(), reason :: binary()}
   def parse({{:atom, "fun"}, _, [{{:atom, function_name}, _, args}, [do: block]]}, functions_keys) do
     ast = parse_block(AST.wrap_in_block(block), functions_keys)
     args = parse_args(args)
@@ -46,6 +48,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @doc """
   Execute function code and returns the result
   """
+  @spec execute(ast :: any(), constants :: map()) :: result :: any()
   def execute(ast, constants) do
     Scope.init(constants)
     {result, _} = Code.eval_quoted(ast)

--- a/lib/archethic/contracts/interpreter/function_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/function_interpreter.ex
@@ -45,10 +45,8 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @doc """
   Execute function code and returns the result
   """
-  def execute(ast) do
-    # FIXME:
-    # perturbant voir process
-    Scope.init()
+  def execute(ast, constants) do
+    Scope.init(constants)
     {result, _} = Code.eval_quoted(ast)
     result
   end

--- a/lib/archethic/contracts/interpreter/function_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/function_interpreter.ex
@@ -7,8 +7,6 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @doc """
   Parse the given node and return the function name it's args as strings and the AST block.
   """
-  def parse(_, _ \\ [])
-
   def parse({{:atom, "fun"}, _, [{{:atom, function_name}, _, args}, [do: block]]}, functions_keys) do
     ast = parse_block(block, functions_keys)
     args = parse_args(args)

--- a/lib/archethic/contracts/interpreter/function_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/function_interpreter.ex
@@ -7,6 +7,8 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @doc """
   Parse the given node and return the function name it's args as strings and the AST block.
   """
+  @spec parse(any(), list(Interpreter.function_key())) ::
+          {:ok, atom(), any()} | {:error, any(), String.t()}
   def parse({{:atom, "fun"}, _, [{{:atom, function_name}, _, args}, [do: block]]}, functions_keys) do
     ast = parse_block(block, functions_keys)
     args = parse_args(args)

--- a/lib/archethic/contracts/interpreter/function_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/function_interpreter.ex
@@ -1,5 +1,6 @@
 defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @moduledoc false
+  alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.Contracts.Interpreter.Scope
   alias Archethic.Contracts.Interpreter.CommonInterpreter
   require Logger
@@ -10,7 +11,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @spec parse(any(), list(Interpreter.function_key())) ::
           {:ok, atom(), any()} | {:error, any(), String.t()}
   def parse({{:atom, "fun"}, _, [{{:atom, function_name}, _, args}, [do: block]]}, functions_keys) do
-    ast = parse_block(block, functions_keys)
+    ast = parse_block(AST.wrap_in_block(block), functions_keys)
     args = parse_args(args)
     {:ok, function_name, args, ast}
   catch
@@ -26,7 +27,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
          [{{:atom, "fun"}, _, [{{:atom, function_name}, _, args}]}, [do: block]]},
         functions_keys
       ) do
-    ast = parse_block(block, functions_keys)
+    ast = parse_block(AST.wrap_in_block(block), functions_keys)
     args = parse_args(args)
 
     {:ok, function_name, args, ast}

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -125,9 +125,9 @@ defmodule Archethic.Contracts.Interpreter.Scope do
   end
 
   def execute_function_ast(function_name, args) do
-      get_function_ast(function_name, args)
-      |> Code.eval_quoted()
-      |> elem(0)
+    get_function_ast(function_name, args)
+    |> Code.eval_quoted()
+    |> elem(0)
   end
 
   # Return the path where to assign/read a variable.

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -8,6 +8,9 @@ defmodule Archethic.Contracts.Interpreter.Scope do
   """
   @spec init(map()) :: :ok
   def init(global_variables \\ %{}) do
+    # add functions to global var
+    global_variables = Map.put(global_variables, :functions, %{})
+
     Process.put(
       :scope,
       global_variables
@@ -112,6 +115,29 @@ defmodule Archethic.Contracts.Interpreter.Scope do
       Process.get(:scope),
       where_is(scopes_hierarchy, map_name) ++ [map_name, key_name]
     )
+  end
+
+  def add_function(function_name, args, ast) do
+    function_key = function_name <> "/" <> Integer.to_string(length(args))
+
+    Process.put(
+      :scope,
+      put_in(
+        Process.get(:scope),
+        [:functions, function_key],
+        %{args: args, ast: ast}
+      )
+    )
+  end
+
+  def get_function_ast(function_name, nil) do
+    function_key = function_name <> "/" <> Integer.to_string(0)
+    get_in(Process.get(:scope), [:functions, function_key, :ast])
+  end
+
+  def get_function_ast(function_name, args) do
+    function_key = function_name <> "/" <> Integer.to_string(length(args))
+    get_in(Process.get(:scope), [:functions, function_key, :ast])
   end
 
   # Return the path where to assign/read a variable.

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -115,13 +115,19 @@ defmodule Archethic.Contracts.Interpreter.Scope do
   end
 
   def get_function_ast(function_name, nil) do
-    function_key = function_name <> "/" <> Integer.to_string(0)
+    function_key = function_name <> "/" <> "0"
     get_in(Process.get(:scope), [:functions, function_key, :ast])
   end
 
   def get_function_ast(function_name, args) do
     function_key = function_name <> "/" <> Integer.to_string(length(args))
     get_in(Process.get(:scope), [:functions, function_key, :ast])
+  end
+
+  def execute_function_ast(function_name, args) do
+      get_function_ast(function_name, args)
+      |> Code.eval_quoted()
+      |> elem(0)
   end
 
   # Return the path where to assign/read a variable.

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -116,12 +116,12 @@ defmodule Archethic.Contracts.Interpreter.Scope do
 
   def get_function_ast(function_name, nil) do
     function_key = function_name <> "/" <> "0"
-    get_in(Process.get(:scope), [:functions, function_key, :ast])
+    get_in(Process.get(:scope), ["functions", function_key, :ast])
   end
 
   def get_function_ast(function_name, args) do
     function_key = function_name <> "/" <> Integer.to_string(length(args))
-    get_in(Process.get(:scope), [:functions, function_key, :ast])
+    get_in(Process.get(:scope), ["functions", function_key, :ast])
   end
 
   def execute_function_ast(function_name, args) do

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -114,30 +114,18 @@ defmodule Archethic.Contracts.Interpreter.Scope do
     )
   end
 
-  def get_function_ast(function_name, nil) do
-    function_key = function_to_function_key(function_name, [])
-    get_in(Process.get(:scope), ["functions", function_key, :ast])
+  defp get_function_ast(function_name, nil) do
+    get_in(Process.get(:scope), ["functions", {function_name, 0}, :ast])
   end
 
-  def get_function_ast(function_name, args) do
-    function_key = function_to_function_key(function_name, args)
-    get_in(Process.get(:scope), ["functions", function_key, :ast])
+  defp get_function_ast(function_name, args) do
+    get_in(Process.get(:scope), ["functions", {function_name, length(args)}, :ast])
   end
 
   def execute_function_ast(function_name, args) do
     get_function_ast(function_name, args)
     |> Code.eval_quoted()
     |> elem(0)
-  end
-
-  def function_to_function_key(function_name, args) do
-    arity =
-      case args do
-        nil -> 0
-        _ -> length(args)
-      end
-
-    function_name <> "/" <> Integer.to_string(arity)
   end
 
   # Return the path where to assign/read a variable.

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -8,9 +8,6 @@ defmodule Archethic.Contracts.Interpreter.Scope do
   """
   @spec init(map()) :: :ok
   def init(global_variables \\ %{}) do
-    # add functions to global var
-    global_variables = Map.put(global_variables, :functions, %{})
-
     Process.put(
       :scope,
       global_variables
@@ -114,19 +111,6 @@ defmodule Archethic.Contracts.Interpreter.Scope do
     get_in(
       Process.get(:scope),
       where_is(scopes_hierarchy, map_name) ++ [map_name, key_name]
-    )
-  end
-
-  def add_function(function_name, args, ast) do
-    function_key = function_name <> "/" <> Integer.to_string(length(args))
-
-    Process.put(
-      :scope,
-      put_in(
-        Process.get(:scope),
-        [:functions, function_key],
-        %{args: args, ast: ast}
-      )
     )
   end
 

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -122,6 +122,10 @@ defmodule Archethic.Contracts.Interpreter.Scope do
     get_in(Process.get(:scope), ["functions", {function_name, length(args)}, :ast])
   end
 
+  @doc """
+  Return the AST of an executable function
+  """
+  @spec get_function_ast(String.t(), list(any())) :: any()
   def execute_function_ast(function_name, args) do
     get_function_ast(function_name, args)
     |> Code.eval_quoted()

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -114,10 +114,6 @@ defmodule Archethic.Contracts.Interpreter.Scope do
     )
   end
 
-  defp get_function_ast(function_name, nil) do
-    get_in(Process.get(:scope), ["functions", {function_name, 0}, :ast])
-  end
-
   defp get_function_ast(function_name, args) do
     get_in(Process.get(:scope), ["functions", {function_name, length(args)}, :ast])
   end

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -119,9 +119,9 @@ defmodule Archethic.Contracts.Interpreter.Scope do
   end
 
   @doc """
-  Return the AST of an executable function
+  Execute a function AST
   """
-  @spec get_function_ast(String.t(), list(any())) :: any()
+  @spec execute_function_ast(String.t(), list(any())) :: any()
   def execute_function_ast(function_name, args) do
     get_function_ast(function_name, args)
     |> Code.eval_quoted()

--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -115,12 +115,12 @@ defmodule Archethic.Contracts.Interpreter.Scope do
   end
 
   def get_function_ast(function_name, nil) do
-    function_key = function_name <> "/" <> "0"
+    function_key = function_to_function_key(function_name, [])
     get_in(Process.get(:scope), ["functions", function_key, :ast])
   end
 
   def get_function_ast(function_name, args) do
-    function_key = function_name <> "/" <> Integer.to_string(length(args))
+    function_key = function_to_function_key(function_name, args)
     get_in(Process.get(:scope), ["functions", function_key, :ast])
   end
 
@@ -128,6 +128,16 @@ defmodule Archethic.Contracts.Interpreter.Scope do
     get_function_ast(function_name, args)
     |> Code.eval_quoted()
     |> elem(0)
+  end
+
+  def function_to_function_key(function_name, args) do
+    arity =
+      case args do
+        nil -> 0
+        _ -> length(args)
+      end
+
+    function_name <> "/" <> Integer.to_string(arity)
   end
 
   # Return the path where to assign/read a variable.

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -558,7 +558,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
         |> elem(1)
         |> FunctionInterpreter.parse()
 
-      function_constant = %{"functions"=> %{"hello/0" => %{args: [], ast: ast_hello}}}
+      function_constant = %{"functions" => %{"hello/0" => %{args: [], ast: ast_hello}}}
 
       code = ~S"""
       actions triggered_by: transaction do

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -34,7 +34,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use whitelisted module existing function" do
@@ -48,7 +48,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to have comments" do
@@ -63,7 +63,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should return the correct trigger type" do
@@ -76,7 +76,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
 
       code = ~S"""
       actions triggered_by: interval, at: "* * * * *"  do
@@ -87,7 +87,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
 
       code = ~S"""
       actions triggered_by: datetime, at: 1676282760 do
@@ -98,7 +98,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should not parse if datetime is not rounded" do
@@ -111,7 +111,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should return a proper error message if trigger is invalid" do
@@ -124,7 +124,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should not be able to use whitelisted module non existing function" do
@@ -138,7 +138,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -150,7 +150,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to create variables" do
@@ -164,7 +164,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to create lists" do
@@ -178,7 +178,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to create keywords" do
@@ -192,7 +192,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use common functions" do
@@ -207,7 +207,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should not be able to use non existing functions" do
@@ -222,7 +222,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -235,7 +235,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should not be able to use wrong types in common functions" do
@@ -250,7 +250,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use the result of a function call as a parameter" do
@@ -264,7 +264,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use a function call as a parameter to a lib function" do
@@ -280,7 +280,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should not be able to use wrong types in contract functions" do
@@ -294,7 +294,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should not be able to use if as an expression" do
@@ -312,7 +312,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should not be able to use for as an expression" do
@@ -328,7 +328,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use nested ." do
@@ -345,7 +345,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -359,7 +359,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use [] access with a string" do
@@ -375,7 +375,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use [] access with a variable" do
@@ -392,7 +392,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use [] access with a dot access" do
@@ -409,7 +409,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use [] access with a fn call" do
@@ -425,7 +425,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use nested [] access" do
@@ -441,7 +441,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use loop" do
@@ -461,7 +461,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use ranges" do
@@ -475,7 +475,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should not be able to use non existing function" do
@@ -489,7 +489,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse()
+               |> ActionInterpreter.parse([])
     end
 
     test "should be able to use existing function" do
@@ -556,7 +556,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
         func_hello
         |> Interpreter.sanitize_code()
         |> elem(1)
-        |> FunctionInterpreter.parse()
+        |> FunctionInterpreter.parse([])
 
       function_constant = %{"functions" => %{{"hello", 0} => %{args: [], ast: ast_hello}}}
 
@@ -582,7 +582,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
         func_hello
         |> Interpreter.sanitize_code()
         |> elem(1)
-        |> FunctionInterpreter.parse()
+        |> FunctionInterpreter.parse([])
 
       function_constant = %{"functions" => %{{"hello", 0} => %{args: [], ast: ast_hello}}}
 

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -504,7 +504,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                |> Interpreter.sanitize_code()
                |> elem(1)
                # mark as existing
-               |> ActionInterpreter.parse(["hello/0"])
+               |> ActionInterpreter.parse([{"hello", 0}])
     end
   end
 
@@ -558,7 +558,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
         |> elem(1)
         |> FunctionInterpreter.parse()
 
-      function_constant = %{"functions" => %{"hello/0" => %{args: [], ast: ast_hello}}}
+      function_constant = %{"functions" => %{{"hello", 0} => %{args: [], ast: ast_hello}}}
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -568,7 +568,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       """
 
       assert %Transaction{data: %TransactionData{content: "hello world"}} =
-               sanitize_parse_execute(code, function_constant, ["hello/0"])
+               sanitize_parse_execute(code, function_constant, [{"hello", 0}])
     end
 
     test "should be able to use a custom function call as parameter" do
@@ -584,7 +584,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
         |> elem(1)
         |> FunctionInterpreter.parse()
 
-      function_constant = %{"functions" => %{"hello/0" => %{args: [], ast: ast_hello}}}
+      function_constant = %{"functions" => %{{"hello", 0} => %{args: [], ast: ast_hello}}}
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -593,7 +593,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       """
 
       assert %Transaction{data: %TransactionData{content: "hello world"}} =
-               sanitize_parse_execute(code, function_constant, ["hello/0"])
+               sanitize_parse_execute(code, function_constant, [{"hello", 0}])
     end
 
     test "should be able to use a function call as parameter" do

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -7,7 +7,6 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
   alias Archethic.Contracts.ContractConstants, as: Constants
   alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.ActionInterpreter
-  alias Archethic.Contracts.Interpreter.FunctionInterpreter
 
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
@@ -543,57 +542,6 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       """
 
       assert %Transaction{data: %TransactionData{content: "hello"}} = sanitize_parse_execute(code)
-    end
-
-    test "should be able to use a function" do
-      func_hello = ~S"""
-      fun hello() do
-          "hello world"
-      end
-      """
-
-      {:ok, "hello", [], ast_hello} =
-        func_hello
-        |> Interpreter.sanitize_code()
-        |> elem(1)
-        |> FunctionInterpreter.parse([])
-
-      function_constant = %{"functions" => %{{"hello", 0} => %{args: [], ast: ast_hello}}}
-
-      code = ~S"""
-      actions triggered_by: transaction do
-          test = hello()
-          Contract.set_content test
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "hello world"}} =
-               sanitize_parse_execute(code, function_constant, [{"hello", 0}])
-    end
-
-    test "should be able to use a custom function call as parameter" do
-      func_hello = ~S"""
-      fun hello() do
-          "hello world"
-      end
-      """
-
-      {:ok, "hello", [], ast_hello} =
-        func_hello
-        |> Interpreter.sanitize_code()
-        |> elem(1)
-        |> FunctionInterpreter.parse([])
-
-      function_constant = %{"functions" => %{{"hello", 0} => %{args: [], ast: ast_hello}}}
-
-      code = ~S"""
-      actions triggered_by: transaction do
-          Contract.set_content hello()
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "hello world"}} =
-               sanitize_parse_execute(code, function_constant, [{"hello", 0}])
     end
 
     test "should be able to use a function call as parameter" do

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -503,7 +503,8 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ActionInterpreter.parse(["hello/0"]) #mark as existing
+               # mark as existing
+               |> ActionInterpreter.parse(["hello/0"])
     end
   end
 
@@ -566,7 +567,8 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       end
       """
 
-      assert %Transaction{data: %TransactionData{content: "hello world"}} = sanitize_parse_execute(code, function_constant, ["hello/0"])
+      assert %Transaction{data: %TransactionData{content: "hello world"}} =
+               sanitize_parse_execute(code, function_constant, ["hello/0"])
     end
 
     test "should be able to use a custom function call as parameter" do
@@ -590,7 +592,8 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       end
       """
 
-      assert %Transaction{data: %TransactionData{content: "hello world"}} = sanitize_parse_execute(code, function_constant, ["hello/0"])
+      assert %Transaction{data: %TransactionData{content: "hello world"}} =
+               sanitize_parse_execute(code, function_constant, ["hello/0"])
     end
 
     test "should be able to use a function call as parameter" do

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -7,6 +7,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
   alias Archethic.Contracts.ContractConstants, as: Constants
   alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.ActionInterpreter
+  alias Archethic.Contracts.Interpreter.FunctionInterpreter
 
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
@@ -475,6 +476,34 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                |> Interpreter.sanitize_code()
                |> elem(1)
                |> ActionInterpreter.parse()
+    end
+
+    test "should not be able to use non existing function" do
+      code = ~S"""
+      actions triggered_by: transaction do
+        hello()
+      end
+      """
+
+      assert {:error, _, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionInterpreter.parse()
+    end
+
+    test "should be able to use existing function" do
+      code = ~S"""
+      actions triggered_by: transaction do
+        hello()
+      end
+      """
+
+      assert {:ok, _, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ActionInterpreter.parse(["hello/0"]) #mark as existing
     end
   end
 

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -558,7 +558,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
         |> elem(1)
         |> FunctionInterpreter.parse()
 
-      function_constant = %{functions: %{"hello/0" => %{args: [], ast: ast_hello}}}
+      function_constant = %{"functions"=> %{"hello/0" => %{args: [], ast: ast_hello}}}
 
       code = ~S"""
       actions triggered_by: transaction do
@@ -584,7 +584,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
         |> elem(1)
         |> FunctionInterpreter.parse()
 
-      function_constant = %{functions: %{"hello/0" => %{args: [], ast: ast_hello}}}
+      function_constant = %{"functions" => %{"hello/0" => %{args: [], ast: ast_hello}}}
 
       code = ~S"""
       actions triggered_by: transaction do

--- a/test/archethic/contracts/interpreter/condition_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/condition_interpreter_test.exs
@@ -612,7 +612,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
                "next" => Constants.from_transaction(next_tx),
-               functions: %{"smth/0" => %{args: [], ast: ast_smth}}
+               "functions" => %{"smth/0" => %{args: [], ast: ast_smth}}
              })
 
       func_bool = ~S"""
@@ -644,7 +644,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
                "next" => Constants.from_transaction(next_tx),
-               functions: %{"im_true/0" => %{args: [], ast: ast_bool}}
+               "functions" => %{"im_true/0" => %{args: [], ast: ast_bool}}
              })
     end
 

--- a/test/archethic/contracts/interpreter/condition_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/condition_interpreter_test.exs
@@ -28,7 +28,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
     end
 
     test "parse a condition oracle" do
@@ -40,7 +40,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
     end
 
     test "parse a condition transaction" do
@@ -52,7 +52,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
     end
 
     test "does not parse anything else" do
@@ -64,7 +64,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
     end
   end
 
@@ -78,7 +78,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
     end
 
     test "parse strict value" do
@@ -92,7 +92,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
 
       assert is_tuple(ast) && :ok == Macro.validate(ast)
     end
@@ -108,7 +108,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
 
       assert is_tuple(ast) && :ok == Macro.validate(ast)
     end
@@ -141,7 +141,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
     end
 
     test "parse false" do
@@ -155,7 +155,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
     end
 
     test "parse AST" do
@@ -169,7 +169,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> ConditionInterpreter.parse()
+               |> ConditionInterpreter.parse([])
     end
   end
 
@@ -189,7 +189,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "transaction" => Constants.from_transaction(tx)
@@ -209,7 +209,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -233,7 +233,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "transaction" => Constants.from_transaction(tx)
@@ -253,7 +253,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -272,7 +272,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       refute code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -306,7 +306,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -324,7 +324,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       refute code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -374,7 +374,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "transaction" => Constants.from_transaction(tx)
@@ -405,7 +405,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "transaction" => Constants.from_transaction(tx)
@@ -420,7 +420,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "transaction" => Constants.from_transaction(tx)
@@ -435,7 +435,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       refute code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "transaction" => Constants.from_transaction(tx)
@@ -450,7 +450,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "transaction" => Constants.from_transaction(tx)
@@ -470,7 +470,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -489,7 +489,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       refute code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -510,7 +510,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -529,7 +529,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -548,7 +548,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       refute code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -572,7 +572,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
@@ -591,7 +591,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
         func_smth
         |> Interpreter.sanitize_code()
         |> elem(1)
-        |> FunctionInterpreter.parse()
+        |> FunctionInterpreter.parse([])
 
       code = ~s"""
       condition inherit: [
@@ -625,7 +625,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
         func_bool
         |> Interpreter.sanitize_code()
         |> elem(1)
-        |> FunctionInterpreter.parse()
+        |> FunctionInterpreter.parse([])
 
       code = ~s"""
       condition inherit: [
@@ -685,7 +685,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse()
+             |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),

--- a/test/archethic/contracts/interpreter/condition_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/condition_interpreter_test.exs
@@ -5,7 +5,6 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
   alias Archethic.Contracts.ContractConstants, as: Constants
   alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.ConditionInterpreter
-  alias Archethic.Contracts.Interpreter.FunctionInterpreter
 
   alias Archethic.Contracts.Interpreter.ConditionValidator
   alias Archethic.TransactionChain.Transaction
@@ -577,74 +576,6 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
                "next" => Constants.from_transaction(next_tx)
-             })
-    end
-
-    test "should be able to use functions" do
-      func_smth = ~S"""
-      fun smth() do
-        "smth"
-      end
-      """
-
-      {:ok, "smth", [], ast_smth} =
-        func_smth
-        |> Interpreter.sanitize_code()
-        |> elem(1)
-        |> FunctionInterpreter.parse([])
-
-      code = ~s"""
-      condition inherit: [
-        content: (
-          "smth" == smth()
-        )
-      ]
-      """
-
-      previous_tx = %Transaction{data: %TransactionData{}}
-      next_tx = %Transaction{data: %TransactionData{content: "smth"}}
-
-      assert code
-             |> Interpreter.sanitize_code()
-             |> elem(1)
-             |> ConditionInterpreter.parse([{"smth", 0}])
-             |> elem(2)
-             |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_transaction(previous_tx),
-               "next" => Constants.from_transaction(next_tx),
-               "functions" => %{{"smth", 0} => %{args: [], ast: ast_smth}}
-             })
-
-      func_bool = ~S"""
-      fun im_true() do
-        1 == 1
-      end
-      """
-
-      {:ok, "im_true", [], ast_bool} =
-        func_bool
-        |> Interpreter.sanitize_code()
-        |> elem(1)
-        |> FunctionInterpreter.parse([])
-
-      code = ~s"""
-      condition inherit: [
-        content: im_true()
-      ]
-      """
-
-      previous_tx = %Transaction{data: %TransactionData{}}
-      next_tx = %Transaction{data: %TransactionData{content: "hello"}}
-
-      assert code
-             |> Interpreter.sanitize_code()
-             |> elem(1)
-             |> ConditionInterpreter.parse([{"im_true", 0}])
-             |> elem(2)
-             |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_transaction(previous_tx),
-               "next" => Constants.from_transaction(next_tx),
-               "functions" => %{{"im_true", 0} => %{args: [], ast: ast_bool}}
              })
     end
 

--- a/test/archethic/contracts/interpreter/condition_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/condition_interpreter_test.exs
@@ -125,7 +125,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                |> Interpreter.sanitize_code()
                |> elem(1)
                # mark function as existing
-               |> ConditionInterpreter.parse(["get_uco_transfers/0"])
+               |> ConditionInterpreter.parse([{"get_uco_transfers", 0}])
 
       assert is_tuple(ast) && :ok == Macro.validate(ast)
     end
@@ -607,12 +607,12 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse(["smth/0"])
+             |> ConditionInterpreter.parse([{"smth", 0}])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
                "next" => Constants.from_transaction(next_tx),
-               "functions" => %{"smth/0" => %{args: [], ast: ast_smth}}
+               "functions" => %{{"smth", 0} => %{args: [], ast: ast_smth}}
              })
 
       func_bool = ~S"""
@@ -639,12 +639,12 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
       assert code
              |> Interpreter.sanitize_code()
              |> elem(1)
-             |> ConditionInterpreter.parse(["im_true/0"])
+             |> ConditionInterpreter.parse([{"im_true", 0}])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
                "previous" => Constants.from_transaction(previous_tx),
                "next" => Constants.from_transaction(next_tx),
-               "functions" => %{"im_true/0" => %{args: [], ast: ast_bool}}
+               "functions" => %{{"im_true", 0} => %{args: [], ast: ast_bool}}
              })
     end
 

--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -121,7 +121,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                |> Interpreter.sanitize_code()
                |> elem(1)
                # mark function as declared
-               |> FunctionInterpreter.parse(["hello/0"])
+               |> FunctionInterpreter.parse([{"hello", 0}])
     end
   end
 
@@ -150,9 +150,9 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
         |> Interpreter.sanitize_code()
         |> elem(1)
         # pass allowed function
-        |> FunctionInterpreter.parse(["hello/0"])
+        |> FunctionInterpreter.parse([{"hello", 0}])
 
-      function_constant = %{"functions" => %{"hello/0" => %{args: [], ast: ast_hello}}}
+      function_constant = %{"functions" => %{{"hello", 0} => %{args: [], ast: ast_hello}}}
 
       assert 4.0 = FunctionInterpreter.execute(ast_test, function_constant)
     end

--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -124,37 +124,39 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                |> FunctionInterpreter.parse(["hello/0"])
     end
 
-    describe "execute/2" do
-      test "should be able to execute function without args" do
-        fun1 = ~S"""
-        export fun hello do
-          1 + 3
-        end
-        """
 
-        {:ok, "hello", [], ast_hello} =
-          fun1
-          |> Interpreter.sanitize_code()
-          |> elem(1)
-          |> FunctionInterpreter.parse()
+  end
 
-        fun2 = ~S"""
-        fun test() do
-          hello()
-        end
-        """
-
-        {:ok, "test", [], ast_test} =
-          fun2
-          |> Interpreter.sanitize_code()
-          |> elem(1)
-          # pass allowed function
-          |> FunctionInterpreter.parse(["hello/0"])
-
-        function_constant = %{functions: %{"hello/0" => %{args: [], ast: ast_hello}}}
-
-        assert 4.0 = FunctionInterpreter.execute(ast_test, function_constant)
+  describe "execute/2" do
+    test "should be able to execute function without args" do
+      fun1 = ~S"""
+      export fun hello do
+        1 + 3
       end
+      """
+
+      {:ok, "hello", [], ast_hello} =
+        fun1
+        |> Interpreter.sanitize_code()
+        |> elem(1)
+        |> FunctionInterpreter.parse()
+
+      fun2 = ~S"""
+      fun test() do
+        hello()
+      end
+      """
+
+      {:ok, "test", [], ast_test} =
+        fun2
+        |> Interpreter.sanitize_code()
+        |> elem(1)
+          # pass allowed function
+        |> FunctionInterpreter.parse(["hello/0"])
+
+      function_constant = %{functions: %{"hello/0" => %{args: [], ast: ast_hello}}}
+
+      assert 4.0 = FunctionInterpreter.execute(ast_test, function_constant)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -123,8 +123,6 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                # mark function as declared
                |> FunctionInterpreter.parse(["hello/0"])
     end
-
-
   end
 
   describe "execute/2" do
@@ -151,7 +149,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
         fun2
         |> Interpreter.sanitize_code()
         |> elem(1)
-          # pass allowed function
+        # pass allowed function
         |> FunctionInterpreter.parse(["hello/0"])
 
       function_constant = %{"functions" => %{"hello/0" => %{args: [], ast: ast_hello}}}

--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -1,0 +1,99 @@
+defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
+  @moduledoc false
+
+  use ArchethicCase
+  use ExUnitProperties
+
+  import ArchethicCase
+
+  alias Archethic.Contracts.Interpreter.FunctionInterpreter
+  alias Archethic.Contracts.Interpreter
+  # ----------------------------------------------
+  # parse/1
+  # ----------------------------------------------
+  describe "parse/1" do
+    test "should be able to parse a private function" do
+      code = ~S"""
+      fun test_private do
+
+      end
+      """
+
+      assert {:ok, "test_private", _, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> FunctionInterpreter.parse()
+    end
+
+    test "should be able to parse a public function" do
+      code = ~S"""
+      export fun test_public do
+
+      end
+      """
+
+      assert {:ok, "test_public", _, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> FunctionInterpreter.parse()
+    end
+
+    test "should be able to parse a private function with arguments" do
+      code = ~S"""
+      fun test_private(arg1, arg2) do
+
+      end
+      """
+
+      assert {:ok, "test_private", ["arg1", "arg2"], _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> FunctionInterpreter.parse()
+    end
+
+    test "should be able to parse a public function with arguments" do
+      code = ~S"""
+      export fun test_public(arg1, arg2) do
+
+      end
+      """
+
+      assert {:ok, "test_public", ["arg1", "arg2"], _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> FunctionInterpreter.parse()
+    end
+
+    test "should not be able to use non-whitelisted modules" do
+      code = ~S"""
+      fun test_private do
+        Contract.set_content "hello"
+      end
+      """
+
+      assert {:error, _, "Contract is not allowed in function"} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> FunctionInterpreter.parse()
+    end
+
+    test "should be able to parse when there is whitelisted module" do
+      code = ~S"""
+      fun test do
+       Json.to_string "[1,2,3]"
+      end
+      """
+
+      assert {:ok, "test", [], _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> FunctionInterpreter.parse()
+    end
+  end
+end

--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -120,40 +120,41 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> FunctionInterpreter.parse(["hello/0"])  # mark function as declared
+               # mark function as declared
+               |> FunctionInterpreter.parse(["hello/0"])
     end
 
+    describe "execute/2" do
+      test "should be able to execute function without args" do
+        fun1 = ~S"""
+        export fun hello do
+          1 + 3
+        end
+        """
 
-  describe "execute/2" do
-    test "should be able to execute function without args" do
-      fun1 = ~S"""
-      export fun hello do
-        1 + 3
+        {:ok, "hello", [], ast_hello} =
+          fun1
+          |> Interpreter.sanitize_code()
+          |> elem(1)
+          |> FunctionInterpreter.parse()
+
+        fun2 = ~S"""
+        fun test() do
+          hello()
+        end
+        """
+
+        {:ok, "test", [], ast_test} =
+          fun2
+          |> Interpreter.sanitize_code()
+          |> elem(1)
+          # pass allowed function
+          |> FunctionInterpreter.parse(["hello/0"])
+
+        function_constant = %{functions: %{"hello/0" => %{args: [], ast: ast_hello}}}
+
+        assert 4.0 = FunctionInterpreter.execute(ast_test, function_constant)
       end
-      """
-
-      {:ok, "hello", [], ast_hello} =
-        fun1
-        |> Interpreter.sanitize_code()
-        |> elem(1)
-        |> FunctionInterpreter.parse()
-
-      fun2 = ~S"""
-      fun test() do
-        hello()
-      end
-      """
-
-      {:ok, "test", [], ast_test} =
-        fun2
-        |> Interpreter.sanitize_code()
-        |> elem(1)
-        # pass allowed function
-        |> FunctionInterpreter.parse(["hello/0"])
-
-      function_constant = %{functions: %{"hello/0" => %{args: [], ast: ast_hello}}}
-
-      assert 4.0 = FunctionInterpreter.execute(ast_test, function_constant)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -1,4 +1,4 @@
-defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
+defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
   @moduledoc false
 
   use ArchethicCase

--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -154,7 +154,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
           # pass allowed function
         |> FunctionInterpreter.parse(["hello/0"])
 
-      function_constant = %{functions: %{"hello/0" => %{args: [], ast: ast_hello}}}
+      function_constant = %{"functions" => %{"hello/0" => %{args: [], ast: ast_hello}}}
 
       assert 4.0 = FunctionInterpreter.execute(ast_test, function_constant)
     end

--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -22,7 +22,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> FunctionInterpreter.parse()
+               |> FunctionInterpreter.parse([])
     end
 
     test "should be able to parse a public function" do
@@ -36,7 +36,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> FunctionInterpreter.parse()
+               |> FunctionInterpreter.parse([])
     end
 
     test "should be able to parse a private function with arguments" do
@@ -50,7 +50,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> FunctionInterpreter.parse()
+               |> FunctionInterpreter.parse([])
     end
 
     test "should be able to parse a public function with arguments" do
@@ -64,7 +64,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> FunctionInterpreter.parse()
+               |> FunctionInterpreter.parse([])
     end
 
     test "should not be able to use non-whitelisted modules" do
@@ -78,7 +78,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> FunctionInterpreter.parse()
+               |> FunctionInterpreter.parse([])
     end
 
     test "should be able to parse when there is whitelisted module" do
@@ -92,7 +92,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> FunctionInterpreter.parse()
+               |> FunctionInterpreter.parse([])
     end
 
     test "should not be able to call non declared function" do
@@ -106,7 +106,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
                code
                |> Interpreter.sanitize_code()
                |> elem(1)
-               |> FunctionInterpreter.parse()
+               |> FunctionInterpreter.parse([])
     end
 
     test "should be able to call declared function" do
@@ -137,7 +137,7 @@ defmodule(Archethic.Contracts.Interpreter.FunctionInterpreterTest) do
         fun1
         |> Interpreter.sanitize_code()
         |> elem(1)
-        |> FunctionInterpreter.parse()
+        |> FunctionInterpreter.parse([])
 
       fun2 = ~S"""
       fun test() do

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -414,6 +414,7 @@ defmodule Archethic.Contracts.InterpreterTest do
         @version 1
         condition transaction: []
         actions triggered_by: transaction do
+          temp = func1()
           Contract.set_content func2()
         end
 
@@ -457,7 +458,10 @@ defmodule Archethic.Contracts.InterpreterTest do
         end
 
         fun my_func() do
-          my_var = "toto"
+          my_var = ""
+          if true do
+            my_var = "toto"
+          end
           my_var
         end
 

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -304,11 +304,12 @@ defmodule Archethic.Contracts.InterpreterTest do
         validation_stamp: ValidationStamp.generate_dummy()
       }
 
-      assert {:ok, %Transaction{
-              data: %TransactionData{
-                    content: "hello"
-                  }
-             }} =
+      assert {:ok,
+              %Transaction{
+                data: %TransactionData{
+                  content: "hello"
+                }
+              }} =
                Interpreter.execute_trigger(
                  :transaction,
                  Contract.from_transaction!(contract_tx),

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -260,9 +260,9 @@ defmodule ArchethicCase do
     expect(mock, function_name, 0, function)
   end
 
-  def sanitize_parse_execute(code, constants \\ %{}) do
+  def sanitize_parse_execute(code, constants \\ %{}, functions \\ []) do
     with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
-         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code) do
+         {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code, functions) do
       ActionInterpreter.execute(
         action_ast,
         constants |> ContractFactory.append_contract_constant(code)


### PR DESCRIPTION
# Description

Add possibility to create and use custom functions in Smart contracts.
However, I have a failing test which is not concerned by anything i changed:
```
doctest Archethic.Crypto.sign/2 (28) (CryptoTest)
     test/archethic/crypto_test.exs:15
```

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Multiple tests on :
- FunctionInterpreter
- ActionInterpreter
- ConditionInterpreter
- Interpreter

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
