### PR TITLE
AEIP-18 token resupply implementation

### DIFF
--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -867,7 +867,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
          "Invalid token transaction - token_reference exists but does not contain a valid JSON"}
 
       :error ->
-        {:error, "Invalid token transaction - token_reference is not an hexacdecimal"}
+        {:error, "Invalid token transaction - token_reference is not an hexadecimal"}
     end
   end
 

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -116,6 +116,19 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       %LedgerOperations{
         unspent_outputs: []
       }
+
+      iex> LedgerOperations.from_transaction(%LedgerOperations{},
+      ...>   %Transaction{
+      ...>     address: "@Token2",
+      ...>     type: :token,
+      ...>     data: %TransactionData{content: "{\"supply\": 100000000, \"token_reference\": \"40546F6B656E526566\", \"aeip\": [2, 18]}"}
+      ...>   }, ~U[2022-10-10 08:07:31.784Z]
+      ...>  )
+      %LedgerOperations{
+        unspent_outputs: [
+          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@TokenRef", 0}, timestamp: ~U[2022-10-10 08:07:31.784Z]}
+        ]
+      }
   """
   @spec from_transaction(t(), Transaction.t(), DateTime.t()) :: t()
   def from_transaction(

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -140,6 +140,17 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
 
   def from_transaction(ops = %__MODULE__{}, %Transaction{}, _timestamp), do: ops
 
+  defp get_token_utxos(%{"token_reference" => token_ref, "supply" => supply}, address, timestamp) do
+    [
+      %UnspentOutput{
+        from: address,
+        amount: supply,
+        type: {:token, Base.decode16!(token_ref), 0},
+        timestamp: timestamp
+      }
+    ]
+  end
+
   defp get_token_utxos(%{"type" => "fungible", "supply" => supply}, address, timestamp) do
     [
       %UnspentOutput{

--- a/priv/json-schemas/token-core.json
+++ b/priv/json-schemas/token-core.json
@@ -27,6 +27,17 @@
       "type": "string",
       "description": "Symbol of the token"
     },
+    "aeip": {
+      "type": "array",
+      "description": "List of supported AEIPs",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "allow_mint": {
+      "type": "boolean",
+      "description": "This token can be resupplied later or not (AEIP-18)"
+    },
     "properties": {
       "description": "List of the global token properties",
       "type": "object"
@@ -50,5 +61,6 @@
   "required": [
     "supply",
     "type"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/priv/json-schemas/token-resupply.json
+++ b/priv/json-schemas/token-resupply.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "supply": {
+            "type": "integer",
+            "description": "Number of tokens to create",
+            "exclusiveMinimum": 0,
+            "maximum": 1.84467440737095e19
+        },
+        "aeip": {
+            "type": "array",
+            "description": "List of supported AEIPs",
+            "items": {
+                "type": "integer"
+            }
+        },
+        "token_reference": {
+            "type": "string",
+            "description": "Address of the fungible token to resupply"
+        }
+    },
+    "required": [
+        "supply",
+        "token_reference"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
# Description

Implement AEIP-18: token resupply
Fixes #1174 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual scenario:
- create a fungible token
- create a resupply transaction
- utxos should have the same token_address

![Screenshot_2023-08-01_16-04-41](https://github.com/archethic-foundation/archethic-node/assets/74045243/a67b5299-1188-4a67-bd66-446e41ab0c94)


plus a few unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
