### PR TITLE
Adapt the fee for multi recipients transactions

### DIFF
--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -27,7 +27,7 @@ defmodule Archethic.Mining do
 
   use Retry
 
-  @protocol_version 1
+  @protocol_version 2
 
   def protocol_version, do: @protocol_version
 
@@ -245,6 +245,13 @@ defmodule Archethic.Mining do
   @doc """
   Get the transaction fee
   """
-  @spec get_transaction_fee(Transaction.t(), float(), DateTime.t()) :: non_neg_integer()
-  defdelegate get_transaction_fee(tx, uco_price_in_usd, timestamp), to: Fee, as: :calculate
+  @spec get_transaction_fee(
+          transaction :: Transaction.t(),
+          uco_price_in_usd :: float(),
+          timestamp :: DateTime.t(),
+          protocol_version :: pos_integer()
+        ) :: non_neg_integer()
+  def get_transaction_fee(tx, uco_price_in_usd, timestamp, proto_version \\ protocol_version()) do
+    Fee.calculate(tx, uco_price_in_usd, timestamp, proto_version)
+  end
 end

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -1274,7 +1274,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, 0.07, timestamp),
+          fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx),
           tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -290,7 +290,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, 0.07, timestamp),
+          fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx),
           tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
@@ -313,7 +313,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, 0.07, timestamp),
+          fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx),
           tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
@@ -336,7 +336,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, 0.07, timestamp),
+          fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx),
           tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
@@ -374,7 +374,7 @@ defmodule Archethic.Mining.ValidationContextTest do
          validation_time: timestamp,
          unspent_outputs: unspent_outputs
        }) do
-    fee = Fee.calculate(tx, 0.07, timestamp)
+    fee = Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version())
 
     %ValidationStamp{
       timestamp: timestamp,
@@ -414,7 +414,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations: %LedgerOperations{
-        fee: Fee.calculate(tx, 0.07, timestamp),
+        fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version()),
         transaction_movements: Transaction.get_movements(tx),
         unspent_outputs: [
           %UnspentOutput{
@@ -442,7 +442,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, 0.07, timestamp),
+          fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx)
         }
         |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)

--- a/test/archethic/replication_test.exs
+++ b/test/archethic/replication_test.exs
@@ -268,7 +268,7 @@ defmodule Archethic.ReplicationTest do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, 0.07, timestamp)
+        fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version())
       }
       |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
       |> elem(1)

--- a/test/archethic_web/api/rest/controllers/transaction_controller_test.exs
+++ b/test/archethic_web/api/rest/controllers/transaction_controller_test.exs
@@ -68,7 +68,7 @@ defmodule ArchethicWeb.API.REST.TransactionControllerTest do
         })
 
       assert %{
-               "fee" => 5_000_290,
+               "fee" => 6_500_289,
                "rates" => %{
                  "eur" => 0.2,
                  "usd" => 0.2

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -60,7 +60,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, 0.07, timestamp),
+        fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version()),
         transaction_movements: Transaction.get_movements(tx)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
@@ -101,7 +101,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, 0.07, timestamp)
+        fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version())
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
       |> elem(1)
@@ -136,7 +136,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, 0.07, timestamp)
+        fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version())
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
       |> elem(1)
@@ -172,7 +172,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, 0.07, timestamp)
+        fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version())
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
       |> elem(1)
@@ -234,7 +234,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, 0.07, timestamp),
+        fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version()),
         transaction_movements: [
           %TransactionMovement{to: "@Bob4", amount: 30_330_000_000, type: :UCO}
         ]
@@ -286,7 +286,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, 0.07, timestamp),
+        fee: Fee.calculate(tx, 0.07, timestamp, ArchethicCase.current_protocol_version()),
         transaction_movements: Transaction.get_movements(tx)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)


### PR DESCRIPTION
# Description

The idea is to ensure a bulk transaction to be more cost efficient than multiple transactions. 

Indeed, the validation is done one time versus multiple times.

The cost is then determined as logarithmic according to the number of recipients


Fixes #1041 

# How Has This Been Tested?

- Unit tests
- Multiple recipients sending with CLI

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
