### PR TITLE
JSON RPC methods that used transaction as payload now only takes 1 param

### DIFF
--- a/lib/archethic_web/api/ecto_schemas/transaction_payload.ex
+++ b/lib/archethic_web/api/ecto_schemas/transaction_payload.ex
@@ -43,7 +43,10 @@ defmodule ArchethicWeb.API.TransactionPayload do
     ])
     |> cast_embed(:data, required: true)
     |> validate_data()
+    |> then(&{:ok, &1})
   end
+
+  def changeset(_params), do: :error
 
   def to_map(changes, acc \\ %{})
 

--- a/lib/archethic_web/api/jsonrpc/method.ex
+++ b/lib/archethic_web/api/jsonrpc/method.ex
@@ -4,7 +4,7 @@ defmodule ArchethicWeb.API.JsonRPC.Method do
   """
 
   @callback validate_params(params :: map() | list()) ::
-              {:ok, params :: any()} | {:error, reasons :: list()}
+              {:ok, params :: any()} | {:error, reasons :: map()}
 
   @callback execute(params :: any()) ::
               {:ok, result :: map() | list() | any()}

--- a/lib/archethic_web/api/jsonrpc/methods/add_origin_key.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/add_origin_key.ex
@@ -24,7 +24,7 @@ defmodule ArchethicWeb.API.JsonRPC.Method.AddOriginKey do
   Validate parameter to match the expected JSON pattern
   """
   @spec validate_params(param :: map()) ::
-          {:ok, params :: map()} | {:error, reasons :: list()}
+          {:ok, params :: map()} | {:error, reasons :: map()}
   def validate_params(params) do
     case OriginPublicKeyPayload.changeset(params) do
       %{valid?: true, changes: changes} ->

--- a/lib/archethic_web/api/jsonrpc/methods/call_contract_function.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/call_contract_function.ex
@@ -9,7 +9,7 @@ defmodule ArchethicWeb.API.JsonRPC.Method.CallContractFunction do
 
   @behaviour Method
 
-  @spec validate_params(params :: map()) :: {:ok, params :: map()} | {:error, reasons :: list()}
+  @spec validate_params(params :: map()) :: {:ok, params :: map()} | {:error, reasons :: map()}
   def validate_params(params) do
     case FunctionCallPayload.changeset(params) do
       %{valid?: true, changes: changed_params} ->

--- a/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
@@ -19,8 +19,8 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
   """
   @spec validate_params(param :: map()) ::
           {:ok, params :: Transaction.t()} | {:error, reasons :: list()}
-  def validate_params(params) do
-    case TransactionPayload.changeset(params) do
+  def validate_params(%{"transaction" => transaction_params}) do
+    case TransactionPayload.changeset(transaction_params) do
       changeset = %{valid?: true} ->
         tx = changeset |> TransactionPayload.to_map() |> Transaction.cast()
         {:ok, tx}
@@ -31,6 +31,8 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
         {:error, reasons}
     end
   end
+
+  def validate_params(_), do: {:error, %{transaction: ["is required"]}}
 
   @doc """
   Execute the function to send a new tranaction in the network

--- a/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
@@ -18,17 +18,19 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
   Validate parameter to match the expected JSON pattern
   """
   @spec validate_params(param :: map()) ::
-          {:ok, params :: Transaction.t()} | {:error, reasons :: list()}
+          {:ok, params :: Transaction.t()} | {:error, reasons :: map()}
   def validate_params(%{"transaction" => transaction_params}) do
     case TransactionPayload.changeset(transaction_params) do
-      changeset = %{valid?: true} ->
+      {:ok, changeset = %{valid?: true}} ->
         tx = changeset |> TransactionPayload.to_map() |> Transaction.cast()
         {:ok, tx}
 
-      changeset ->
+      {:ok, changeset} ->
         reasons = Ecto.Changeset.traverse_errors(changeset, &WebUtils.translate_error/1)
-
         {:error, reasons}
+
+      :error ->
+        {:error, %{transaction: ["must be an object"]}}
     end
   end
 

--- a/lib/archethic_web/api/jsonrpc/methods/send_transaction.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/send_transaction.ex
@@ -19,8 +19,8 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SendTransaction do
   """
   @spec validate_params(param :: map()) ::
           {:ok, params :: Transaction.t()} | {:error, reasons :: list()}
-  def validate_params(params) do
-    case TransactionPayload.changeset(params) do
+  def validate_params(%{"transaction" => transaction_params}) do
+    case TransactionPayload.changeset(transaction_params) do
       changeset = %{valid?: true} ->
         tx = changeset |> TransactionPayload.to_map() |> Transaction.cast()
         {:ok, tx}
@@ -31,6 +31,8 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SendTransaction do
         {:error, reasons}
     end
   end
+
+  def validate_params(_), do: {:error, %{transaction: ["is required"]}}
 
   @doc """
   Execute the function to send a new tranaction in the network

--- a/lib/archethic_web/api/jsonrpc/methods/send_transaction.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/send_transaction.ex
@@ -18,17 +18,19 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SendTransaction do
   Validate parameter to match the expected JSON pattern
   """
   @spec validate_params(param :: map()) ::
-          {:ok, params :: Transaction.t()} | {:error, reasons :: list()}
+          {:ok, params :: Transaction.t()} | {:error, reasons :: map()}
   def validate_params(%{"transaction" => transaction_params}) do
     case TransactionPayload.changeset(transaction_params) do
-      changeset = %{valid?: true} ->
+      {:ok, changeset = %{valid?: true}} ->
         tx = changeset |> TransactionPayload.to_map() |> Transaction.cast()
         {:ok, tx}
 
-      changeset ->
+      {:ok, changeset} ->
         reasons = Ecto.Changeset.traverse_errors(changeset, &WebUtils.translate_error/1)
-
         {:error, reasons}
+
+      :error ->
+        {:error, %{transaction: ["must be an object"]}}
     end
   end
 

--- a/lib/archethic_web/api/jsonrpc/methods/simulate_contract_execution.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/simulate_contract_execution.ex
@@ -22,8 +22,8 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SimulateContractExecution do
   """
   @spec validate_params(param :: map()) ::
           {:ok, params :: Transaction.t()} | {:error, reasons :: list()}
-  def validate_params(params) do
-    case TransactionPayload.changeset(params) do
+  def validate_params(%{"transaction" => transaction_params}) do
+    case TransactionPayload.changeset(transaction_params) do
       changeset = %{valid?: true} ->
         tx = changeset |> TransactionPayload.to_map() |> Transaction.cast()
         {:ok, tx}
@@ -34,6 +34,8 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SimulateContractExecution do
         {:error, reasons}
     end
   end
+
+  def validate_params(_), do: {:error, %{transaction: ["is required"]}}
 
   @doc """
   Execute the function to send a new tranaction in the network

--- a/lib/archethic_web/api/jsonrpc/methods/simulate_contract_execution.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/simulate_contract_execution.ex
@@ -21,17 +21,19 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SimulateContractExecution do
   Validate parameter to match the expected JSON pattern
   """
   @spec validate_params(param :: map()) ::
-          {:ok, params :: Transaction.t()} | {:error, reasons :: list()}
+          {:ok, params :: Transaction.t()} | {:error, reasons :: map()}
   def validate_params(%{"transaction" => transaction_params}) do
     case TransactionPayload.changeset(transaction_params) do
-      changeset = %{valid?: true} ->
+      {:ok, changeset = %{valid?: true}} ->
         tx = changeset |> TransactionPayload.to_map() |> Transaction.cast()
         {:ok, tx}
 
-      changeset ->
+      {:ok, changeset} ->
         reasons = Ecto.Changeset.traverse_errors(changeset, &WebUtils.translate_error/1)
-
         {:error, reasons}
+
+      :error ->
+        {:error, %{transaction: ["must be an object"]}}
     end
   end
 

--- a/lib/archethic_web/api/rest/controllers/transaction_controller.ex
+++ b/lib/archethic_web/api/rest/controllers/transaction_controller.ex
@@ -18,7 +18,7 @@ defmodule ArchethicWeb.API.REST.TransactionController do
 
   def new(conn, params = %{}) do
     case TransactionPayload.changeset(params) do
-      changeset = %{valid?: true} ->
+      {:ok, changeset = %{valid?: true}} ->
         tx =
           changeset
           |> TransactionPayload.to_map()
@@ -38,7 +38,7 @@ defmodule ArchethicWeb.API.REST.TransactionController do
             conn |> put_status(504) |> json(%{status: "error - networking error"})
         end
 
-      changeset ->
+      {:ok, changeset} ->
         Logger.debug(
           "Invalid transaction #{inspect(Ecto.Changeset.traverse_errors(changeset, &ArchethicWeb.WebUtils.translate_error/1))}"
         )
@@ -99,7 +99,7 @@ defmodule ArchethicWeb.API.REST.TransactionController do
 
   def transaction_fee(conn, tx) do
     case TransactionPayload.changeset(tx) do
-      changeset = %{valid?: true} ->
+      {:ok, changeset = %{valid?: true}} ->
         timestamp = DateTime.utc_now()
 
         previous_price =
@@ -126,7 +126,7 @@ defmodule ArchethicWeb.API.REST.TransactionController do
           }
         })
 
-      changeset ->
+      {:ok, changeset} ->
         conn
         |> put_status(:bad_request)
         |> put_view(ErrorView)
@@ -143,7 +143,7 @@ defmodule ArchethicWeb.API.REST.TransactionController do
         params = %{}
       ) do
     case TransactionPayload.changeset(params) do
-      changeset = %{valid?: true} ->
+      {:ok, changeset = %{valid?: true}} ->
         trigger_tx =
           %Transaction{data: %TransactionData{recipients: recipients}} =
           changeset
@@ -208,7 +208,7 @@ defmodule ArchethicWeb.API.REST.TransactionController do
             |> json(results)
         end
 
-      changeset ->
+      {:ok, changeset} ->
         error_details =
           Ecto.Changeset.traverse_errors(
             changeset,

--- a/test/archethic_web/api/ecto_schemas/transaction_payload_test.exs
+++ b/test/archethic_web/api/ecto_schemas/transaction_payload_test.exs
@@ -8,31 +8,39 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
   alias Ecto.Changeset
 
   describe "changeset/1" do
+    test "should return errors if params is not a map" do
+      assert :error = TransactionPayload.changeset(nil)
+      assert :error = TransactionPayload.changeset(1)
+      assert :error = TransactionPayload.changeset("1")
+    end
+
     test "should return errors if there are missing fields in the transaction schema" do
-      assert %Ecto.Changeset{
-               valid?: false,
-               errors: [
-                 data: {"can't be blank", [validation: :required]},
-                 version: {"can't be blank", [validation: :required]},
-                 address: {"can't be blank", [validation: :required]},
-                 type: {"can't be blank", [validation: :required]},
-                 previousPublicKey: {"can't be blank", [validation: :required]},
-                 previousSignature: {"can't be blank", [validation: :required]},
-                 originSignature: {"can't be blank", [validation: :required]}
-               ]
-             } = TransactionPayload.changeset(%{})
+      assert {:ok,
+              %Ecto.Changeset{
+                valid?: false,
+                errors: [
+                  data: {"can't be blank", [validation: :required]},
+                  version: {"can't be blank", [validation: :required]},
+                  address: {"can't be blank", [validation: :required]},
+                  type: {"can't be blank", [validation: :required]},
+                  previousPublicKey: {"can't be blank", [validation: :required]},
+                  previousSignature: {"can't be blank", [validation: :required]},
+                  originSignature: {"can't be blank", [validation: :required]}
+                ]
+              }} = TransactionPayload.changeset(%{})
     end
 
     test "should return errors if the crypto primitives are invalid" do
-      assert %Ecto.Changeset{
-               valid?: false,
-               errors: [
-                 address: {"must be hexadecimal", _},
-                 previousPublicKey: {"must be hexadecimal", _},
-                 previousSignature: {"must be hexadecimal", _},
-                 originSignature: {"must be hexadecimal", _}
-               ]
-             } =
+      assert {:ok,
+              %Ecto.Changeset{
+                valid?: false,
+                errors: [
+                  address: {"must be hexadecimal", _},
+                  previousPublicKey: {"must be hexadecimal", _},
+                  previousSignature: {"must be hexadecimal", _},
+                  originSignature: {"must be hexadecimal", _}
+                ]
+              }} =
                TransactionPayload.changeset(%{
                  "version" => 1,
                  "address" => "abc",
@@ -58,10 +66,11 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the content is not in hex" do
-      %Ecto.Changeset{
-        valid?: false,
-        changes: %{data: %{errors: errors}}
-      } =
+      {:ok,
+       %Ecto.Changeset{
+         valid?: false,
+         changes: %{data: %{errors: errors}}
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -80,10 +89,11 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     test "should return an error if the content size is greater than content max size" do
       content = Base.encode16(:crypto.strong_rand_bytes(4 * 1024 * 1024))
 
-      %Ecto.Changeset{
-        valid?: false,
-        changes: %{data: %{errors: errors}}
-      } =
+      {:ok,
+       %Ecto.Changeset{
+         valid?: false,
+         changes: %{data: %{errors: errors}}
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -101,10 +111,11 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the code is not a string" do
-      %Ecto.Changeset{
-        valid?: false,
-        changes: %{data: %{errors: errors}}
-      } =
+      {:ok,
+       %Ecto.Changeset{
+         valid?: false,
+         changes: %{data: %{errors: errors}}
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -121,10 +132,11 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the code length is more than 24KB" do
-      %Ecto.Changeset{
-        valid?: false,
-        changes: %{data: %{errors: errors}}
-      } =
+      {:ok,
+       %Ecto.Changeset{
+         valid?: false,
+         changes: %{data: %{errors: errors}}
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -142,10 +154,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the uco ledger transfer address is invalid" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -167,10 +179,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the uco ledger transfer amount is invalid" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -199,10 +211,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the uco ledger transfers are more than 256" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -234,10 +246,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the token ledger transfer address is invalid" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -269,10 +281,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the token ledger transfer amount is invalid" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -309,10 +321,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the token ledger transfer token address is invalid" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -343,10 +355,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the token ledger transfers are more than 256" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -381,10 +393,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the encrypted secret is not an hexadecimal" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -406,10 +418,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the public key in the authorized keys is not valid" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -444,10 +456,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
                }
              ] = changeset |> get_errors |> get_in([:data, :ownerships])
 
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -481,10 +493,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the encrypted key in the authorized keys is not valid" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -514,10 +526,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error ownerships are more than 256." do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -551,10 +563,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error authorized keys in a ownership can't be more than 256" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -587,10 +599,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
     end
 
     test "should return an error if the recipients are invalid" do
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -607,10 +619,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
 
       assert ["must be hexadecimal"] = changeset |> get_errors() |> get_in([:data, :recipients])
 
-      changeset =
-        %Ecto.Changeset{
-          valid?: false
-        } =
+      {:ok,
+       changeset = %Ecto.Changeset{
+         valid?: false
+       }} =
         TransactionPayload.changeset(%{
           "version" => 1,
           "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -630,10 +642,10 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
   end
 
   test "should return an error if the recipients are more that 256" do
-    changeset =
-      %Ecto.Changeset{
-        valid?: false
-      } =
+    {:ok,
+     changeset = %Ecto.Changeset{
+       valid?: false
+     }} =
       TransactionPayload.changeset(%{
         "version" => 1,
         "address" => Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
@@ -724,6 +736,7 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
                  "recipients" => [Base.encode16(recipient)]
                }
              })
+             |> elem(1)
              |> TransactionPayload.to_map()
   end
 

--- a/test/archethic_web/api/jsonrpc/controllers/jsonrpc_controller_test.exs
+++ b/test/archethic_web/api/jsonrpc/controllers/jsonrpc_controller_test.exs
@@ -88,7 +88,7 @@ defmodule ArchethicWeb.API.JsonRPCControllerTest do
   defp valid_rpc_request(opts \\ []) do
     id = Keyword.get(opts, :id, 1)
     method = Keyword.get(opts, :method, "send_transaction")
-    params = Keyword.get(opts, :params, valid_tx_param())
+    params = Keyword.get(opts, :params, %{"transaction" => valid_tx_param()})
 
     %{
       "jsonrpc" => "2.0",

--- a/test/archethic_web/api/jsonrpc/methods/estimate_transaction_fee_test.exs
+++ b/test/archethic_web/api/jsonrpc/methods/estimate_transaction_fee_test.exs
@@ -30,6 +30,15 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.EstimateTransactionFeeTest do
   end
 
   describe "validate_params" do
+    test "should send error when transaction key is missing" do
+      assert {:error,
+              %{
+                transaction: [
+                  "is required"
+                ]
+              }} = EstimateTransactionFee.validate_params(%{})
+    end
+
     test "should send bad_request response for invalid transaction body" do
       assert {:error,
               %{
@@ -54,7 +63,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.EstimateTransactionFeeTest do
                 version: [
                   "can't be blank"
                 ]
-              }} = EstimateTransactionFee.validate_params(%{})
+              }} = EstimateTransactionFee.validate_params(%{"transaction" => %{}})
     end
   end
 

--- a/test/archethic_web/api/jsonrpc/methods/send_transaction_test.exs
+++ b/test/archethic_web/api/jsonrpc/methods/send_transaction_test.exs
@@ -41,6 +41,15 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SendTransactionTest do
   end
 
   describe "validate_params" do
+    test "should send error when transaction key is missing" do
+      assert {:error,
+              %{
+                transaction: [
+                  "is required"
+                ]
+              }} = SendTransaction.validate_params(%{})
+    end
+
     test "should send bad_request response for invalid transaction body" do
       assert {:error,
               %{
@@ -65,7 +74,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SendTransactionTest do
                 version: [
                   "can't be blank"
                 ]
-              }} = SendTransaction.validate_params(%{})
+              }} = SendTransaction.validate_params(%{"transaction" => %{}})
     end
   end
 

--- a/test/archethic_web/api/jsonrpc/methods/simulate_contract_execution_test.exs
+++ b/test/archethic_web/api/jsonrpc/methods/simulate_contract_execution_test.exs
@@ -39,6 +39,15 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
   end
 
   describe "validate_params" do
+    test "should send error when transaction key is missing" do
+      assert {:error,
+              %{
+                transaction: [
+                  "is required"
+                ]
+              }} = SimulateContractExecution.validate_params(%{})
+    end
+
     test "should send bad_request response for invalid transaction body" do
       assert {:error,
               %{
@@ -63,7 +72,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
                 version: [
                   "can't be blank"
                 ]
-              }} = SimulateContractExecution.validate_params(%{})
+              }} = SimulateContractExecution.validate_params(%{"transaction" => %{}})
     end
   end
 


### PR DESCRIPTION
# Description

Wrap the transaction payload inside a "transaction" object for these 3 methods: `SimulateContractExecution`, `EstimateTransactionFee` and `SendTransaction`.

Fixes #1225

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

**This require the 3 SDKs to be updated.**
- [x] libgo
- [x] libdart
- [x] libjs

# How Has This Been Tested?

Unit tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
