### PR TITLE
AEIP-19 token recipients

### DIFF
--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -187,8 +187,11 @@ defmodule Archethic.Bootstrap.NetworkInit do
         fee: Mining.get_transaction_fee(tx, 0.07, timestamp),
         transaction_movements: Transaction.get_movements(tx)
       }
-      |> LedgerOperations.from_transaction(tx, timestamp)
-      |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
+      |> LedgerOperations.consume_inputs(
+        tx.address,
+        unspent_outputs ++ LedgerOperations.get_utxos_from_transaction(tx, timestamp),
+        timestamp
+      )
 
     validation_stamp =
       %ValidationStamp{

--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -186,7 +186,7 @@ defmodule Archethic.Bootstrap.NetworkInit do
       %LedgerOperations{
         fee: Mining.get_transaction_fee(tx, 0.07, timestamp),
         transaction_movements: Transaction.get_movements(tx),
-        unspent_outputs: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
+        tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
       }
       |> LedgerOperations.consume_inputs(
         tx.address,

--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -185,13 +185,15 @@ defmodule Archethic.Bootstrap.NetworkInit do
     operations =
       %LedgerOperations{
         fee: Mining.get_transaction_fee(tx, 0.07, timestamp),
-        transaction_movements: Transaction.get_movements(tx)
+        transaction_movements: Transaction.get_movements(tx),
+        unspent_outputs: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
       }
       |> LedgerOperations.consume_inputs(
         tx.address,
-        unspent_outputs ++ LedgerOperations.get_utxos_from_transaction(tx, timestamp),
+        unspent_outputs,
         timestamp
       )
+      |> elem(1)
 
     validation_stamp =
       %ValidationStamp{

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -169,6 +169,7 @@ defmodule Archethic.Mining.StandaloneWorkflow do
       transaction_type: validated_tx.type
     )
 
+    IO.inspect(validated_tx: validated_tx)
     message = %ValidateTransaction{
       transaction: validated_tx
     }

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -169,7 +169,6 @@ defmodule Archethic.Mining.StandaloneWorkflow do
       transaction_type: validated_tx.type
     )
 
-    IO.inspect(validated_tx: validated_tx)
     message = %ValidateTransaction{
       transaction: validated_tx
     }

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1214,6 +1214,13 @@ defmodule Archethic.Mining.ValidationContext do
         end
       end)
 
+    IO.inspect(
+      transaction_movements: transaction_movements,
+      initial_movements: initial_movements,
+      resolved_movements: resolved_movements,
+      resolved_addresses: resolved_addresses
+    )
+
     length(resolved_movements) == length(transaction_movements) and
       Enum.all?(resolved_movements, &(&1 in transaction_movements))
   end

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -795,7 +795,7 @@ defmodule Archethic.Mining.ValidationContext do
     %LedgerOperations{
       fee: fee,
       transaction_movements: resolved_movements,
-      unspent_outputs: LedgerOperations.get_utxos_from_transaction(tx, validation_time)
+      tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, validation_time)
     }
     |> LedgerOperations.consume_inputs(
       tx.address,
@@ -1224,7 +1224,7 @@ defmodule Archethic.Mining.ValidationContext do
       %LedgerOperations{
         fee: fee,
         transaction_movements: Transaction.get_movements(tx),
-        unspent_outputs: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
+        tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
       }
       |> LedgerOperations.consume_inputs(
         tx.address,

--- a/lib/archethic/replication/transaction_validator.ex
+++ b/lib/archethic/replication/transaction_validator.ex
@@ -340,7 +340,7 @@ defmodule Archethic.Replication.TransactionValidator do
       %LedgerOperations{
         fee: fee,
         transaction_movements: transaction_movements,
-        unspent_outputs: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
+        tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
       }
       |> LedgerOperations.consume_inputs(
         address,

--- a/lib/archethic/transaction_chain/transaction.ex
+++ b/lib/archethic/transaction_chain/transaction.ex
@@ -970,11 +970,13 @@ defmodule Archethic.TransactionChain.Transaction do
   end
 
   defp get_movements_from_token_creation(tx_address, %{"recipients" => recipients, "type" => type}) do
-    Enum.map(recipients, fn r = %{"to" => address_hex, "amount" => amount} ->
-      token_id = r["token_id"] || 0
+    fungible? = type == "fungible"
+
+    Enum.map(recipients, fn recipient = %{"to" => address_hex, "amount" => amount} ->
+      token_id = Map.get(recipient, "token_id", 0)
       address = Base.decode16!(address_hex, case: :mixed)
 
-      if type == "non-fungible" and amount != @unit_uco do
+      if not fungible? and amount != @unit_uco do
         nil
       else
         %TransactionMovement{

--- a/lib/archethic/transaction_chain/transaction.ex
+++ b/lib/archethic/transaction_chain/transaction.ex
@@ -18,6 +18,7 @@ defmodule Archethic.TransactionChain.Transaction do
 
   alias Archethic.Utils
 
+  @unit_uco 100_000_000
   @version 1
 
   defstruct [
@@ -476,11 +477,15 @@ defmodule Archethic.TransactionChain.Transaction do
 
                 case Base.decode16(address_hex, case: :mixed) do
                   {:ok, address} ->
-                    %TransactionMovement{
-                      to: address,
-                      amount: amount,
-                      type: {:token, token_address, token_id}
-                    }
+                    if not fungible? && amount != @unit_uco do
+                      []
+                    else
+                      %TransactionMovement{
+                        to: address,
+                        amount: amount,
+                        type: {:token, token_address, token_id}
+                      }
+                    end
 
                   _ ->
                     []

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -45,94 +45,9 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
 
   @doc ~S"""
   Build some ledger operations from a specific transaction
-  ## Examples
-      iex> LedgerOperations.from_transaction(%LedgerOperations{},
-      ...>   %Transaction{
-      ...>     address: "@Token2",
-      ...>     type: :token,
-      ...>     data: %TransactionData{content: "{\"supply\": 1000000000, \"type\": \"fungible\" }"}
-      ...>   },~U[2022-10-10 08:07:31.784Z]
-      ...> )
-      %LedgerOperations{
-          unspent_outputs: [%UnspentOutput{from: "@Token2", amount: 1000000000, type: {:token, "@Token2", 0},timestamp: ~U[2022-10-10 08:07:31.784Z]}]
-      }
-
-      iex> LedgerOperations.from_transaction(%LedgerOperations{},
-      ...>   %Transaction{
-      ...>     address: "@Token2",
-      ...>     type: :token,
-      ...>     data: %TransactionData{content: "{\"supply\": 1000000000, \"type\": \"non-fungible\", \"collection\": [{},{},{},{},{},{},{},{},{},{}]}"}
-      ...>   },~U[2022-10-10 08:07:31.784Z]
-      ...>  )
-      %LedgerOperations{
-        unspent_outputs: [
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 1}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 2}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 3}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 4}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 5}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 6}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 7}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 8}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 9}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 10},timestamp: ~U[2022-10-10 08:07:31.784Z]}
-        ]
-      }
-
-      iex> LedgerOperations.from_transaction(%LedgerOperations{},
-      ...>   %Transaction{
-      ...>     address: "@Token2",
-      ...>     type: :token,
-      ...>     data: %TransactionData{content: "{\"supply\": 100000000, \"type\": \"non-fungible\"}"}
-      ...>   },~U[2022-10-10 08:07:31.784Z]
-      ...>  )
-      %LedgerOperations{
-        unspent_outputs: [
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 1}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-        ]
-      }
-
-      iex> LedgerOperations.from_transaction(%LedgerOperations{},
-      ...>   %Transaction{
-      ...>     address: "@Token2",
-      ...>     type: :token,
-      ...>     data: %TransactionData{content: "{\"supply\": 200000000, \"type\": \"non-fungible\", \"collection\": [{\"id\": 42}, {\"id\": 38}]}"}
-      ...>   },~U[2022-10-10 08:07:31.784Z]
-      ...>  )
-      %LedgerOperations{
-        unspent_outputs: [
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 42}, timestamp: ~U[2022-10-10 08:07:31.784Z]},
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@Token2", 38}, timestamp: ~U[2022-10-10 08:07:31.784Z]}
-        ]
-      }
-
-      iex> LedgerOperations.from_transaction(%LedgerOperations{},
-      ...>   %Transaction{
-      ...>     address: "@Token2",
-      ...>     type: :token,
-      ...>     data: %TransactionData{content: "{\"supply\": 1000000000, \"type\": \"non-fungible\", \"collection\": [{}]}"}
-      ...>   }, ~U[2022-10-10 08:07:31.784Z]
-      ...>  )
-      %LedgerOperations{
-        unspent_outputs: []
-      }
-
-      iex> LedgerOperations.from_transaction(%LedgerOperations{},
-      ...>   %Transaction{
-      ...>     address: "@Token2",
-      ...>     type: :token,
-      ...>     data: %TransactionData{content: "{\"supply\": 100000000, \"token_reference\": \"40546F6B656E526566\", \"aeip\": [2, 18]}"}
-      ...>   }, ~U[2022-10-10 08:07:31.784Z]
-      ...>  )
-      %LedgerOperations{
-        unspent_outputs: [
-          %UnspentOutput{from: "@Token2", amount: 100_000_000, type: {:token, "@TokenRef", 0}, timestamp: ~U[2022-10-10 08:07:31.784Z]}
-        ]
-      }
   """
-  @spec from_transaction(t(), Transaction.t(), DateTime.t()) :: t()
-  def from_transaction(
-        ops = %__MODULE__{},
+  @spec get_utxos_from_transaction(Transaction.t(), DateTime.t()) :: list(UnspentOutput.t())
+  def get_utxos_from_transaction(
         %Transaction{
           address: address,
           type: type,
@@ -143,24 +58,17 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       when type in [:token, :mint_rewards] and not is_nil(timestamp) do
     case Jason.decode(content) do
       {:ok, json} ->
-        utxos = get_token_utxos(json, address, timestamp)
-
-        ops
-        |> Map.update(:unspent_outputs, utxos, &(utxos ++ &1))
+        get_token_utxos(json, address, timestamp)
 
       _ ->
-        ops
+        []
     end
   end
 
-  def from_transaction(ops = %__MODULE__{}, %Transaction{}, _timestamp), do: ops
-
-  defp get_token_recipients(json_content) do
-    json_content["recipients"] || []
-  end
+  def get_utxos_from_transaction(%Transaction{}, _timestamp), do: []
 
   defp get_token_utxos(
-         json_content = %{"token_reference" => token_ref, "supply" => supply},
+         %{"token_reference" => token_ref, "supply" => supply},
          address,
          timestamp
        ) do
@@ -172,11 +80,10 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
         timestamp: timestamp
       }
     ]
-    |> subtract_recipients(json_content)
   end
 
   defp get_token_utxos(
-         json_content = %{"type" => "fungible", "supply" => supply},
+         %{"type" => "fungible", "supply" => supply},
          address,
          timestamp
        ) do
@@ -188,11 +95,10 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
         timestamp: timestamp
       }
     ]
-    |> subtract_recipients(json_content)
   end
 
   defp get_token_utxos(
-         json_content = %{
+         %{
            "type" => "non-fungible",
            "supply" => supply,
            "collection" => collection
@@ -213,14 +119,13 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
           timestamp: timestamp
         }
       end)
-      |> subtract_recipients(json_content)
     else
       []
     end
   end
 
   defp get_token_utxos(
-         json_content = %{"type" => "non-fungible", "supply" => @unit_uco},
+         %{"type" => "non-fungible", "supply" => @unit_uco},
          address,
          timestamp
        ) do
@@ -232,37 +137,9 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
         timestamp: timestamp
       }
     ]
-    |> subtract_recipients(json_content)
   end
 
   defp get_token_utxos(_, _, _), do: []
-
-  defp subtract_recipients([], _), do: []
-
-  defp subtract_recipients(utxos, json_content = %{"recipients" => recipients})
-       when is_list(recipients) do
-    Enum.reduce(utxos, [], fn utxo = %UnspentOutput{type: {:token, _, token_id}}, acc0 ->
-      utxo_modified =
-        json_content
-        |> get_token_recipients()
-        |> Enum.filter(&((&1["token_id"] || 0) == token_id))
-        |> Enum.reduce(utxo, fn
-          %{"amount" => amount}, acc1 ->
-            %UnspentOutput{acc1 | amount: acc1.amount - amount}
-
-          _, acc1 ->
-            acc1
-        end)
-
-      if utxo_modified.amount > 0 do
-        [utxo_modified | acc0]
-      else
-        acc0
-      end
-    end)
-  end
-
-  defp subtract_recipients(utxos, _), do: utxos
 
   @doc """
   Returns the amount to spend from the transaction movements and the fee
@@ -528,6 +405,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
 
       Map.update!(ops, :unspent_outputs, &(new_unspent_outputs ++ &1))
     else
+      IO.inspect("NOT SUFFICIENT FUNDS IN CONSUME INPUTS =====================")
       ops
     end
   end

--- a/priv/json-schemas/token-core.json
+++ b/priv/json-schemas/token-core.json
@@ -4,7 +4,7 @@
   "properties": {
     "supply": {
       "type": "integer",
-      "description": "Number of tokens to create",
+      "description": "Number of tokens to create (100 000 000 for 1 token if decimals=8)",
       "exclusiveMinimum": 0,
       "maximum": 1.84467440737095e19
     },
@@ -37,6 +37,24 @@
     "allow_mint": {
       "type": "boolean",
       "description": "This token can be resupplied later or not (AEIP-18)"
+    },
+    "recipients": {
+      "type": "array",
+      "description": "Token recipients (AEIP-19)",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "to": {
+            "type": "string",
+            "description": "Recipient address"
+          },
+          "amount": {
+            "type": "integer",
+            "description": "Amount of tokens to sent to this recipient (100 000 000 for 1 token if decimals=8)"
+          }
+        }
+      }
     },
     "properties": {
       "description": "List of the global token properties",

--- a/priv/json-schemas/token-core.json
+++ b/priv/json-schemas/token-core.json
@@ -51,6 +51,7 @@
           },
           "amount": {
             "type": "integer",
+            "minimum": 1,
             "description": "Amount of tokens to sent to this recipient (100 000 000 for 1 token if decimals=8)"
           }
         }

--- a/priv/json-schemas/token-core.json
+++ b/priv/json-schemas/token-core.json
@@ -1,5 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "address": {
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^0[0-2]0[025][0-9a-fA-F]{64}$"
+        },
+        {
+          "type": "string",
+          "pattern": "^0[0-2]0[134][0-9a-fA-F]{128}$"
+        }
+      ]
+    }
+  },
   "type": "object",
   "properties": {
     "supply": {
@@ -44,9 +58,17 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "to",
+          "amount"
+        ],
         "properties": {
+          "token_id": {
+            "type": "integer",
+            "description": "The index of the token in a collection"
+          },
           "to": {
-            "type": "string",
+            "$ref": "#/$defs/address",
             "description": "Recipient address"
           },
           "amount": {

--- a/priv/json-schemas/token-resupply.json
+++ b/priv/json-schemas/token-resupply.json
@@ -1,6 +1,20 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
+    "$defs": {
+        "address": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "pattern": "^0[0-2]0[025][0-9a-fA-F]{64}$"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^0[0-2]0[134][0-9a-fA-F]{128}$"
+                }
+            ]
+        }
+    },
     "properties": {
         "supply": {
             "type": "integer",
@@ -16,7 +30,7 @@
             }
         },
         "token_reference": {
-            "type": "string",
+            "$ref": "#/$defs/address",
             "description": "Address of the fungible token to resupply"
         },
         "recipients": {
@@ -25,10 +39,18 @@
             "items": {
                 "type": "object",
                 "additionalProperties": false,
+                "required": [
+                    "to",
+                    "amount"
+                ],
                 "properties": {
+                    "token_id": {
+                        "type": "integer",
+                        "description": "The index of the token in a collection"
+                    },
                     "to": {
-                        "type": "string",
-                        "description": "Recipient address"
+                        "$ref": "#/$defs/address",
+                        "description": "The recipient's address"
                     },
                     "amount": {
                         "type": "integer",

--- a/priv/json-schemas/token-resupply.json
+++ b/priv/json-schemas/token-resupply.json
@@ -18,6 +18,24 @@
         "token_reference": {
             "type": "string",
             "description": "Address of the fungible token to resupply"
+        },
+        "recipients": {
+            "type": "array",
+            "description": "Token recipients (AEIP-19)",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "to": {
+                        "type": "string",
+                        "description": "Recipient address"
+                    },
+                    "amount": {
+                        "type": "integer",
+                        "description": "Amount of tokens to sent to this recipient (100 000 000 for 1 token if decimals=8)"
+                    }
+                }
+            }
         }
     },
     "required": [

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -1275,10 +1275,11 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       ledger_operations:
         %LedgerOperations{
           fee: Fee.calculate(tx, 0.07, timestamp),
-          transaction_movements: Transaction.get_movements(tx)
+          transaction_movements: Transaction.get_movements(tx),
+          tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
-        |> LedgerOperations.from_transaction(tx, timestamp)
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp),
+        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
+        |> elem(1),
       protocol_version: ArchethicCase.current_protocol_version()
     }
   end

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -1347,7 +1347,7 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
           0
         )
 
-      assert {:error, "Invalid token transaction - token_reference is not an hexadecimal"} =
+      assert {:error, "Invalid token transaction - neither a token creation nor a token resupply"} =
                PendingTransactionValidation.validate(tx)
     end
 

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -259,10 +259,11 @@ defmodule Archethic.Mining.ValidationContextTest do
       ledger_operations:
         %LedgerOperations{
           fee: Fee.calculate(tx, 0.07, timestamp),
-          transaction_movements: Transaction.get_movements(tx)
+          transaction_movements: Transaction.get_movements(tx),
+          tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
-        |> LedgerOperations.from_transaction(tx, timestamp)
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp),
+        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
+        |> elem(1),
       signature: :crypto.strong_rand_bytes(32),
       protocol_version: ArchethicCase.current_protocol_version()
     }
@@ -281,10 +282,11 @@ defmodule Archethic.Mining.ValidationContextTest do
       ledger_operations:
         %LedgerOperations{
           fee: Fee.calculate(tx, 0.07, timestamp),
-          transaction_movements: Transaction.get_movements(tx)
+          transaction_movements: Transaction.get_movements(tx),
+          tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
-        |> LedgerOperations.from_transaction(tx, timestamp)
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp),
+        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
+        |> elem(1),
       protocol_version: ArchethicCase.current_protocol_version()
     }
     |> ValidationStamp.sign()
@@ -303,10 +305,11 @@ defmodule Archethic.Mining.ValidationContextTest do
       ledger_operations:
         %LedgerOperations{
           fee: Fee.calculate(tx, 0.07, timestamp),
-          transaction_movements: Transaction.get_movements(tx)
+          transaction_movements: Transaction.get_movements(tx),
+          tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
-        |> LedgerOperations.from_transaction(tx, timestamp)
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp),
+        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
+        |> elem(1),
       protocol_version: ArchethicCase.current_protocol_version()
     }
     |> ValidationStamp.sign()
@@ -327,7 +330,8 @@ defmodule Archethic.Mining.ValidationContextTest do
           fee: 2_020_000_000,
           transaction_movements: Transaction.get_movements(tx)
         }
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp),
+        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
+        |> elem(1),
       protocol_version: ArchethicCase.current_protocol_version()
     }
     |> ValidationStamp.sign()
@@ -360,7 +364,8 @@ defmodule Archethic.Mining.ValidationContextTest do
             }
           ]
         }
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp),
+        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
+        |> elem(1),
       protocol_version: ArchethicCase.current_protocol_version()
     }
     |> ValidationStamp.sign()
@@ -408,7 +413,8 @@ defmodule Archethic.Mining.ValidationContextTest do
           fee: Fee.calculate(tx, 0.07, timestamp),
           transaction_movements: Transaction.get_movements(tx)
         }
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp),
+        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
+        |> elem(1),
       error: :invalid_pending_transaction,
       protocol_version: ArchethicCase.current_protocol_version()
     }

--- a/test/archethic/replication_test.exs
+++ b/test/archethic/replication_test.exs
@@ -271,6 +271,7 @@ defmodule Archethic.ReplicationTest do
         fee: Fee.calculate(tx, 0.07, timestamp)
       }
       |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
+      |> elem(1)
 
     validation_stamp =
       %ValidationStamp{

--- a/test/archethic/transaction_chain/transaction/validation_stamp/ledger_operations_test.exs
+++ b/test/archethic/transaction_chain/transaction/validation_stamp/ledger_operations_test.exs
@@ -1,16 +1,540 @@
 defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperationsTest do
-  use ArchethicCase
-
-  import ArchethicCase, only: [current_protocol_version: 0]
-  use ExUnitProperties
-
-  alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionFactory
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.TransactionMovement
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
-  alias Archethic.TransactionChain.TransactionData
+
+  use ArchethicCase
+  import ArchethicCase
 
   doctest LedgerOperations
+
+  describe("get_utxos_from_transaction/2") do
+    test "should return empty list for non token/mint_reward transactiosn" do
+      types = Archethic.TransactionChain.Transaction.types() -- [:node, :mint_reward]
+
+      Enum.each(types, fn t ->
+        assert [] =
+                 LedgerOperations.get_utxos_from_transaction(
+                   TransactionFactory.create_valid_transaction([], type: t),
+                   DateTime.utc_now()
+                 )
+      end)
+    end
+
+    test "should return empty list if content is invalid" do
+      assert [] =
+               LedgerOperations.get_utxos_from_transaction(
+                 TransactionFactory.create_valid_transaction([],
+                   type: :token,
+                   content: "not a json"
+                 ),
+                 DateTime.utc_now()
+               )
+
+      assert [] =
+               LedgerOperations.get_utxos_from_transaction(
+                 TransactionFactory.create_valid_transaction([], type: :token, content: "{}"),
+                 DateTime.utc_now()
+               )
+    end
+  end
+
+  describe("get_utxos_from_transaction/2 with a token resupply transaction") do
+    test "should return a utxo" do
+      token_address = random_address()
+      token_address_hex = token_address |> Base.encode16()
+      now = DateTime.utc_now()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+          "token_reference": "#{token_address_hex}",
+          "supply": 1000000
+          }
+          """
+        )
+
+      tx_address = tx.address
+
+      assert [
+               %UnspentOutput{
+                 amount: 1_000_000,
+                 from: ^tx_address,
+                 type: {:token, ^token_address, 0},
+                 timestamp: ^now
+               }
+             ] = LedgerOperations.get_utxos_from_transaction(tx, now)
+    end
+
+    test "should return an empty list if invalid tx" do
+      now = DateTime.utc_now()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+          "token_reference": "nonhexadecimal",
+          "supply": 1000000
+          }
+          """
+        )
+
+      assert [] = LedgerOperations.get_utxos_from_transaction(tx, now)
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+          "token_reference": {"foo": "bar"},
+          "supply": 1000000
+          }
+          """
+        )
+
+      assert [] = LedgerOperations.get_utxos_from_transaction(tx, now)
+
+      token_address = random_address()
+      token_address_hex = token_address |> Base.encode16()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+          "token_reference": "#{token_address_hex}",
+          "supply": "hello"
+          }
+          """
+        )
+
+      assert [] = LedgerOperations.get_utxos_from_transaction(tx, now)
+    end
+  end
+
+  describe("get_utxos_from_transaction/2 with a token creation transaction") do
+    test "should return a utxo (for fungible)" do
+      now = DateTime.utc_now()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+            "supply": 1000000000,
+            "type": "fungible",
+            "decimals": 8,
+            "name": "NAME OF MY TOKEN",
+            "symbol": "MTK"
+          }
+          """
+        )
+
+      tx_address = tx.address
+
+      assert [
+               %UnspentOutput{
+                 amount: 1_000_000_000,
+                 from: ^tx_address,
+                 type: {:token, ^tx_address, 0},
+                 timestamp: ^now
+               }
+             ] = LedgerOperations.get_utxos_from_transaction(tx, now)
+    end
+
+    test "should return a utxo (for non-fungible)" do
+      now = DateTime.utc_now()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+            "supply": 100000000,
+            "type": "non-fungible",
+            "name": "My NFT",
+            "symbol": "MNFT",
+            "properties": {
+               "image": "base64 of the image",
+               "description": "This is a NFT with an image"
+            }
+          }
+          """
+        )
+
+      tx_address = tx.address
+
+      assert [
+               %UnspentOutput{
+                 amount: 100_000_000,
+                 from: ^tx_address,
+                 type: {:token, ^tx_address, 1},
+                 timestamp: ^now
+               }
+             ] = LedgerOperations.get_utxos_from_transaction(tx, now)
+    end
+
+    test "should return a utxo (for non-fungible collection)" do
+      now = DateTime.utc_now()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+            "supply": 300000000,
+            "name": "My NFT",
+            "type": "non-fungible",
+            "symbol": "MNFT",
+            "properties": {
+               "description": "this property is for all NFT"
+            },
+            "collection": [
+               { "image": "link of the 1st NFT image" },
+               { "image": "link of the 2nd NFT image" },
+               {
+                  "image": "link of the 3rd NFT image",
+                  "other_property": "other value"
+               }
+            ]
+          }
+          """
+        )
+
+      tx_address = tx.address
+
+      assert [
+               %UnspentOutput{
+                 amount: 100_000_000,
+                 from: ^tx_address,
+                 type: {:token, ^tx_address, 1},
+                 timestamp: ^now
+               },
+               %UnspentOutput{
+                 amount: 100_000_000,
+                 from: ^tx_address,
+                 type: {:token, ^tx_address, 2},
+                 timestamp: ^now
+               },
+               %UnspentOutput{
+                 amount: 100_000_000,
+                 from: ^tx_address,
+                 type: {:token, ^tx_address, 3},
+                 timestamp: ^now
+               }
+             ] = LedgerOperations.get_utxos_from_transaction(tx, now)
+    end
+
+    test "should return an empty list if invalid tx" do
+      now = DateTime.utc_now()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+          "supply": "foo"
+          }
+          """
+        )
+
+      assert [] = LedgerOperations.get_utxos_from_transaction(tx, now)
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+          "supply": 100000000
+          }
+          """
+        )
+
+      assert [] = LedgerOperations.get_utxos_from_transaction(tx, now)
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+            "type": "fungible"
+          }
+          """
+        )
+
+      assert [] = LedgerOperations.get_utxos_from_transaction(tx, now)
+    end
+  end
+
+  describe "consume_inputs/4" do
+    test "When a single unspent output is sufficient to satisfy the transaction movements" do
+      assert %LedgerOperations{
+               transaction_movements: [
+                 %TransactionMovement{to: "@Bob4", amount: 1_040_000_000, type: :UCO},
+                 %TransactionMovement{to: "@Charlie2", amount: 217_000_000, type: :UCO}
+               ],
+               fee: 40_000_000,
+               unspent_outputs: [
+                 %UnspentOutput{
+                   from: "@Alice2",
+                   amount: 703_000_000,
+                   type: :UCO,
+                   timestamp: ~U[2022-10-10 10:44:38.983Z]
+                 }
+               ]
+             } =
+               LedgerOperations.consume_inputs(
+                 %LedgerOperations{
+                   transaction_movements: [
+                     %TransactionMovement{to: "@Bob4", amount: 1_040_000_000, type: :UCO},
+                     %TransactionMovement{to: "@Charlie2", amount: 217_000_000, type: :UCO}
+                   ],
+                   fee: 40_000_000
+                 },
+                 "@Alice2",
+                 [
+                   %UnspentOutput{
+                     from: "@Bob3",
+                     amount: 2_000_000_000,
+                     type: :UCO,
+                     timestamp: ~U[2022-10-09 08:39:10.463Z]
+                   }
+                 ],
+                 ~U[2022-10-10 10:44:38.983Z]
+               )
+               |> elem(1)
+    end
+
+    test "When multiple little unspent output are sufficient to satisfy the transaction movements" do
+      assert %LedgerOperations{
+               transaction_movements: [
+                 %TransactionMovement{to: "@Bob4", amount: 1_040_000_000, type: :UCO},
+                 %TransactionMovement{to: "@Charlie2", amount: 217_000_000, type: :UCO}
+               ],
+               fee: 40_000_000,
+               unspent_outputs: [
+                 %UnspentOutput{
+                   from: "@Alice2",
+                   amount: 1_103_000_000,
+                   type: :UCO,
+                   timestamp: ~U[2022-10-10 10:44:38.983Z]
+                 }
+               ]
+             } =
+               %LedgerOperations{
+                 transaction_movements: [
+                   %TransactionMovement{to: "@Bob4", amount: 1_040_000_000, type: :UCO},
+                   %TransactionMovement{to: "@Charlie2", amount: 217_000_000, type: :UCO}
+                 ],
+                 fee: 40_000_000
+               }
+               |> LedgerOperations.consume_inputs(
+                 "@Alice2",
+                 [
+                   %UnspentOutput{from: "@Bob3", amount: 500_000_000, type: :UCO},
+                   %UnspentOutput{from: "@Tom4", amount: 700_000_000, type: :UCO},
+                   %UnspentOutput{from: "@Christina", amount: 400_000_000, type: :UCO},
+                   %UnspentOutput{from: "@Hugo", amount: 800_000_000, type: :UCO}
+                 ],
+                 ~U[2022-10-10 10:44:38.983Z]
+               )
+               |> elem(1)
+    end
+
+    test "When using Token unspent outputs are sufficient to satisfy the transaction movements" do
+      assert %LedgerOperations{
+               transaction_movements: [
+                 %TransactionMovement{
+                   to: "@Bob4",
+                   amount: 1_000_000_000,
+                   type: {:token, "@CharlieToken", 0}
+                 }
+               ],
+               fee: 40_000_000,
+               unspent_outputs: [
+                 %UnspentOutput{
+                   from: "@Alice2",
+                   amount: 160_000_000,
+                   type: :UCO,
+                   timestamp: ~U[2022-10-10 10:44:38.983Z]
+                 },
+                 %UnspentOutput{
+                   from: "@Alice2",
+                   amount: 200_000_000,
+                   type: {:token, "@CharlieToken", 0},
+                   timestamp: ~U[2022-10-10 10:44:38.983Z]
+                 }
+               ]
+             } =
+               %LedgerOperations{
+                 transaction_movements: [
+                   %TransactionMovement{
+                     to: "@Bob4",
+                     amount: 1_000_000_000,
+                     type: {:token, "@CharlieToken", 0}
+                   }
+                 ],
+                 fee: 40_000_000
+               }
+               |> LedgerOperations.consume_inputs(
+                 "@Alice2",
+                 [
+                   %UnspentOutput{
+                     from: "@Charlie1",
+                     amount: 200_000_000,
+                     type: :UCO,
+                     timestamp: ~U[2022-10-09 08:39:10.463Z]
+                   },
+                   %UnspentOutput{
+                     from: "@Bob3",
+                     amount: 1_200_000_000,
+                     type: {:token, "@CharlieToken", 0},
+                     timestamp: ~U[2022-10-09 08:39:10.463Z]
+                   }
+                 ],
+                 ~U[2022-10-10 10:44:38.983Z]
+               )
+               |> elem(1)
+    end
+
+    test "When multiple Token unspent outputs are sufficient to satisfy the transaction movements" do
+      assert %LedgerOperations{
+               transaction_movements: [
+                 %TransactionMovement{
+                   to: "@Bob4",
+                   amount: 1_000_000_000,
+                   type: {:token, "@CharlieToken", 0}
+                 }
+               ],
+               fee: 40_000_000,
+               unspent_outputs: [
+                 %UnspentOutput{
+                   from: "@Alice2",
+                   amount: 160_000_000,
+                   type: :UCO,
+                   timestamp: ~U[2022-10-10 10:44:38.983Z]
+                 },
+                 %UnspentOutput{
+                   from: "@Alice2",
+                   amount: 900_000_000,
+                   type: {:token, "@CharlieToken", 0},
+                   timestamp: ~U[2022-10-10 10:44:38.983Z]
+                 }
+               ]
+             } =
+               %LedgerOperations{
+                 transaction_movements: [
+                   %TransactionMovement{
+                     to: "@Bob4",
+                     amount: 1_000_000_000,
+                     type: {:token, "@CharlieToken", 0}
+                   }
+                 ],
+                 fee: 40_000_000
+               }
+               |> LedgerOperations.consume_inputs(
+                 "@Alice2",
+                 [
+                   %UnspentOutput{from: "@Charlie1", amount: 200_000_000, type: :UCO},
+                   %UnspentOutput{
+                     from: "@Bob3",
+                     amount: 500_000_000,
+                     type: {:token, "@CharlieToken", 0}
+                   },
+                   %UnspentOutput{
+                     from: "@Hugo5",
+                     amount: 700_000_000,
+                     type: {:token, "@CharlieToken", 0}
+                   },
+                   %UnspentOutput{
+                     from: "@Tom1",
+                     amount: 700_000_000,
+                     type: {:token, "@CharlieToken", 0}
+                   }
+                 ],
+                 ~U[2022-10-10 10:44:38.983Z]
+               )
+               |> elem(1)
+    end
+
+    test "When non-fungible tokens are used as input but want to consume only a single input" do
+      assert %LedgerOperations{
+               fee: 40_000_000,
+               transaction_movements: [
+                 %TransactionMovement{
+                   to: "@Bob4",
+                   amount: 100_000_000,
+                   type: {:token, "@CharlieToken", 2}
+                 }
+               ],
+               unspent_outputs: [
+                 %UnspentOutput{
+                   from: "@Alice2",
+                   amount: 160_000_000,
+                   type: :UCO,
+                   timestamp: ~U[2022-10-10 10:44:38.983Z]
+                 },
+                 %UnspentOutput{
+                   from: "@CharlieToken",
+                   amount: 100_000_000,
+                   type: {:token, "@CharlieToken", 1},
+                   timestamp: ~U[2022-10-09 08:39:10.463Z]
+                 },
+                 %UnspentOutput{
+                   from: "@CharlieToken",
+                   amount: 100_000_000,
+                   type: {:token, "@CharlieToken", 3},
+                   timestamp: ~U[2022-10-09 08:39:10.463Z]
+                 }
+               ]
+             } =
+               %LedgerOperations{
+                 transaction_movements: [
+                   %TransactionMovement{
+                     to: "@Bob4",
+                     amount: 100_000_000,
+                     type: {:token, "@CharlieToken", 2}
+                   }
+                 ],
+                 fee: 40_000_000
+               }
+               |> LedgerOperations.consume_inputs(
+                 "@Alice2",
+                 [
+                   %UnspentOutput{
+                     from: "@Charlie1",
+                     amount: 200_000_000,
+                     type: :UCO,
+                     timestamp: ~U[2022-10-09 08:39:10.463Z]
+                   },
+                   %UnspentOutput{
+                     from: "@CharlieToken",
+                     amount: 100_000_000,
+                     type: {:token, "@CharlieToken", 1},
+                     timestamp: ~U[2022-10-09 08:39:10.463Z]
+                   },
+                   %UnspentOutput{
+                     from: "@CharlieToken",
+                     amount: 100_000_000,
+                     type: {:token, "@CharlieToken", 2},
+                     timestamp: ~U[2022-10-09 08:39:10.463Z]
+                   },
+                   %UnspentOutput{
+                     from: "@CharlieToken",
+                     amount: 100_000_000,
+                     type: {:token, "@CharlieToken", 3},
+                     timestamp: ~U[2022-10-09 08:39:10.463Z]
+                   }
+                 ],
+                 ~U[2022-10-10 10:44:38.983Z]
+               )
+               |> elem(1)
+    end
+  end
 end

--- a/test/archethic/transaction_chain/transaction_test.exs
+++ b/test/archethic/transaction_chain/transaction_test.exs
@@ -366,5 +366,29 @@ defmodule Archethic.TransactionChain.TransactionTest do
                }
              ] = Transaction.get_movements(tx)
     end
+
+    test "should return an empty list when trying to send a fraction of a non-fungible" do
+      recipient1 = random_address()
+      recipient1_hex = recipient1 |> Base.encode16()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+            "supply": 100000000,
+            "type": "non-fungible",
+            "name": "My NFT",
+            "symbol": "MNFT",
+            "recipients": [{
+              "to": "#{recipient1_hex}",
+              "amount": 1
+            }]
+          }
+          """
+        )
+
+      assert [] = Transaction.get_movements(tx)
+    end
   end
 end

--- a/test/archethic/transaction_chain/transaction_test.exs
+++ b/test/archethic/transaction_chain/transaction_test.exs
@@ -2,7 +2,7 @@ defmodule Archethic.TransactionChain.TransactionTest do
   @moduledoc false
   use ArchethicCase, async: false
 
-  import ArchethicCase, only: [current_transaction_version: 0, current_protocol_version: 0]
+  import ArchethicCase
 
   alias Archethic.Crypto
   alias Archethic.TransactionChain.Transaction
@@ -82,8 +82,8 @@ defmodule Archethic.TransactionChain.TransactionTest do
       tx = TransactionFactory.create_valid_transaction()
 
       keys = [
-        [create_random_key(), Crypto.first_node_public_key()],
-        [create_random_key(), create_random_key()]
+        [random_public_key(), Crypto.first_node_public_key()],
+        [random_public_key(), random_public_key()]
       ]
 
       assert Transaction.valid_stamps_signature?(tx, keys)
@@ -117,5 +117,254 @@ defmodule Archethic.TransactionChain.TransactionTest do
     end
   end
 
-  defp create_random_key(), do: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+  describe "get_movements/1 ledgers" do
+    test "should return the ledgers" do
+      assert [
+               %TransactionMovement{
+                 to: "@Alice1",
+                 amount: 10,
+                 type: :UCO
+               },
+               %TransactionMovement{
+                 to: "@Alice1",
+                 amount: 3,
+                 type: {:token, "@BobToken", 0}
+               }
+             ] =
+               Transaction.get_movements(%Transaction{
+                 data: %TransactionData{
+                   ledger: %Ledger{
+                     uco: %UCOLedger{
+                       transfers: [
+                         %UCOLedger.Transfer{to: "@Alice1", amount: 10}
+                       ]
+                     },
+                     token: %TokenLedger{
+                       transfers: [
+                         %TokenLedger.Transfer{
+                           to: "@Alice1",
+                           amount: 3,
+                           token_address: "@BobToken",
+                           token_id: 0
+                         }
+                       ]
+                     }
+                   }
+                 }
+               })
+    end
+  end
+
+  describe "get_movements/1 token resupply transaction" do
+    test "should return the movements for a fungible token" do
+      recipient1 = random_address()
+      recipient1_hex = recipient1 |> Base.encode16()
+      recipient2 = random_address()
+      recipient2_hex = recipient2 |> Base.encode16()
+      token = random_address()
+      token_hex = token |> Base.encode16()
+
+      assert [
+               %TransactionMovement{
+                 to: ^recipient1,
+                 amount: 1_000,
+                 type: {:token, ^token, 0}
+               },
+               %TransactionMovement{
+                 to: ^recipient2,
+                 amount: 2_000,
+                 type: {:token, ^token, 0}
+               }
+             ] =
+               Transaction.get_movements(
+                 TransactionFactory.create_valid_transaction([],
+                   type: :token,
+                   content: """
+                   {
+                     "token_reference": "#{token_hex}",
+                     "supply": 1000000,
+                     "recipients": [{
+                       "to": "#{recipient1_hex}",
+                       "amount": 1000
+                     },
+                     {
+                      "to": "#{recipient2_hex}",
+                      "amount": 2000
+                     }]
+                   }
+                   """
+                 )
+               )
+    end
+
+    test "should return an empty list if no recipients" do
+      token = random_address()
+      token_hex = token |> Base.encode16()
+
+      assert [] =
+               Transaction.get_movements(
+                 TransactionFactory.create_valid_transaction([],
+                   type: :token,
+                   content: """
+                   {
+                     "token_reference": "#{token_hex}",
+                     "supply": 1000000
+                   }
+                   """
+                 )
+               )
+    end
+
+    test "should return an empty list if invalid transaction" do
+      token = random_address()
+      token_hex = token |> Base.encode16()
+
+      assert [] =
+               Transaction.get_movements(
+                 TransactionFactory.create_valid_transaction([],
+                   type: :token,
+                   content: """
+                   {
+                    "token_reference": "#{token_hex}"
+                   }
+                   """
+                 )
+               )
+
+      assert [] =
+               Transaction.get_movements(
+                 TransactionFactory.create_valid_transaction([],
+                   type: :token,
+                   content: """
+                   {
+                     "supply": 1000000
+                   }
+                   """
+                 )
+               )
+    end
+  end
+
+  describe "get_movements/1 token creation transaction" do
+    test "should return the movements for a fungible token" do
+      recipient1 = random_address()
+      recipient1_hex = recipient1 |> Base.encode16()
+      recipient2 = random_address()
+      recipient2_hex = recipient2 |> Base.encode16()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+           "aeip": [2, 8, 19],
+           "supply": 300000000,
+           "type": "fungible",
+           "name": "My token",
+           "symbol": "MTK",
+           "properties": {},
+           "recipients": [{
+              "to": "#{recipient1_hex}",
+              "amount": 1000
+            },
+            {
+             "to": "#{recipient2_hex}",
+             "amount": 2000
+            }]
+          }
+          """
+        )
+
+      tx_address = tx.address
+
+      assert [
+               %TransactionMovement{
+                 to: ^recipient1,
+                 amount: 1_000,
+                 type: {:token, ^tx_address, 0}
+               },
+               %TransactionMovement{
+                 to: ^recipient2,
+                 amount: 2_000,
+                 type: {:token, ^tx_address, 0}
+               }
+             ] = Transaction.get_movements(tx)
+    end
+
+    test "should return the movements for a non-fungible token" do
+      recipient1 = random_address()
+      recipient1_hex = recipient1 |> Base.encode16()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+            "supply": 100000000,
+            "type": "non-fungible",
+            "name": "My NFT",
+            "symbol": "MNFT",
+            "recipients": [{
+              "to": "#{recipient1_hex}",
+              "amount": 100000000
+            }]
+          }
+          """
+        )
+
+      tx_address = tx.address
+
+      assert [
+               %TransactionMovement{
+                 to: ^recipient1,
+                 amount: 100_000_000,
+                 type: {:token, ^tx_address, 1}
+               }
+             ] = Transaction.get_movements(tx)
+    end
+
+    test "should return the movements for a non-fungible token (collection)" do
+      recipient1 = random_address()
+      recipient1_hex = recipient1 |> Base.encode16()
+
+      tx =
+        TransactionFactory.create_valid_transaction([],
+          type: :token,
+          content: """
+          {
+            "supply": 300000000,
+            "name": "My NFT",
+            "type": "non-fungible",
+            "symbol": "MNFT",
+            "properties": {
+               "description": "this property is for all NFT"
+            },
+            "collection": [
+               { "image": "link of the 1st NFT image" },
+               { "image": "link of the 2nd NFT image" },
+               {
+                  "image": "link of the 3rd NFT image",
+                  "other_property": "other value"
+               }
+            ],
+            "recipients": [{
+              "to": "#{recipient1_hex}",
+              "amount": 100000000,
+              "token_id": 3
+            }]
+          }
+          """
+        )
+
+      tx_address = tx.address
+
+      assert [
+               %TransactionMovement{
+                 to: ^recipient1,
+                 amount: 100_000_000,
+                 type: {:token, ^tx_address, 3}
+               }
+             ] = Transaction.get_movements(tx)
+    end
+  end
 end

--- a/test/archethic/transaction_chain/transaction_test.exs
+++ b/test/archethic/transaction_chain/transaction_test.exs
@@ -325,7 +325,8 @@ defmodule Archethic.TransactionChain.TransactionTest do
             "symbol": "MNFT",
             "recipients": [{
               "to": "#{recipient1_hex}",
-              "amount": 100000000
+              "amount": 100000000,
+              "token_id": 1
             }]
           }
           """

--- a/test/archethic/transaction_chain/transaction_test.exs
+++ b/test/archethic/transaction_chain/transaction_test.exs
@@ -218,6 +218,8 @@ defmodule Archethic.TransactionChain.TransactionTest do
     test "should return an empty list if invalid transaction" do
       token = random_address()
       token_hex = token |> Base.encode16()
+      recipient1 = random_address()
+      recipient1_hex = recipient1 |> Base.encode16()
 
       assert [] =
                Transaction.get_movements(
@@ -226,6 +228,23 @@ defmodule Archethic.TransactionChain.TransactionTest do
                    content: """
                    {
                     "token_reference": "#{token_hex}"
+                   }
+                   """
+                 )
+               )
+
+      assert [] =
+               Transaction.get_movements(
+                 TransactionFactory.create_valid_transaction([],
+                   type: :token,
+                   content: """
+                   {
+                    "token_reference": "not an hexadecimal",
+                    "supply": 100000000,
+                    "recipients": [{
+                      "to": "#{recipient1_hex}",
+                      "amount": 1000
+                    }]
                    }
                    """
                  )

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -64,6 +64,7 @@ defmodule Archethic.TransactionFactory do
         transaction_movements: Transaction.get_movements(tx)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
+      |> elem(1)
 
     validation_stamp =
       %ValidationStamp{
@@ -103,6 +104,7 @@ defmodule Archethic.TransactionFactory do
         fee: Fee.calculate(tx, 0.07, timestamp)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
+      |> elem(1)
 
     validation_stamp =
       %ValidationStamp{
@@ -137,6 +139,7 @@ defmodule Archethic.TransactionFactory do
         fee: Fee.calculate(tx, 0.07, timestamp)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
+      |> elem(1)
 
     validation_stamp = %ValidationStamp{
       timestamp: timestamp,
@@ -172,6 +175,7 @@ defmodule Archethic.TransactionFactory do
         fee: Fee.calculate(tx, 0.07, timestamp)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
+      |> elem(1)
 
     validation_stamp = %ValidationStamp{
       timestamp: timestamp,
@@ -201,6 +205,7 @@ defmodule Archethic.TransactionFactory do
         fee: 1_000_000_000
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
+      |> elem(1)
 
     validation_stamp =
       %ValidationStamp{
@@ -235,6 +240,7 @@ defmodule Archethic.TransactionFactory do
         ]
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
+      |> elem(1)
 
     validation_stamp =
       %ValidationStamp{
@@ -284,6 +290,7 @@ defmodule Archethic.TransactionFactory do
         transaction_movements: Transaction.get_movements(tx)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
+      |> elem(1)
 
     validation_stamp =
       %ValidationStamp{


### PR DESCRIPTION
# Description

/!\ Base branch 1174-token-resupply (AEIP-18) 
This is AEIP-19 implementation. This adds a `recipients` field in the token transactions. Minted tokens can be sent to recipients in the same transaction.

Fixes #1175 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Scenario 1: Create a token with recipients
```yaml
transaction_type: token
content: |
  {
    "supply": 10000000000,
    "type": "fungible",
    "decimals": 8,
    "name": "COINCOIN",
    "allow_mint": true,
    "recipients": [
      {"to": "00002223bbd4ec3d64ae597696c7d7ade1cee65c639d885450ad2d7b75592ac76afa", "amount": 333}
    ],
    "aeip": [2, 18]
  }
```
```
go run main.go send-transaction --config newtoken.yaml --access-seed bastien --index 0
```
- Check the movements in resulting

Scenario 2: 
- Create a resupply with recipients
```yaml
transaction_type: token
content: |
  {
    "aeip": [2,18],
    "supply": 100000000,
    "recipients": [{"to": "00002223bbd4ec3d64ae597696c7d7ade1cee65c639d885450ad2d7b75592ac76afa", "amount": 100000000}],
    "token_reference": "000058C44C933FBD047BF694490371BB41DA037597FFD57970A1DE6832AF990B7752"
  }
```
```
go run main.go send-transaction --config supply.yaml --access-seed bastien --index 1
```
- Check the movements in resulting


Many unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
