### PR TITLE
Fix aeweb schema, add hashFunction

### DIFF
--- a/priv/json-schemas/aeweb.json
+++ b/priv/json-schemas/aeweb.json
@@ -51,6 +51,15 @@
           "exclusiveMinimum": 0,
           "description": "AEWeb's version"
         },
+        "hashFunction": {
+          "type": "string",
+          "enum": [
+            "md5",
+            "sha1",
+            "sha256",
+            "sha512"
+          ]
+        },
         "publicationStatus": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
# Description

AEWeb schema is missing attribute `hashFunction`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- 
# How Has This Been Tested?

Used AEWeb cli and AEWeb front app, both works well

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
