### PR TITLE
Add new Code module in SC library

### DIFF
--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -64,14 +64,16 @@ defmodule Archethic.Contracts.Interpreter do
   Sanitize code takes care of converting atom to {:atom, bin()}.
   This way the user cannot create atoms at all. (which is mandatory to avoid atoms-table exhaustion)
   """
-  @spec sanitize_code(binary()) :: {:ok, Macro.t()} | {:error, any()}
-  def sanitize_code(code) when is_binary(code) do
+  @spec sanitize_code(binary(), list()) :: {:ok, Macro.t()} | {:error, any()}
+  def sanitize_code(code, opts \\ []) when is_binary(code) do
+    ignore_meta? = Keyword.get(opts, :ignore_meta?, false)
+
     opts = [static_atoms_encoder: &atom_encoder/2]
     charlist_code = code |> String.to_charlist()
 
     case :elixir.string_to_tokens(charlist_code, 1, 1, "nofile", opts) do
       {:ok, tokens} ->
-        transform_0x_to_hex(tokens) |> :elixir.tokens_to_quoted("nofile", opts)
+        transform_tokens(tokens, ignore_meta?) |> :elixir.tokens_to_quoted("nofile", opts)
 
       error ->
         error
@@ -80,14 +82,22 @@ defmodule Archethic.Contracts.Interpreter do
     _ -> {:error, :invalid_syntax}
   end
 
-  defp transform_0x_to_hex(tokens) do
+  defp transform_tokens(tokens, ignore_meta?) do
     Enum.map(tokens, fn
+      # Transform 0x to hex
       {:int, {line, column, _}, [?0, ?x | hex]} ->
         string_hex = hex |> List.to_string() |> String.upcase()
-        {:bin_string, {line, column, nil}, [string_hex]}
+        meta = if ignore_meta?, do: {0, 0, nil}, else: {line, column, nil}
+
+        {:bin_string, meta, [string_hex]}
 
       token ->
-        token
+        if ignore_meta? do
+          {_line, _colum, last} = elem(token, 1)
+          token |> Tuple.delete_at(1) |> Tuple.insert_at(1, {0, 0, last})
+        else
+          token
+        end
     end)
   end
 

--- a/lib/archethic/contracts/interpreter/condition_validator.ex
+++ b/lib/archethic/contracts/interpreter/condition_validator.ex
@@ -97,8 +97,10 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
            "previous" => %{"code" => prev_code}
          }
        ) do
-    {"code",
-     Interpreter.sanitize_code(prev_code || "") == Interpreter.sanitize_code(next_code || "")}
+    prev_ast = prev_code |> Interpreter.sanitize_code(ignore_meta?: true)
+    next_ast = next_code |> Interpreter.sanitize_code(ignore_meta?: true)
+
+    {"code", prev_ast == next_ast}
   end
 
   # Validation rules for inherit constraints

--- a/lib/archethic/contracts/interpreter/library.ex
+++ b/lib/archethic/contracts/interpreter/library.ex
@@ -33,7 +33,7 @@ defmodule Archethic.Contracts.Interpreter.Library do
   This function is also used to create the atoms of the modules
   """
   def list_common_modules() do
-    [:Map, :List, :Regex, :Json, :Time, :Chain, :Crypto, :Token, :String]
+    [:Map, :List, :Regex, :Json, :Time, :Chain, :Crypto, :Token, :String, :Code]
     |> Enum.map(&Atom.to_string/1)
   end
 

--- a/lib/archethic/contracts/interpreter/library/common/code.ex
+++ b/lib/archethic/contracts/interpreter/library/common/code.ex
@@ -1,0 +1,35 @@
+defmodule Archethic.Contracts.Interpreter.Library.Common.Code do
+  @moduledoc false
+  @behaviour Archethic.Contracts.Interpreter.Library
+
+  alias Archethic.Contracts.Interpreter
+  alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
+
+  @spec is_same?(binary(), binary()) :: boolean()
+  def is_same?(first_code, second_code) do
+    first_ast = first_code |> Interpreter.sanitize_code(ignore_meta?: true)
+    second_ast = second_code |> Interpreter.sanitize_code(ignore_meta?: true)
+
+    first_ast == second_ast
+  end
+
+  @spec is_valid?(binary()) :: boolean()
+  def is_valid?(code) do
+    case Interpreter.parse(code) do
+      {:ok, _} -> true
+      {:error, _} -> false
+    end
+  end
+
+  @spec check_types(atom(), list()) :: boolean()
+  def check_types(:is_same?, [first, second]) do
+    (AST.is_binary?(first) || AST.is_variable_or_function_call?(first)) &&
+      (AST.is_binary?(second) || AST.is_variable_or_function_call?(second))
+  end
+
+  def check_types(:is_valid?, [first]) do
+    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+  end
+
+  def check_types(_, _), do: false
+end

--- a/test/archethic/contracts/interpreter/library/common/code_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/code_test.exs
@@ -1,0 +1,105 @@
+defmodule Archethic.Contracts.Interpreter.Library.Common.CodeTest do
+  use ArchethicCase
+
+  alias Archethic.Contracts.Interpreter.Library.Common.Code
+
+  # ----------------------------------------
+  describe "is_same?/2" do
+    test "should return true if codes are the same" do
+      code = ~S"""
+      @version 1
+
+      condition transaction: []
+
+      actions triggered_by: transaction do
+        Contract.set_content "Should work"
+      end
+      """
+
+      assert Code.is_same?(code, code)
+    end
+
+    test "should return false if codes are different" do
+      first_code = ~S"""
+      @version 1
+
+      condition transaction: []
+
+      actions triggered_by: transaction do
+        Contract.set_content "Hello there"
+      end
+      """
+
+      second_code = ~S"""
+      @version 1
+
+      condition transaction: []
+
+      actions triggered_by: transaction do
+        Contract.set_content "When moon ?"
+      end
+      """
+
+      refute Code.is_same?(first_code, second_code)
+    end
+
+    test "should return true even with difference in line return and line space" do
+      first_code = ~S"""
+      @version 1
+
+      condition transaction: []
+
+      actions triggered_by: transaction do
+        Contract.set_content "Yolo"
+      end
+      """
+
+      second_code = ~S"""
+          
+
+      @version 1
+
+      condition transaction: []
+      actions triggered_by: transaction do Contract.set_content "Yolo" end
+
+      """
+
+      assert Code.is_same?(first_code, second_code)
+    end
+  end
+
+  # ----------------------------------------
+  describe "is_valid?/1" do
+    test "should return true if code is valid" do
+      code = ~S"""
+      @version 1
+
+      condition transaction: [
+        content: "No you're not"
+      ]
+
+      actions triggered_by: transaction do
+        Contract.set_content "Woaw ! I'm a content !"
+      end
+      """
+
+      assert Code.is_valid?(code)
+    end
+
+    test "should return false if code is invalid" do
+      code = ~S"""
+      @version 1
+
+      condition which_is_not_valid: [
+        content: "Poor code"
+      ]
+
+      actions triggered_by: transaction do
+        Contract.set_content "You will never goes here"
+      end
+      """
+
+      refute Code.is_valid?(code)
+    end
+  end
+end


### PR DESCRIPTION
# Description

In some case we need to compare code inside a smart contract. Instead of comparing strings, we can tokenize the code and ensure the two codes behave the same even if strings are not literally the same.

To do it I updated the sanitize code function to remove the metadata about code (such as line, colum ...) as it only the AST instructions can be compared

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests and SC playground

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
