### PR TITLE
Add Contract.call_function in SC language

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -69,7 +69,7 @@ defmodule Archethic.Contracts do
   """
   @spec execute_function(
           Contract.t(),
-          :string,
+          String.t(),
           list()
         ) ::
           {:ok, result :: any()}

--- a/lib/archethic/contracts/interpreter/legacy/utils_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/legacy/utils_interpreter.ex
@@ -550,7 +550,7 @@ defmodule Archethic.Contracts.Interpreter.Legacy.UtilsInterpreter do
   are binary encode terms, and so are true binary.To differentiate between the two,
   we check if the string is printable.
   """
-  def get_address(address, context) do
+  def get_address(address, context) when is_binary(address) do
     address =
       if String.printable?(address) do
         case Base.decode16(address, case: :mixed) do
@@ -569,6 +569,8 @@ defmodule Archethic.Contracts.Interpreter.Legacy.UtilsInterpreter do
       _ -> raise "Invalid address in #{inspect(context)}"
     end
   end
+
+  def get_address(_address, context), do: raise("Invalid address in #{inspect(context)}")
 
   def get_public_key(public_key, context) do
     public_key =


### PR DESCRIPTION
# Description

Add a new function in Contract module in SC library to allow user to call a public function from a contract

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit test
Manuel testing with those contract
```elixir
@version 1
export fun add(x, y) do
  x + y
end
```

```elixir
@version 1
condition transaction: []
actions triggered_by: transaction do
  address = 0x0000c32fd6b33c9ff557ad8826f516c1c81d0242524be10891a009b77c50e252bcc5
  res = Contract.call_function(address, "add", [1, 2])
  Contract.set_content res
end
```

triggered second contract and result transaction contained 3 in content

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
