### PR TITLE
Smart Contracts: limit Http module to 1 call per SC

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/http_impl.ex
+++ b/lib/archethic/contracts/interpreter/library/common/http_impl.ex
@@ -21,6 +21,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImpl do
   @tag [:io]
   @impl Http
   def fetch(uri) do
+    if check_too_many_calls() do
+      raise Library.Error, message: "Http module got called more than once"
+    end
+
     task =
       Task.Supervisor.async_nolink(
         TaskSupervisor,
@@ -52,6 +56,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImpl do
   @tag [:io]
   @impl Http
   def fetch_many(uris) do
+    if check_too_many_calls() do
+      raise Library.Error, message: "Http module got called more than once"
+    end
+
     uris_count = length(uris)
 
     if uris_count > 5 do
@@ -174,6 +182,17 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImpl do
           {:error, _, reason, _} ->
             {:error, reason}
         end
+    end
+  end
+
+  defp check_too_many_calls() do
+    case Process.get(:smart_contract_http_fetch_called) do
+      true ->
+        true
+
+      nil ->
+        Process.put(:smart_contract_http_fetch_called, true)
+        false
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/http_impl_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/http_impl_test.exs
@@ -60,6 +60,11 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImplTest do
     test "should raise if the endpoint is too slow" do
       assert_raise Library.Error, fn -> HttpImpl.fetch("https://127.0.0.1:8081/very-slow") end
     end
+
+    test "should raise if it's called more than once in the same process" do
+      assert %{"status" => 200, "body" => "hello"} = HttpImpl.fetch("https://127.0.0.1:8081")
+      assert_raise Library.Error, fn -> HttpImpl.fetch("https://127.0.0.1:8081") end
+    end
   end
 
   describe "fetch_many/1" do
@@ -123,6 +128,13 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImplTest do
           "https://127.0.0.1:8081/data?kbytes=200"
         ])
       end
+    end
+
+    test "should raise if it's called more than once in the same process" do
+      assert [%{"status" => 200, "body" => "hello"}] =
+               HttpImpl.fetch_many(["https://127.0.0.1:8081"])
+
+      assert_raise Library.Error, fn -> HttpImpl.fetch_many(["https://127.0.0.1:8081"]) end
     end
   end
 end


### PR DESCRIPTION
# Description

limit Http module to 1 call per SC
Fixes #1186

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tested 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
