### PR TITLE
String.to_hex now encode any string in hex

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/string.ex
+++ b/lib/archethic/contracts/interpreter/library/common/string.ex
@@ -21,7 +21,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.String do
         Base.encode16(bin)
 
       :error ->
-        nil
+        Base.encode16(str)
     end
   end
 

--- a/test/archethic/contracts/interpreter/library/common/string_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/string_test.exs
@@ -8,7 +8,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
   import ArchethicCase
 
   alias Archethic.Contracts.Interpreter.Library.Common.String
-  alias Archethic.Contracts.ContractConstants, as: Constants
 
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
@@ -138,119 +137,13 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
 
   # ----------------------------------------
   describe "to_hex/1" do
-    test "should work on a string" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          Contract.set_content String.to_hex("abc123def456")
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ABC123DEF456"}} =
-               sanitize_parse_execute(code)
+    test "should convert string to hex" do
+      assert "77696C6C206265636F6D6520686578" == String.to_hex("will become hex")
     end
 
-    test "should work on a variable" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          var = "abc123def456"
-          Contract.set_content String.to_hex(var)
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ABC123DEF456"}} =
-               sanitize_parse_execute(code)
-    end
-
-    test "should work on a constant" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          Contract.set_content String.to_hex(transaction.address)
-      end
-      """
-
-      address = random_address()
-
-      trigger_tx = %Transaction{
-        type: :data,
-        address: address,
-        data: %TransactionData{}
-      }
-
-      assert %Transaction{data: %TransactionData{content: hex}} =
-               sanitize_parse_execute(code, %{
-                 "transaction" => Constants.from_transaction(trigger_tx)
-               })
-
-      assert address == Base.decode16!(hex)
-    end
-
-    test "should be able to compare with hash" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          if Crypto.hash("foo") == String.to_hex("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae") do
-            Contract.set_content "ok"
-          end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
-    end
-
-    test "should be able to compare" do
-      address = random_address()
-
-      code = ~s"""
-      actions triggered_by: transaction do
-          if transaction.address == String.to_hex("#{Base.encode16(address, case: :lower)}") do
-            Contract.set_content "ok"
-          end
-      end
-      """
-
-      trigger_tx = %Transaction{
-        type: :data,
-        address: address,
-        data: %TransactionData{}
-      }
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} =
-               sanitize_parse_execute(code, %{
-                 "transaction" => Constants.from_transaction(trigger_tx)
-               })
-    end
-
-    test "should not parse if compiler knows there is a type error" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          Contract.set_content String.to_hex(123)
-      end
-      """
-
-      {:error, _, "invalid function arguments"} = sanitize_parse_execute(code)
-    end
-
-    test "should return nil if size of string is incorrect" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          if nil == String.to_hex("abc") do
-            Contract.set_content "ok"
-          end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
-    end
-
-    test "should return nil if size of string contains non hexadecimal chars" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          if nil == String.to_hex("fghijk") do
-            Contract.set_content "ok"
-          end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+    test "should keep hex if string is already hex" do
+      assert "ABCD" = String.to_hex("ABCD")
+      assert "ABCD" = String.to_hex("abcd")
     end
   end
 

--- a/test/archethic/contracts/interpreter/library/common/string_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/string_test.exs
@@ -5,133 +5,56 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
   """
 
   use ArchethicCase
-  import ArchethicCase
 
   alias Archethic.Contracts.Interpreter.Library.Common.String
-
-  alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.TransactionData
 
   doctest String
 
   # ----------------------------------------
   describe "size/1" do
-    test "should work" do
-      code = ~s"""
-      actions triggered_by: transaction do
-        Contract.set_content String.size("hello")
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "5"}} = sanitize_parse_execute(code)
+    test "should return the size of a string" do
+      assert String.size("hello") == 5
     end
   end
 
   # ----------------------------------------
   describe "in?/1" do
-    test "should work" do
-      code = ~s"""
-      actions triggered_by: transaction do
-        if String.in?("bob,alice", "bob") do
-          Contract.set_content "ok"
-        else
-          Contract.set_content "ko"
-        end
-      end
-      """
+    test "should return true if a string contains another string" do
+      assert String.in?("bob,alice", "bob")
+    end
 
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
-
-      code = ~s"""
-      actions triggered_by: transaction do
-        if String.in?("bob,alice", "robert") do
-          Contract.set_content "ko"
-        else
-          Contract.set_content "ok"
-
-        end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+    test "shoudl return false if a string does not contain another string" do
+      refute String.in?("bob,alice", "robert")
     end
   end
 
   # ----------------------------------------
   describe "to_number/1" do
     test "should parse integer" do
-      code = ~s"""
-      actions triggered_by: transaction do
-        if String.to_number("14") == 14 do
-          Contract.set_content "ok"
-        end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+      assert 14 == String.to_number("14")
     end
 
     test "should parse float" do
-      code = ~s"""
-      actions triggered_by: transaction do
-        if String.to_number("14.1") == 14.1 do
-          Contract.set_content "ok"
-        end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+      assert String.to_number("14.1") == 14.1
     end
 
     test "should return nil if not a number" do
-      code = ~s"""
-      actions triggered_by: transaction do
-        if String.to_number("bob") == nil do
-          Contract.set_content "ok"
-        end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+      assert String.to_number("bob") == nil
     end
   end
 
   # ----------------------------------------
   describe "from_number/1" do
     test "should convert int" do
-      code = ~s"""
-      actions triggered_by: transaction do
-        if String.from_number(14) == "14" do
-          Contract.set_content "ok"
-        end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+      assert String.from_number(14) == "14"
     end
 
     test "should convert float" do
-      code = ~s"""
-      actions triggered_by: transaction do
-        if String.from_number(14.1) == "14.1" do
-          Contract.set_content "ok"
-        end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+      assert String.from_number(14.1) == "14.1"
     end
 
     test "should display float as int if possible" do
-      code = ~s"""
-      actions triggered_by: transaction do
-        if String.from_number(14.0) == "14" do
-          Contract.set_content "ok"
-        end
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "ok"}} = sanitize_parse_execute(code)
+      assert String.from_number(14.0) == "14"
     end
   end
 
@@ -149,99 +72,15 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
 
   # ----------------------------------------
   describe "to_uppercase/1" do
-    test "should work on a string" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          Contract.set_content String.to_uppercase("IiIiIiIiIiII")
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "IIIIIIIIIIII"}} =
-               sanitize_parse_execute(code)
-    end
-
-    test "should work on a variable" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          var = "IiIiIiIiIiII"
-          Contract.set_content String.to_uppercase(var)
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "IIIIIIIIIIII"}} =
-               sanitize_parse_execute(code)
-    end
-
-    test "should not parse if compiler knows there is a type error" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          Contract.set_content String.to_uppercase(123)
-      end
-      """
-
-      {:error, _, "invalid function arguments"} = sanitize_parse_execute(code)
-    end
-
-    test "should raise when not a string" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          var = 123
-          Contract.set_content String.to_uppercase(var)
-      end
-      """
-
-      assert_raise(FunctionClauseError, fn ->
-        sanitize_parse_execute(code)
-      end)
+    test "should convert string to uppercase" do
+      assert String.to_uppercase("IiIiIiIiIiII") == "IIIIIIIIIIII"
     end
   end
 
   # ----------------------------------------
   describe "to_lowercase/1" do
-    test "should work on a string" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          Contract.set_content String.to_lowercase("IiIiIiIiIiII")
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "iiiiiiiiiiii"}} =
-               sanitize_parse_execute(code)
-    end
-
-    test "should work on a variable" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          var = "IiIiIiIiIiII"
-          Contract.set_content String.to_lowercase(var)
-      end
-      """
-
-      assert %Transaction{data: %TransactionData{content: "iiiiiiiiiiii"}} =
-               sanitize_parse_execute(code)
-    end
-
-    test "should not parse if compiler knows there is a type error" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          Contract.set_content String.to_lowercase(123)
-      end
-      """
-
-      {:error, _, "invalid function arguments"} = sanitize_parse_execute(code)
-    end
-
-    test "should raise when not a string" do
-      code = ~s"""
-      actions triggered_by: transaction do
-          var = 123
-          Contract.set_content String.to_lowercase(var)
-      end
-      """
-
-      assert_raise(FunctionClauseError, fn ->
-        sanitize_parse_execute(code)
-      end)
+    test "should convert string to lowercase" do
+      assert String.to_lowercase("IiIiIiIiIiII") == "iiiiiiiiiiii"
     end
   end
 end


### PR DESCRIPTION
# Description

To not allow developer to interact with binaries, we can let them convert any string in hexadecimal format and concatenate hex representation of string.

Fixes #1160 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
