### PR TITLE
Json RPC endpoint does not require content to be base16

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -195,6 +195,8 @@ config :ex_cldr,
   default_backend: Archethic.Cldr,
   json_library: Jason
 
+config :ex_json_schema, :remote_schema_resolver, {Archethic.Utils, :local_schema_resolver!}
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config("#{Mix.env()}.exs")

--- a/lib/archethic/transaction_chain/transaction/data/recipient.ex
+++ b/lib/archethic/transaction_chain/transaction/data/recipient.ex
@@ -88,8 +88,11 @@ defmodule Archethic.TransactionChain.TransactionData.Recipient do
   @spec cast(recipient :: binary() | map()) :: t()
   def cast(recipient) when is_binary(recipient), do: %__MODULE__{address: recipient}
 
-  def cast(%{address: address, action: action, args: args}),
-    do: %__MODULE__{address: address, action: action, args: args}
+  def cast(recipient = %{address: address}) do
+    action = Map.get(recipient, :action)
+    args = Map.get(recipient, :args)
+    %__MODULE__{address: address, action: action, args: args}
+  end
 
   @doc false
   @spec to_map(recipient :: t()) :: map()

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -1157,4 +1157,16 @@ defmodule Archethic.Utils do
         :not_found
     end
   end
+
+  @doc """
+  Resolver function used by ExJsonSchema to resolve local path
+  """
+  @spec local_schema_resolver!(path :: binary()) :: map()
+  def local_schema_resolver!("file://" <> path) do
+    Application.app_dir(:archethic, "priv/json-schemas/#{path}")
+    |> File.read!()
+    |> Jason.decode!()
+  end
+
+  def local_schema_resolver!(_), do: raise("Invalid URI for $ref")
 end

--- a/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
@@ -8,9 +8,7 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
   alias Archethic.TransactionChain.Transaction
 
   alias ArchethicWeb.API.JsonRPC.Method
-  alias ArchethicWeb.API.TransactionPayload
-
-  alias ArchethicWeb.WebUtils
+  alias ArchethicWeb.API.JsonRPC.TransactionSchema
 
   @behaviour Method
 
@@ -20,21 +18,19 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
   @spec validate_params(param :: map()) ::
           {:ok, params :: Transaction.t()} | {:error, reasons :: map()}
   def validate_params(%{"transaction" => transaction_params}) do
-    case TransactionPayload.changeset(transaction_params) do
-      {:ok, changeset = %{valid?: true}} ->
-        tx = changeset |> TransactionPayload.to_map() |> Transaction.cast()
-        {:ok, tx}
-
-      {:ok, changeset} ->
-        reasons = Ecto.Changeset.traverse_errors(changeset, &WebUtils.translate_error/1)
-        {:error, reasons}
+    case TransactionSchema.validate(transaction_params) do
+      :ok ->
+        {:ok, TransactionSchema.to_transaction(transaction_params)}
 
       :error ->
-        {:error, %{transaction: ["must be an object"]}}
+        {:error, %{"transaction" => "Must be an object"}}
+
+      {:error, reasons} ->
+        {:error, reasons}
     end
   end
 
-  def validate_params(_), do: {:error, %{transaction: ["is required"]}}
+  def validate_params(_), do: {:error, %{"transaction" => "Is required"}}
 
   @doc """
   Execute the function to send a new tranaction in the network

--- a/lib/archethic_web/api/jsonrpc/methods/send_transaction.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/send_transaction.ex
@@ -6,11 +6,9 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SendTransaction do
   alias Archethic.TransactionChain.Transaction
 
   alias ArchethicWeb.API.JsonRPC.Method
-  alias ArchethicWeb.API.TransactionPayload
+  alias ArchethicWeb.API.JsonRPC.TransactionSchema
 
   alias ArchethicWeb.TransactionSubscriber
-
-  alias ArchethicWeb.WebUtils
 
   @behaviour Method
 
@@ -20,21 +18,19 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SendTransaction do
   @spec validate_params(param :: map()) ::
           {:ok, params :: Transaction.t()} | {:error, reasons :: map()}
   def validate_params(%{"transaction" => transaction_params}) do
-    case TransactionPayload.changeset(transaction_params) do
-      {:ok, changeset = %{valid?: true}} ->
-        tx = changeset |> TransactionPayload.to_map() |> Transaction.cast()
-        {:ok, tx}
-
-      {:ok, changeset} ->
-        reasons = Ecto.Changeset.traverse_errors(changeset, &WebUtils.translate_error/1)
-        {:error, reasons}
+    case TransactionSchema.validate(transaction_params) do
+      :ok ->
+        {:ok, TransactionSchema.to_transaction(transaction_params)}
 
       :error ->
-        {:error, %{transaction: ["must be an object"]}}
+        {:error, %{"transaction" => "Must be an object"}}
+
+      {:error, reasons} ->
+        {:error, reasons}
     end
   end
 
-  def validate_params(_), do: {:error, %{transaction: ["is required"]}}
+  def validate_params(_), do: {:error, %{"transaction" => "Is required"}}
 
   @doc """
   Execute the function to send a new tranaction in the network

--- a/lib/archethic_web/api/jsonrpc/methods/simulate_contract_execution.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/simulate_contract_execution.ex
@@ -14,9 +14,7 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SimulateContractExecution do
 
   alias ArchethicWeb.API.JsonRPC.Method
   alias ArchethicWeb.API.JsonRPC.Error
-  alias ArchethicWeb.API.TransactionPayload
-
-  alias ArchethicWeb.WebUtils
+  alias ArchethicWeb.API.JsonRPC.TransactionSchema
 
   @behaviour Method
 
@@ -26,21 +24,19 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SimulateContractExecution do
   @spec validate_params(param :: map()) ::
           {:ok, params :: Transaction.t()} | {:error, reasons :: map()}
   def validate_params(%{"transaction" => transaction_params}) do
-    case TransactionPayload.changeset(transaction_params) do
-      {:ok, changeset = %{valid?: true}} ->
-        tx = changeset |> TransactionPayload.to_map() |> Transaction.cast()
-        {:ok, tx}
-
-      {:ok, changeset} ->
-        reasons = Ecto.Changeset.traverse_errors(changeset, &WebUtils.translate_error/1)
-        {:error, reasons}
+    case TransactionSchema.validate(transaction_params) do
+      :ok ->
+        {:ok, TransactionSchema.to_transaction(transaction_params)}
 
       :error ->
-        {:error, %{transaction: ["must be an object"]}}
+        {:error, %{"transaction" => "Must be an object"}}
+
+      {:error, reasons} ->
+        {:error, reasons}
     end
   end
 
-  def validate_params(_), do: {:error, %{transaction: ["is required"]}}
+  def validate_params(_), do: {:error, %{"transaction" => "Is required"}}
 
   @doc """
   Execute the function to send a new tranaction in the network

--- a/lib/archethic_web/api/jsonrpc/schemas/transaction.ex
+++ b/lib/archethic_web/api/jsonrpc/schemas/transaction.ex
@@ -1,0 +1,158 @@
+defmodule ArchethicWeb.API.JsonRPC.TransactionSchema do
+  @moduledoc """
+  Validate request parameter to match the transaction Json Schema
+  """
+
+  alias Archethic.TransactionChain.Transaction
+
+  alias Archethic.Utils
+
+  @transaction_schema :archethic
+                      |> Application.app_dir("priv/json-schemas/transaction.json")
+                      |> File.read!()
+                      |> Jason.decode!()
+                      |> ExJsonSchema.Schema.resolve()
+
+  @keys_to_base_decode [
+    :address,
+    :to,
+    :token_address,
+    :secret,
+    :public_key,
+    :encrypted_secret_key,
+    :origin_signature,
+    :previous_public_key,
+    :previous_signature
+  ]
+
+  @doc """
+  Validate a map to match the transaction Json Schema
+  """
+  @spec validate(params :: map()) :: :ok | {:error, map()} | :error
+  def validate(params) when is_map(params) do
+    with :ok <- ExJsonSchema.Validator.validate(@transaction_schema, params),
+         :ok <- validate_recipients_version(params) do
+      :ok
+    else
+      {:error, reasons} -> {:error, format_errors(reasons)}
+    end
+  end
+
+  def validate(_), do: :error
+
+  defp validate_recipients_version(params = %{"version" => 1}) do
+    case get_in(params, ["data", "recipients"]) do
+      nil ->
+        :ok
+
+      recipients ->
+        if Enum.any?(recipients, &is_map/1) do
+          {:error, [{"Transaction V1 cannot use named action recipients", "#/data/recipients"}]}
+        else
+          :ok
+        end
+    end
+  end
+
+  defp validate_recipients_version(params) do
+    case get_in(params, ["data", "recipients"]) do
+      nil ->
+        :ok
+
+      recipients ->
+        if Enum.any?(recipients, &is_binary/1) do
+          {:error,
+           [{"From V2, transaction must use named action recipients", "#/data/recipients"}]}
+        else
+          :ok
+        end
+    end
+  end
+
+  defp format_errors(errors),
+    do: Enum.reduce(errors, %{}, fn {details, field}, acc -> Map.put(acc, field, details) end)
+
+  @doc """
+  Transform a map to a Transaction structure
+  """
+  @spec to_transaction(params :: map()) :: Transaction.t()
+  def to_transaction(params) do
+    # Remove recipient args to not convert them to atom
+    {original_recipients, params} = remove_recipient_args(params)
+
+    params
+    |> Utils.atomize_keys(to_snake_case?: true)
+    |> decode_hex()
+    |> format_ownerships()
+    |> put_original_recipients_args(original_recipients)
+    |> Transaction.cast()
+  end
+
+  defp remove_recipient_args(params = %{"version" => 1}), do: {[], params}
+
+  defp remove_recipient_args(params) do
+    get_and_update_in(params, ["data", "recipients"], fn
+      nil ->
+        {[], []}
+
+      recipients ->
+        updated_recipients =
+          Enum.map(recipients, fn
+            recipient = %{"args" => args} when is_list(args) -> Map.put(recipient, "args", [])
+            recipient -> recipient
+          end)
+
+        {recipients, updated_recipients}
+    end)
+  end
+
+  defp put_original_recipients_args(params, original_recipients) do
+    update_in(params, [:data, :recipients], fn recipients ->
+      recipients
+      |> Enum.zip(original_recipients)
+      |> Enum.map(fn
+        {recipient = %{args: _}, original_recipient} ->
+          Map.put(recipient, :args, Map.fetch!(original_recipient, "args"))
+
+        {recipient, _} ->
+          recipient
+      end)
+    end)
+  end
+
+  defp decode_hex(params) when is_map(params) do
+    params
+    |> Map.keys()
+    |> Enum.reduce(params, fn
+      key, acc when key in @keys_to_base_decode ->
+        Map.update!(acc, key, &Base.decode16!(&1, case: :mixed))
+
+      key, acc ->
+        Map.update!(acc, key, &decode_hex/1)
+    end)
+  end
+
+  defp decode_hex(params) when is_list(params), do: Enum.map(params, &decode_hex/1)
+
+  defp decode_hex(params), do: params
+
+  defp format_ownerships(params) do
+    update_in(params, [:data, :ownerships], fn
+      nil -> []
+      ownerships -> Enum.map(ownerships, &format_ownership/1)
+    end)
+  end
+
+  defp format_ownership(ownership) do
+    # Transform ownership's authorized_keys from list to map
+    Map.update!(ownership, :authorized_keys, fn authorized_keys ->
+      Enum.reduce(
+        authorized_keys,
+        %{},
+        fn %{public_key: public_key, encrypted_secret_key: encrypted_secret_key}, acc ->
+          Map.put(acc, public_key, encrypted_secret_key)
+        end
+      )
+    end)
+  end
+end

--- a/priv/json-schemas/schemas/base/address.json
+++ b/priv/json-schemas/schemas/base/address.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string",
+  "oneOf": [
+    {
+      "type": "string",
+      "pattern": "^0[0-2]0[025][0-9a-fA-F]{64}$"
+    },
+    {
+      "type": "string",
+      "pattern": "^0[0-2]0[134][0-9a-fA-F]{128}$"
+    }
+  ]
+}

--- a/priv/json-schemas/schemas/base/hexadecimal.json
+++ b/priv/json-schemas/schemas/base/hexadecimal.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string",
+  "pattern": "^([0-9a-fA-F]{2})*$"
+}

--- a/priv/json-schemas/schemas/base/public_key.json
+++ b/priv/json-schemas/schemas/base/public_key.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string",
+  "oneOf": [
+    {
+      "type": "string",
+      "pattern": "^00[0-9a-fA-F]{66}$"
+    },
+    {
+      "type": "string",
+      "pattern": "^0[12][0-9a-fA-F]{132}$"
+    }
+  ]
+}

--- a/priv/json-schemas/schemas/list/authorized_keys.json
+++ b/priv/json-schemas/schemas/list/authorized_keys.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "$ref": "file://schemas/object/authorized_key.json"
+  },
+  "maxItems": 255
+}

--- a/priv/json-schemas/schemas/list/ownerships.json
+++ b/priv/json-schemas/schemas/list/ownerships.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "$ref": "file://schemas/object/ownership.json"
+  },
+  "maxItems": 255
+}

--- a/priv/json-schemas/schemas/list/recipients.json
+++ b/priv/json-schemas/schemas/list/recipients.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "oneOf": [
+      {
+        "$ref": "file://schemas/base/address.json"
+      },
+      {
+        "$ref": "file://schemas/object/recipient.json"
+      }
+    ]
+  },
+  "maxItems": 255
+}

--- a/priv/json-schemas/schemas/list/token_transfers.json
+++ b/priv/json-schemas/schemas/list/token_transfers.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "$ref": "file://schemas/object/token_transfer.json"
+  },
+  "maxItems": 255
+}

--- a/priv/json-schemas/schemas/list/uco_transfers.json
+++ b/priv/json-schemas/schemas/list/uco_transfers.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "$ref": "file://schemas/object/uco_transfer.json"
+  },
+  "maxItems": 255
+}

--- a/priv/json-schemas/schemas/object/authorized_key.json
+++ b/priv/json-schemas/schemas/object/authorized_key.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "publicKey": {
+      "$ref": "file://schemas/base/public_key.json",
+      "description": "Public key authorized to decrypt the secret"
+    },
+    "encryptedSecretKey": {
+      "$ref": "file://schemas/base/hexadecimal.json",
+      "description": "Encrypted AES key used to encrypt the secret"
+    }
+  },
+  "required": [
+    "publicKey",
+    "encryptedSecretKey"
+  ],
+  "additionalProperties": false
+}

--- a/priv/json-schemas/schemas/object/ledger.json
+++ b/priv/json-schemas/schemas/object/ledger.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "uco": {
+      "type": "object",
+      "properties": {
+        "transfers": {
+          "$ref": "file://schemas/list/uco_transfers.json",
+          "description": "UCO transfers"
+        }
+      },
+      "additionalProperties": false
+    },
+    "token": {
+      "type": "object",
+      "properties": {
+        "transfers": {
+          "$ref": "file://schemas/list/token_transfers.json",
+          "description": "Token transfers"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/priv/json-schemas/schemas/object/ownership.json
+++ b/priv/json-schemas/schemas/object/ownership.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "secret": {
+      "$ref": "file://schemas/base/hexadecimal.json",
+      "description": "Encrypted secret"
+    },
+    "authorizedKeys": {
+      "$ref": "file://schemas/list/authorized_keys.json",
+      "description": "Authorized keys allowed to decrypt the secret"
+    }
+  },
+  "required": [
+    "secret",
+    "authorizedKeys"
+  ],
+  "additionalProperties": false
+}

--- a/priv/json-schemas/schemas/object/recipient.json
+++ b/priv/json-schemas/schemas/object/recipient.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "address": {
+      "$ref": "file://schemas/base/address.json",
+      "description": "Address of the targeted contract"
+    },
+    "action": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Action to trigger",
+      "minLength": 1
+    },
+    "args": {
+      "description": "Arguments for the action"
+    }
+  },
+  "if": {
+    "properties": {
+      "action": {
+        "const": "null"
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "args": {
+        "type": "null"
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "args": {
+        "type": "array",
+        "items": {
+          "type": [
+            "array",
+            "string",
+            "number",
+            "integer",
+            "object",
+            "null",
+            "boolean"
+          ]
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/priv/json-schemas/schemas/object/token_transfer.json
+++ b/priv/json-schemas/schemas/object/token_transfer.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "to": {
+      "$ref": "file://schemas/base/address.json",
+      "description": "Address of the recipient"
+    },
+    "amount": {
+      "type": "integer",
+      "description": "Amount of token to send in BigInt",
+      "minimum": 1
+    },
+    "tokenAddress": {
+      "$ref": "file://schemas/base/address.json",
+      "description": "Address of the token to send"
+    },
+    "tokenId": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Token ID to send (0 for fungible)"
+    }
+  },
+  "required": [
+    "to",
+    "amount",
+    "tokenAddress",
+    "tokenId"
+  ],
+  "additionalProperties": false
+}

--- a/priv/json-schemas/schemas/object/transaction_data.json
+++ b/priv/json-schemas/schemas/object/transaction_data.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "code": {
+      "type": "string",
+      "description": "Transaction's smart contract code",
+      "maxLength": 24576
+    },
+    "content": {
+      "type": "string",
+      "description": "Transaction's content",
+      "maxLength": 3145728
+    },
+    "recipients": {
+      "$ref": "file://schemas/list/recipients.json",
+      "description": "Transaction's recipients to call smart contract"
+    },
+    "ledger": {
+      "$ref": "file://schemas/object/ledger.json",
+      "description": "Transaction's transfers"
+    },
+    "ownerships": {
+      "$ref": "file://schemas/list/ownerships.json",
+      "description": "Transaction's ownerships"
+    }
+  },
+  "additionalProperties": false
+}

--- a/priv/json-schemas/schemas/object/uco_transfer.json
+++ b/priv/json-schemas/schemas/object/uco_transfer.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "to": {
+      "$ref": "file://schemas/base/address.json",
+      "description": "Address of the recipient"
+    },
+    "amount": {
+      "type": "integer",
+      "description": "Amount of UCO to send in BigInt",
+      "minimum": 1
+    }
+  },
+  "required": [
+    "to",
+    "amount"
+  ],
+  "additionalProperties": false
+}

--- a/priv/json-schemas/transaction.json
+++ b/priv/json-schemas/transaction.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 2,
+      "description": "Transaction's version"
+    },
+    "address": {
+      "$ref": "file://schemas/base/address.json",
+      "description": "Transaction's address"
+    },
+    "type": {
+      "enum": [
+        "keychain_access",
+        "keychain",
+        "transfer",
+        "hosting",
+        "token",
+        "data",
+        "contract",
+        "code_proposal",
+        "code_approval"
+      ],
+      "description": "Transaction's type"
+    },
+    "previousPublicKey": {
+      "$ref": "file://schemas/base/public_key.json",
+      "description": "Transaction's previous public key"
+    },
+    "previousSignature": {
+      "$ref": "file://schemas/base/hexadecimal.json",
+      "description": "Transaction's previous signature"
+    },
+    "originSignature": {
+      "$ref": "file://schemas/base/hexadecimal.json",
+      "description": "Transaction's origin signature"
+    },
+    "data": {
+      "$ref": "file://schemas/object/transaction_data.json",
+      "description": "Transaction's data"
+    }
+  },
+  "required": [
+    "version",
+    "address",
+    "type",
+    "previousPublicKey",
+    "previousSignature",
+    "originSignature",
+    "data"
+  ],
+  "additionalProperties": false
+}

--- a/test/archethic_web/api/jsonrpc/controllers/jsonrpc_controller_test.exs
+++ b/test/archethic_web/api/jsonrpc/controllers/jsonrpc_controller_test.exs
@@ -106,7 +106,7 @@ defmodule ArchethicWeb.API.JsonRPCControllerTest do
       "address" => "0000a9f3bc500d0ed7d923e983eafc080113633456f53c400814e1d4f34c5fa67220",
       "type" => type,
       "data" => %{
-        "content" => "73616c7574",
+        "content" => "hello",
         "code" => "",
         "ownerships" => [],
         "ledger" => %{

--- a/test/archethic_web/api/jsonrpc/methods/estimate_transaction_fee_test.exs
+++ b/test/archethic_web/api/jsonrpc/methods/estimate_transaction_fee_test.exs
@@ -31,38 +31,15 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.EstimateTransactionFeeTest do
 
   describe "validate_params" do
     test "should send error when transaction key is missing" do
-      assert {:error,
-              %{
-                transaction: [
-                  "is required"
-                ]
-              }} = EstimateTransactionFee.validate_params(%{})
+      assert {:error, %{"transaction" => "Is required"}} =
+               EstimateTransactionFee.validate_params(%{})
     end
 
     test "should send bad_request response for invalid transaction body" do
       assert {:error,
               %{
-                address: [
-                  "can't be blank"
-                ],
-                data: [
-                  "can't be blank"
-                ],
-                originSignature: [
-                  "can't be blank"
-                ],
-                previousPublicKey: [
-                  "can't be blank"
-                ],
-                previousSignature: [
-                  "can't be blank"
-                ],
-                type: [
-                  "can't be blank"
-                ],
-                version: [
-                  "can't be blank"
-                ]
+                "#" =>
+                  "Required properties version, address, type, previousPublicKey, previousSignature, originSignature, data were not present."
               }} = EstimateTransactionFee.validate_params(%{"transaction" => %{}})
     end
   end

--- a/test/archethic_web/api/jsonrpc/methods/send_transaction_test.exs
+++ b/test/archethic_web/api/jsonrpc/methods/send_transaction_test.exs
@@ -42,38 +42,14 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SendTransactionTest do
 
   describe "validate_params" do
     test "should send error when transaction key is missing" do
-      assert {:error,
-              %{
-                transaction: [
-                  "is required"
-                ]
-              }} = SendTransaction.validate_params(%{})
+      assert {:error, %{"transaction" => "Is required"}} = SendTransaction.validate_params(%{})
     end
 
     test "should send bad_request response for invalid transaction body" do
       assert {:error,
               %{
-                address: [
-                  "can't be blank"
-                ],
-                data: [
-                  "can't be blank"
-                ],
-                originSignature: [
-                  "can't be blank"
-                ],
-                previousPublicKey: [
-                  "can't be blank"
-                ],
-                previousSignature: [
-                  "can't be blank"
-                ],
-                type: [
-                  "can't be blank"
-                ],
-                version: [
-                  "can't be blank"
-                ]
+                "#" =>
+                  "Required properties version, address, type, previousPublicKey, previousSignature, originSignature, data were not present."
               }} = SendTransaction.validate_params(%{"transaction" => %{}})
     end
   end

--- a/test/archethic_web/api/jsonrpc/methods/simulate_contract_execution_test.exs
+++ b/test/archethic_web/api/jsonrpc/methods/simulate_contract_execution_test.exs
@@ -42,38 +42,15 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
 
   describe "validate_params" do
     test "should send error when transaction key is missing" do
-      assert {:error,
-              %{
-                transaction: [
-                  "is required"
-                ]
-              }} = SimulateContractExecution.validate_params(%{})
+      assert {:error, %{"transaction" => "Is required"}} =
+               SimulateContractExecution.validate_params(%{})
     end
 
     test "should send bad_request response for invalid transaction body" do
       assert {:error,
               %{
-                address: [
-                  "can't be blank"
-                ],
-                data: [
-                  "can't be blank"
-                ],
-                originSignature: [
-                  "can't be blank"
-                ],
-                previousPublicKey: [
-                  "can't be blank"
-                ],
-                previousSignature: [
-                  "can't be blank"
-                ],
-                type: [
-                  "can't be blank"
-                ],
-                version: [
-                  "can't be blank"
-                ]
+                "#" =>
+                  "Required properties version, address, type, previousPublicKey, previousSignature, originSignature, data were not present."
               }} = SimulateContractExecution.validate_params(%{"transaction" => %{}})
     end
   end

--- a/test/archethic_web/api/jsonrpc/schemas/transaction_test.exs
+++ b/test/archethic_web/api/jsonrpc/schemas/transaction_test.exs
@@ -1,0 +1,686 @@
+defmodule ArchethicWeb.API.JsonRPC.TransactionSchemaTest do
+  use ArchethicCase
+  import ArchethicCase
+
+  alias Archethic.Crypto
+
+  alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.TransactionData
+  alias Archethic.TransactionChain.TransactionData.Ledger
+  alias Archethic.TransactionChain.TransactionData.Ownership
+  alias Archethic.TransactionChain.TransactionData.Recipient
+  alias Archethic.TransactionChain.TransactionData.UCOLedger
+  alias Archethic.TransactionChain.TransactionData.UCOLedger.Transfer, as: UCOTransfer
+
+  alias ArchethicWeb.API.JsonRPC.TransactionSchema
+
+  describe "validate/1" do
+    test "should return :error if params are not a map" do
+      assert :error = TransactionSchema.validate(["list"])
+    end
+
+    test "should return errors if there are missing fields in the transaction schema" do
+      assert {:error,
+              %{
+                "#" =>
+                  "Required properties version, address, type, previousPublicKey, previousSignature, originSignature, data were not present."
+              }} = TransactionSchema.validate(%{})
+    end
+
+    test "should return errors if the crypto primitives are invalid" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => "abc",
+        "type" => "transfer",
+        "data" => %{
+          "code" => "",
+          "content" => "hello",
+          "ledger" => %{
+            "uco" => %{
+              "transfers" => []
+            },
+            "token" => %{
+              "transfers" => []
+            }
+          },
+          "ownerships" => [],
+          "recipients" => []
+        },
+        "previousPublicKey" => "abc",
+        "previousSignature" => "abc",
+        "originSignature" => "abc"
+      }
+
+      assert {:error,
+              %{
+                "#/address" =>
+                  "Expected exactly one of the schemata to match, but none of them did.",
+                "#/originSignature" => "Does not match pattern \"^([0-9a-fA-F]{2})*$\".",
+                "#/previousPublicKey" =>
+                  "Expected exactly one of the schemata to match, but none of them did.",
+                "#/previousSignature" => "Does not match pattern \"^([0-9a-fA-F]{2})*$\"."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return error if there is additionnal properties" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "timestamp" => DateTime.utc_now() |> DateTime.to_unix(:millisecond),
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{"unknownKey" => "hello"}
+      }
+
+      assert {
+               :error,
+               %{
+                 "#/data/unknownKey" => "Schema does not allow additional properties.",
+                 "#/timestamp" => "Schema does not allow additional properties."
+               }
+             } = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the content size is greater than content max size" do
+      content = Base.encode16(:crypto.strong_rand_bytes(4 * 1024 * 1024))
+
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{"content" => content}
+      }
+
+      assert {:error,
+              %{
+                "#/data/content" =>
+                  "Expected value to have a maximum length of 3145728 but was 8388608."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the code is not a string" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{"code" => 123}
+      }
+
+      assert {:error, %{"#/data/code" => "Type mismatch. Expected String but got Integer."}} =
+               TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the code length is more than 24KB" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{"code" => Base.encode16(:crypto.strong_rand_bytes(24 * 1024 + 1))}
+      }
+
+      assert {:error,
+              %{
+                "#/data/code" => "Expected value to have a maximum length of 24576 but was 49154."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the uco ledger transfer address is invalid" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ledger" => %{"uco" => %{"transfers" => [%{"to" => "abc", "amount" => 10.0}]}}
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/ledger/uco/transfers/0/to" =>
+                  "Expected exactly one of the schemata to match, but none of them did."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the uco ledger transfer amount is invalid" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ledger" => %{
+            "uco" => %{
+              "transfers" => [
+                %{
+                  "to" => Base.encode16(random_address()),
+                  "amount" => "abc"
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/ledger/uco/transfers/0/amount" =>
+                  "Type mismatch. Expected Integer but got String."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the uco ledger transfers are more than 255" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ledger" => %{
+            "uco" => %{
+              "transfers" =>
+                1..256
+                |> Enum.map(fn _ ->
+                  %{
+                    "to" => Base.encode16(random_address()),
+                    "amount" => Enum.random(1..100)
+                  }
+                end)
+            }
+          }
+        }
+      }
+
+      assert {:error,
+              %{"#/data/ledger/uco/transfers" => "Expected a maximum of 255 items but got 256."}} =
+               TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the token ledger transfer address is invalid" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ledger" => %{
+            "token" => %{
+              "transfers" => [
+                %{
+                  "to" => "abc",
+                  "amount" => 10.0,
+                  "tokenAddress" => Base.encode16(random_address()),
+                  "tokenId" => 0
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/ledger/token/transfers/0/to" =>
+                  "Expected exactly one of the schemata to match, but none of them did."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the token ledger transfer amount is invalid" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ledger" => %{
+            "token" => %{
+              "transfers" => [
+                %{
+                  "to" => Base.encode16(random_address()),
+                  "amount" => "abc",
+                  "tokenAddress" => Base.encode16(random_address()),
+                  "tokenId" => 0
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/ledger/token/transfers/0/amount" =>
+                  "Type mismatch. Expected Integer but got String."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the token ledger transfer token address is invalid" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ledger" => %{
+            "token" => %{
+              "transfers" => [
+                %{
+                  "to" => Base.encode16(random_address()),
+                  "amount" => 10.0,
+                  "tokenAddress" => "abc",
+                  "tokenId" => 0
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/ledger/token/transfers/0/tokenAddress" =>
+                  "Expected exactly one of the schemata to match, but none of them did."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the token ledger transfers are more than 255" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ledger" => %{
+            "token" => %{
+              "transfers" =>
+                1..256
+                |> Enum.map(fn _ ->
+                  %{
+                    "to" => Base.encode16(random_address()),
+                    "amount" => Enum.random(1..100),
+                    "tokenAddress" => Base.encode16(random_address()),
+                    "tokenId" => Enum.random(0..255)
+                  }
+                end)
+            }
+          }
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/ledger/token/transfers" => "Expected a maximum of 255 items but got 256."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the encrypted secret is not an hexadecimal" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ownerships" => [
+            %{
+              "secret" => "abc",
+              "authorizedKeys" => [
+                %{
+                  "publicKey" => Base.encode16(random_address()),
+                  "encryptedSecretKey" => "0123"
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/ownerships/0/secret" => "Does not match pattern \"^([0-9a-fA-F]{2})*$\"."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the public key in the authorized keys is not valid" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ownerships" => [
+            %{
+              "authorizedKeys" => [
+                %{
+                  "publicKey" => "key",
+                  "encryptedSecretKey" => "hello"
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/ownerships/0" => "Required property secret was not present.",
+                "#/data/ownerships/0/authorizedKeys/0/encryptedSecretKey" =>
+                  "Does not match pattern \"^([0-9a-fA-F]{2})*$\".",
+                "#/data/ownerships/0/authorizedKeys/0/publicKey" =>
+                  "Expected exactly one of the schemata to match, but none of them did."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error ownerships are more than 255." do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ownerships" =>
+            1..256
+            |> Enum.map(fn _ ->
+              %{
+                "secret" => Base.encode16(:crypto.strong_rand_bytes(64)),
+                "authorizedKeys" => [
+                  %{
+                    "publicKey" =>
+                      Base.encode16(<<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>),
+                    "encryptedSecretKey" => Base.encode16(:crypto.strong_rand_bytes(64))
+                  }
+                ]
+              }
+            end)
+        }
+      }
+
+      assert {:error, %{"#/data/ownerships" => "Expected a maximum of 255 items but got 256."}} =
+               TransactionSchema.validate(map)
+    end
+
+    test "should return an error authorized keys in a ownership can't be more than 255" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "ownerships" => [
+            %{
+              "secret" => Base.encode16(:crypto.strong_rand_bytes(64)),
+              "authorizedKeys" =>
+                1..256
+                |> Enum.map(fn _ ->
+                  %{
+                    "publicKey" => Base.encode16(random_address()),
+                    "encryptedSecretKey" => Base.encode16(:crypto.strong_rand_bytes(64))
+                  }
+                end)
+            }
+          ]
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/ownerships/0/authorizedKeys" =>
+                  "Expected a maximum of 255 items but got 256."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the recipients are invalid" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "recipients" => [1]
+        }
+      }
+
+      assert {:error,
+              %{
+                "#/data/recipients/0" =>
+                  "Expected exactly one of the schemata to match, but none of them did."
+              }} = TransactionSchema.validate(map)
+
+      map = put_in(map, ["data", "recipients"], [%{"address" => "hello"}])
+
+      assert {:error,
+              %{
+                "#/data/recipients/0" =>
+                  "Expected exactly one of the schemata to match, but none of them did."
+              }} = TransactionSchema.validate(map)
+
+      map =
+        put_in(map, ["data", "recipients"], [
+          %{
+            "address" => Base.encode16(random_address()),
+            "args" => []
+          }
+        ])
+
+      assert {:error,
+              %{
+                "#/data/recipients/0" =>
+                  "Expected exactly one of the schemata to match, but none of them did."
+              }} = TransactionSchema.validate(map)
+    end
+
+    test "should accept recipients both named & unnamed" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "recipients" => [
+            %{
+              "address" => Base.encode16(random_address())
+            },
+            %{
+              "address" => Base.encode16(random_address()),
+              "action" => "something",
+              "args" => []
+            }
+          ]
+        }
+      }
+
+      assert :ok = TransactionSchema.validate(map)
+    end
+
+    test "should return an error if the recipients are more that 255" do
+      map = %{
+        "version" => current_transaction_version(),
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "recipients" =>
+            1..256
+            |> Enum.map(fn _ ->
+              %{
+                "address" => Base.encode16(random_address())
+              }
+            end)
+        }
+      }
+
+      assert {:error, %{"#/data/recipients" => "Expected a maximum of 255 items but got 256."}} =
+               TransactionSchema.validate(map)
+    end
+
+    test "should return error if transaction V1 contains named action recipient" do
+      map = %{
+        "version" => 1,
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "recipients" => [
+            %{
+              "address" => Base.encode16(random_address()),
+              "action" => "something",
+              "args" => []
+            }
+          ]
+        }
+      }
+
+      assert {:error,
+              %{"#/data/recipients" => "Transaction V1 cannot use named action recipients"}} =
+               TransactionSchema.validate(map)
+    end
+
+    test "should return error if transaction V2 contains list of addresses as recipient" do
+      map = %{
+        "version" => 2,
+        "address" => Base.encode16(random_address()),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(random_address()),
+        "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
+        "data" => %{
+          "recipients" => [Base.encode16(random_address())]
+        }
+      }
+
+      assert {:error,
+              %{"#/data/recipients" => "From V2, transaction must use named action recipients"}} =
+               TransactionSchema.validate(map)
+    end
+  end
+
+  describe "to_transaction/1" do
+    test "should return a transaction struct" do
+      address = random_address()
+      previous_public_key = random_address()
+      previous_signature = :crypto.strong_rand_bytes(64)
+      origin_signature = :crypto.strong_rand_bytes(64)
+      recipient = random_address()
+      recipient2_address = random_address()
+      uco_to = random_address()
+      aes_key = :crypto.strong_rand_bytes(32)
+      secret = Crypto.aes_encrypt("hello", aes_key)
+
+      {authorized_public_key, _} = Crypto.generate_deterministic_keypair("seed")
+      encrypted_key = Crypto.ec_encrypt(aes_key, authorized_public_key)
+
+      transaction_version = current_transaction_version()
+
+      map = %{
+        "version" => transaction_version,
+        "address" => Base.encode16(address),
+        "type" => "transfer",
+        "previousPublicKey" => Base.encode16(previous_public_key),
+        "previousSignature" => Base.encode16(previous_signature),
+        "originSignature" => Base.encode16(origin_signature),
+        "data" => %{
+          "ledger" => %{
+            "uco" => %{
+              "transfers" => [
+                %{"to" => Base.encode16(uco_to), "amount" => 1_020_000_000}
+              ]
+            }
+          },
+          "ownerships" => [
+            %{
+              "secret" => Base.encode16(secret),
+              "authorizedKeys" => [
+                %{
+                  "publicKey" => Base.encode16(authorized_public_key),
+                  "encryptedSecretKey" => Base.encode16(encrypted_key)
+                }
+              ]
+            }
+          ],
+          "recipients" => [
+            %{"address" => Base.encode16(recipient)},
+            %{
+              "address" => Base.encode16(recipient2_address),
+              "action" => "something",
+              "args" => [1, 2, 3]
+            }
+          ]
+        }
+      }
+
+      assert %Transaction{
+               version: transaction_version,
+               address: address,
+               type: :transfer,
+               previous_public_key: previous_public_key,
+               previous_signature: previous_signature,
+               origin_signature: origin_signature,
+               data: %TransactionData{
+                 recipients: [
+                   %Recipient{address: recipient, action: nil, args: nil},
+                   %Recipient{
+                     address: recipient2_address,
+                     action: "something",
+                     args: [1, 2, 3]
+                   }
+                 ],
+                 ledger: %Ledger{
+                   uco: %UCOLedger{
+                     transfers: [
+                       %UCOTransfer{to: uco_to, amount: 1_020_000_000}
+                     ]
+                   }
+                 },
+                 ownerships: [
+                   %Ownership{
+                     secret: secret,
+                     authorized_keys: %{
+                       authorized_public_key => encrypted_key
+                     }
+                   }
+                 ]
+               }
+             } == TransactionSchema.to_transaction(map)
+    end
+  end
+end


### PR DESCRIPTION
# Description

Remove the base16 format for the transaction content.

Created new Json Schema validation method.

Fixes #1234

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
