### PR TITLE
 Smart Contracts: new syntax for condition block

### DIFF
--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -484,7 +484,7 @@ defmodule Archethic.Contracts.Interpreter do
     if :oracle in conditions do
       do_check_contract_blocks(rest, conditions)
     else
-      {:error, "missing 'condition oracle' block"}
+      {:error, "missing 'condition triggered_by: oracle' block"}
     end
   end
 
@@ -501,9 +501,9 @@ defmodule Archethic.Contracts.Interpreter do
       do_check_contract_blocks(rest, conditions)
     else
       if action == nil do
-        {:error, "missing 'condition transaction' block"}
+        {:error, "missing 'condition triggered_by: transaction' block"}
       else
-        {:error, "missing 'condition transaction, on: #{action}/#{arity}' block"}
+        {:error, "missing 'condition triggered_by: transaction, on: #{action}/#{arity}' block"}
       end
     end
   end

--- a/test/archethic/contracts/interpreter/condition_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/condition_interpreter_test.exs
@@ -31,6 +31,16 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                |> Interpreter.sanitize_code()
                |> elem(1)
                |> ConditionInterpreter.parse([])
+
+      code = ~s"""
+      condition triggered_by: oracle, as: [      ]
+      """
+
+      assert {:ok, :oracle, %ConditionsSubjects{}} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ConditionInterpreter.parse([])
     end
 
     test "parse a condition transaction" do
@@ -43,11 +53,31 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                |> Interpreter.sanitize_code()
                |> elem(1)
                |> ConditionInterpreter.parse([])
+
+      code = ~s"""
+      condition triggered_by: transaction, as: [      ]
+      """
+
+      assert {:ok, {:transaction, nil, nil}, %ConditionsSubjects{}} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ConditionInterpreter.parse([])
     end
 
     test "does not parse anything else" do
       code = ~s"""
       condition foo: [      ]
+      """
+
+      assert {:error, _, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ConditionInterpreter.parse([])
+
+      code = ~s"""
+      condition triggered_by: foo, as: [      ]
       """
 
       assert {:error, _, _} =
@@ -73,7 +103,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "parse strict value" do
       code = ~s"""
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         content: "Hello"
       ]
       """
@@ -89,7 +119,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "parse library functions" do
       code = ~s"""
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         uco_transfers: Map.size() > 0
       ]
       """
@@ -105,7 +135,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "should not parse :write_contract functions" do
       code = ~s"""
-      condition transaction: [
+       condition triggered_by: transaction, as: [
         uco_transfers: Contract.set_content "content"
       ]
       """
@@ -119,7 +149,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "parse custom functions" do
       code = ~s"""
-      condition transaction: [
+       condition triggered_by: transaction, as: [
         uco_transfers: get_uco_transfers() > 0
       ]
       """
@@ -139,7 +169,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "parse true" do
       code = ~s"""
-      condition transaction: [
+       condition triggered_by: transaction, as: [
         content: true
       ]
       """
@@ -153,7 +183,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "parse false" do
       code = ~s"""
-      condition transaction: [
+       condition triggered_by: transaction, as: [
         content: false
       ]
       """
@@ -167,7 +197,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "parse AST" do
       code = ~s"""
-      condition transaction: [
+       condition triggered_by: transaction, as: [
         content: if true do "Hello" else "World" end
       ]
       """
@@ -181,7 +211,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "parse named action 0 arg" do
       code = ~s"""
-      condition transaction, on: upgrade, as: []
+      condition triggered_by: transaction, on: upgrade, as: []
       """
 
       assert {:ok, {:transaction, "upgrade", []}, %ConditionsSubjects{}} =
@@ -193,7 +223,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "parse named action 1 arg" do
       code = ~s"""
-      condition transaction, on: vote(candidate), as: []
+      condition triggered_by: transaction, on: vote(candidate), as: []
       """
 
       assert {:ok, {:transaction, "vote", ["candidate"]}, %ConditionsSubjects{}} =
@@ -205,7 +235,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "parse named action n args" do
       code = ~s"""
-      condition transaction, on: count(x, y), as: []
+      condition triggered_by: transaction, on: count(x, y), as: []
       """
 
       assert {:ok, {:transaction, "count", ["x", "y"]}, %ConditionsSubjects{}} =
@@ -217,7 +247,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
 
     test "should not parse action > 255 byte" do
       code = ~s"""
-      condition transaction, on: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv(x, y), as: []
+      condition triggered_by: transaction, on: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv(x, y), as: []
       """
 
       assert {:error, {_, "atom length must be less" <> _, _}} =

--- a/test/archethic/contracts/interpreter/condition_validator_test.exs
+++ b/test/archethic/contracts/interpreter/condition_validator_test.exs
@@ -16,8 +16,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
 
   describe "valid_conditions?/2" do
     test "should return true if the transaction's conditions are valid" do
-      code = ~s"""
-      condition transaction: [
+      code = ~s"""iggered_by: transaction, as: [
         type: "transfer"
       ]
       """
@@ -60,7 +59,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
 
     test "should return true if the oracle's conditions are valid" do
       code = ~s"""
-      condition oracle: [
+      condition triggered_by: oracle, as: [
         content: "Hello"
       ]
       """
@@ -178,7 +177,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
       token_address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
 
       code = ~s"""
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         uco_transfers: (
           transaction.uco_transfers["#{Base.encode16(address)}"] == 1
         ),
@@ -238,7 +237,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
       }
 
       code = ~s"""
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         uco_transfers: Map.size() > 0
       ]
       """
@@ -253,7 +252,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              })
 
       code = ~s"""
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         uco_transfers: Map.size() == 1
       ]
       """
@@ -268,7 +267,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              })
 
       code = ~s"""
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         uco_transfers: Map.size() == 2
       ]
       """
@@ -283,7 +282,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              })
 
       code = ~s"""
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         uco_transfers: Map.size() < 10
       ]
       """

--- a/test/archethic/contracts/interpreter/condition_validator_test.exs
+++ b/test/archethic/contracts/interpreter/condition_validator_test.exs
@@ -16,7 +16,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
 
   describe "valid_conditions?/2" do
     test "should return true if the transaction's conditions are valid" do
-      code = ~s"""iggered_by: transaction, as: [
+      code = ~s"""
+      condition triggered_by: transaction, as: [
         type: "transfer"
       ]
       """

--- a/test/archethic/contracts/interpreter/library/common/code_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/code_test.exs
@@ -9,7 +9,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CodeTest do
       code = ~S"""
       @version 1
 
-      condition transaction: []
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
         Contract.set_content "Should work"
@@ -23,7 +23,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CodeTest do
       first_code = ~S"""
       @version 1
 
-      condition transaction: []
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
         Contract.set_content "Hello there"
@@ -33,7 +33,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CodeTest do
       second_code = ~S"""
       @version 1
 
-      condition transaction: []
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
         Contract.set_content "When moon ?"
@@ -47,7 +47,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CodeTest do
       first_code = ~S"""
       @version 1
 
-      condition transaction: []
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
         Contract.set_content "Yolo"
@@ -55,11 +55,11 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CodeTest do
       """
 
       second_code = ~S"""
-          
+
 
       @version 1
 
-      condition transaction: []
+      condition triggered_by: transaction, as: []
       actions triggered_by: transaction do Contract.set_content "Yolo" end
 
       """
@@ -74,7 +74,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CodeTest do
       code = ~S"""
       @version 1
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         content: "No you're not"
       ]
 

--- a/test/archethic/contracts/interpreter/library/common/time_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/time_test.exs
@@ -58,7 +58,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
         content: true
       ]
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         timestamp: Time.now() == #{timestamp}
       ]
 
@@ -99,7 +99,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
         content: true
       ]
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         timestamp: Time.now() < #{timestamp}
       ]
 

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -53,7 +53,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                condition inherit: [
                 content: true
                ]
-               condition transaction: [
+               condition triggered_by: transaction, as: [
                 uco_transfers: List.size() > 0
                ]
 
@@ -73,7 +73,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                condition inherit: [
                 content: true
                ]
-               condition transaction: [
+               condition triggered_by: transaction, as: [
                 uco_transfers: List.size() > 0
                ]
                actions triggered_by: transaction do
@@ -87,7 +87,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       assert {:error, "invalid function arguments - List.empty?(12) - L4"} =
                """
                @version 1
-               condition transaction: []
+               condition triggered_by: transaction, as: []
                actions triggered_by: transaction do
                  x = List.empty?(12)
                end
@@ -104,7 +104,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                   "hello world"
                end
 
-               condition transaction: []
+               condition triggered_by: transaction, as: []
                actions triggered_by: transaction do
                  x = hello_world()
                  x
@@ -123,7 +123,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                  a + t
                end
 
-               condition transaction: []
+               condition triggered_by: transaction, as: []
                actions triggered_by: transaction do
                  x = sum(5,6)
                  x
@@ -142,7 +142,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                   "hello world"
                end
 
-               condition transaction: []
+               condition triggered_by: transaction, as: []
                actions triggered_by: transaction do
                  hey()
                end
@@ -165,7 +165,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                   "hello world"
                end
 
-               condition transaction: []
+               condition triggered_by: transaction, as: []
                actions triggered_by: transaction do
                  x = hello_world()
                  x
@@ -184,7 +184,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                   "hello world"
                end
 
-               condition transaction: []
+               condition triggered_by: transaction, as: []
                actions triggered_by: transaction do
                  x = hello_world(1)
                  x
@@ -199,7 +199,7 @@ defmodule Archethic.Contracts.InterpreterTest do
               "Function List.empty? does not exists with 2 arguments - List.empty?([1], \"foobar\") - L4"} =
                """
                @version 1
-               condition transaction: []
+               condition triggered_by: transaction, as: []
                actions triggered_by: transaction do
                  x = List.empty?([1], "foobar")
                end
@@ -212,7 +212,7 @@ defmodule Archethic.Contracts.InterpreterTest do
               "Function List.non_existing does not exists - List.non_existing([1, 2, 3]) - L4"} =
                """
                @version 1
-               condition transaction: []
+               condition triggered_by: transaction, as: []
                actions triggered_by: transaction do
                  x = List.non_existing([1,2,3])
                end
@@ -224,7 +224,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       assert {:error, "Parse error: invalid language syntax"} =
                """
                @version 1
-               condition transaction: []
+               condition triggered_by: transaction, as: []
                actions triggered_by:transaction do
                 x = "missing space above"
                end
@@ -233,7 +233,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     end
 
     test "should return an human readable error 'condition transaction' block is missing" do
-      assert {:error, "missing 'condition transaction' block"} =
+      assert {:error, "missing 'condition triggered_by: transaction' block"} =
                """
                @version 1
                actions triggered_by: transaction do
@@ -244,7 +244,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     end
 
     test "should return an human readable error 'condition oracle' block is missing" do
-      assert {:error, "missing 'condition oracle' block"} =
+      assert {:error, "missing 'condition triggered_by: oracle' block"} =
                """
                @version 1
                actions triggered_by: oracle do
@@ -254,8 +254,8 @@ defmodule Archethic.Contracts.InterpreterTest do
                |> Interpreter.parse()
     end
 
-    test "should return an human readable error 'condition transaction, on: xxx' block is missing" do
-      assert {:error, "missing 'condition transaction, on: upgrade/0' block"} =
+    test "should return an human readable error 'condition triggered_by: transaction, on: xxx' block is missing" do
+      assert {:error, "missing 'condition triggered_by: transaction, on: upgrade/0' block"} =
                """
                @version 1
                actions triggered_by: transaction, on: upgrade() do
@@ -264,7 +264,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                """
                |> Interpreter.parse()
 
-      assert {:error, "missing 'condition transaction, on: vote/2' block"} =
+      assert {:error, "missing 'condition triggered_by: transaction, on: vote/2' block"} =
                """
                @version 1
                actions triggered_by: transaction, on: vote(x, y) do
@@ -273,7 +273,7 @@ defmodule Archethic.Contracts.InterpreterTest do
                """
                |> Interpreter.parse()
 
-      assert {:error, "missing 'condition transaction, on: vote/2' block"} =
+      assert {:error, "missing 'condition triggered_by: transaction, on: vote/2' block"} =
                """
                @version 1
                actions triggered_by: transaction, on: vote(x,y) do
@@ -323,7 +323,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should return a transaction if the contract is correct and there was a Contract.* call" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           Contract.set_content "hello"
         end
@@ -353,7 +353,7 @@ defmodule Archethic.Contracts.InterpreterTest do
       code = """
         @version 1
 
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           Contract.set_content "hello"
         end
@@ -395,7 +395,7 @@ defmodule Archethic.Contracts.InterpreterTest do
          "hello world"
       end
 
-      condition transaction: []
+        condition triggered_by: transaction, as: []
       actions triggered_by: transaction do
         Contract.set_content hello_world()
       end
@@ -431,7 +431,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "Should not be able to use out of scope variables" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           my_var = "toto"
           Contract.set_content my_func()
@@ -465,7 +465,7 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           temp = func1()
           Contract.set_content func2()
@@ -506,7 +506,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "Should be able to use variables from scope in functions" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           Contract.set_content my_func()
         end
@@ -546,7 +546,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "Should be able to use variables as args for custom functions" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           salary = 1000
           tax = 0.7
@@ -589,7 +589,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "Should be able to use module function calls as args for custom functions" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           Contract.set_content counter(String.to_number(contract.content))
         end
@@ -631,7 +631,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "Should be able to use custom function calls as args for custom functions" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           Contract.set_content counter(other_function())
         end
@@ -676,7 +676,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "Should be able to use string interpolation as arg for custom functions" do
       code = ~S"""
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           name = "Toto"
           Contract.set_content hello("my name is #{name}")
@@ -717,7 +717,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "Should be able to calculate arg before passing it to custom functions" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           name = "Toto"
           Contract.set_content sum_a_b(1 + 5, 4)
@@ -758,7 +758,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should return nil when the contract is correct but no Contract.* call" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           if false do
             Contract.set_content "hello"
@@ -791,7 +791,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should return contract_failure if contract code crash" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
 
         actions triggered_by: transaction do
           x = 10 / 0
@@ -824,7 +824,7 @@ defmodule Archethic.Contracts.InterpreterTest do
 
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
 
         actions triggered_by: transaction do
           Contract.add_uco_transfer amount: -1, to: "0000BFEF73346D20771614449D6BE9C705BF314067A0CF0ACBBF5E617EF5C978D0A1"
@@ -900,7 +900,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should be able to simulate a trigger: oracle" do
       code = """
         @version 1
-        condition oracle: []
+        condition triggered_by: oracle, as: []
         actions triggered_by: oracle do
           Contract.set_content "hello"
         end
@@ -931,7 +931,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should be able to use a named action argument in the action & condition blocks" do
       code = """
         @version 1
-        condition transaction, on: vote(candidate), as: [
+        condition triggered_by: transaction, on: vote(candidate), as: [
           content: candidate == "Dr. Who?"
         ]
         actions triggered_by: transaction, on: vote(candidate) do
@@ -973,7 +973,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "Should not be able to overwrite protected global variables" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
         actions triggered_by: transaction do
           time_now = 2_000_000_000
           Contract.set_content Time.now()
@@ -1015,7 +1015,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should be able to use a named action arguments in the action & condition blocks" do
       code = """
         @version 1
-        condition transaction, on: add(x, y), as: []
+        condition triggered_by: transaction, on: add(x, y), as: []
         actions triggered_by: transaction, on: add(x, y) do
           Contract.set_content x + y
         end
@@ -1055,7 +1055,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should be able to have different spacing in condition & actions named action" do
       code = """
         @version 1
-        condition transaction, on: add(x,      y), as: []
+        condition triggered_by: transaction, on: add(x,      y), as: []
         actions triggered_by: transaction, on: add(x,y) do
           Contract.set_content x + y
         end
@@ -1097,7 +1097,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should transform atom into tuple {:atom, \"value\"}" do
       code = """
       @version 1
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         address: "0xabc123def456"
       ]
       """
@@ -1109,7 +1109,12 @@ defmodule Archethic.Contracts.InterpreterTest do
                 [
                   {_, _, [{{:atom, "version"}, _, _}]},
                   {{:atom, "condition"}, _,
-                   [[{{:atom, "transaction"}, [{{:atom, "address"}, "0xabc123def456"}]}]]}
+                   [
+                     [
+                       {{:atom, "triggered_by"}, {{:atom, "transaction"}, _, nil}},
+                       {{:atom, "as"}, [{{:atom, "address"}, "0xabc123def456"}]}
+                     ]
+                   ]}
                 ]},
                ast
              )
@@ -1118,7 +1123,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should transform 0x hex in uppercase string" do
       code = """
       @version 1
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         address: 0xabc123def456
       ]
       """
@@ -1130,7 +1135,12 @@ defmodule Archethic.Contracts.InterpreterTest do
                 [
                   {_, _, [{{:atom, "version"}, _, _}]},
                   {{:atom, "condition"}, _,
-                   [[{{:atom, "transaction"}, [{{:atom, "address"}, "ABC123DEF456"}]}]]}
+                   [
+                     [
+                       {{:atom, "triggered_by"}, {{:atom, "transaction"}, _, nil}},
+                       {{:atom, "as"}, [{{:atom, "address"}, "ABC123DEF456"}]}
+                     ]
+                   ]}
                 ]},
                ast
              )
@@ -1139,7 +1149,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     test "should return an error when 0x format is not hexadecimal" do
       code = """
       @version 1
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         address: 0xnothexa
       ]
       """

--- a/test/archethic/contracts/worker_test.exs
+++ b/test/archethic/contracts/worker_test.exs
@@ -536,7 +536,7 @@ defmodule Archethic.Contracts.WorkerTest do
       code = """
       @version 1
 
-      condition transaction, on: vote(candidate), as: []
+      condition triggered_by: transaction, on: vote(candidate), as: []
       actions triggered_by: transaction, on: vote(candidate) do
         Contract.set_content(candidate)
       end
@@ -605,7 +605,7 @@ defmodule Archethic.Contracts.WorkerTest do
 
       code = """
       @version 1
-      condition transaction: []
+      condition triggered_by: transaction, as: []
       actions triggered_by: transaction do
         n = 10 / 0
         Contract.set_content n

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -495,7 +495,7 @@ defmodule Archethic.ContractsTest do
     test "should return true if condition is empty" do
       code = """
         @version 1
-        condition transaction: []
+        condition triggered_by: transaction, as: []
 
         actions triggered_by: transaction do
           Contract.set_content "hello"
@@ -528,7 +528,7 @@ defmodule Archethic.ContractsTest do
     test "should return true if condition is true" do
       code = """
         @version 1
-        condition transaction: [
+        condition triggered_by: transaction, as: [
           type: "transfer"
         ]
 
@@ -563,7 +563,7 @@ defmodule Archethic.ContractsTest do
     test "should return false if condition is falsy" do
       code = """
         @version 1
-        condition transaction: [
+        condition triggered_by: transaction, as: [
           type: "data"
         ]
 
@@ -598,7 +598,7 @@ defmodule Archethic.ContractsTest do
     test "should return false if condition execution raise an error" do
       code = """
         @version 1
-        condition transaction: [
+        condition triggered_by: transaction, as: [
           type: 1 + "one"
         ]
 
@@ -638,7 +638,7 @@ defmodule Archethic.ContractsTest do
          true
       end
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
           content: check_content()
       ]
       actions triggered_by: transaction do
@@ -674,7 +674,7 @@ defmodule Archethic.ContractsTest do
          false
       end
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
           content: check_content()
       ]
       actions triggered_by: transaction do
@@ -714,7 +714,7 @@ defmodule Archethic.ContractsTest do
          content == "tresor"
       end
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
           content: check_content()
       ]
       actions triggered_by: transaction do
@@ -751,7 +751,7 @@ defmodule Archethic.ContractsTest do
     test "should return true if condition is empty" do
       code = """
         @version 1
-        condition oracle: []
+        condition triggered_by: oracle, as: []
 
         actions triggered_by: oracle do
           Contract.set_content "hello"
@@ -784,7 +784,7 @@ defmodule Archethic.ContractsTest do
     test "should return true if condition is true" do
       code = """
         @version 1
-        condition oracle: [
+        condition triggered_by: oracle, as: [
           content: "{}"
         ]
 
@@ -820,7 +820,7 @@ defmodule Archethic.ContractsTest do
     test "should return false if condition is falsy" do
       code = """
         @version 1
-        condition oracle: [
+        condition triggered_by: oracle, as: [
           content: "{}"
         ]
 
@@ -858,7 +858,7 @@ defmodule Archethic.ContractsTest do
     test "should return true if condition is empty" do
       code = """
         @version 1
-        condition transaction, on: vote(candidate), as: []
+        condition triggered_by: transaction, on: vote(candidate), as: []
 
         actions triggered_by: transaction, on: vote(person) do
           Contract.set_content "hello"
@@ -894,7 +894,7 @@ defmodule Archethic.ContractsTest do
     test "should return true if condition is true" do
       code = """
       @version 1
-      condition transaction, on: vote(candidate), as: [
+      condition triggered_by: transaction, on: vote(candidate), as: [
         content: "fabulous chimpanzee"
       ]
 
@@ -933,7 +933,7 @@ defmodule Archethic.ContractsTest do
     test "should return false if condition is false" do
       code = """
       @version 1
-      condition transaction, on: vote(candidate), as: [
+      condition triggered_by: transaction, on: vote(candidate), as: [
         content: "immaterial mynah bird"
       ]
 

--- a/test/archethic/p2p/message/validate_smart_contract_call_test.exs
+++ b/test/archethic/p2p/message/validate_smart_contract_call_test.exs
@@ -68,7 +68,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
              code: ~s"""
              @version 1
 
-             condition transaction: [
+             condition triggered_by: transaction, as: [
                content: transaction.timestamp < 5000000000
              ]
 
@@ -104,7 +104,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
              code: ~s"""
              @version 1
 
-             condition transaction, on: upgrade(), as: []
+             condition triggered_by: transaction, on: upgrade(), as: []
              actions triggered_by: transaction, on: upgrade() do
                Contract.set_code transaction.content
              end
@@ -173,7 +173,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
              code: ~s"""
              @version 1
 
-             condition transaction: [
+             condition triggered_by: transaction, as: [
                content: "hola"
              ]
 

--- a/test/archethic_web/api/jsonrpc/methods/call_contract_function_test.exs
+++ b/test/archethic_web/api/jsonrpc/methods/call_contract_function_test.exs
@@ -56,7 +56,8 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
   describe "execute" do
     test "should indicate faillure when failling parsing of contracts" do
       code = """
-      condition transaction: [
+      @version 1
+      condition triggered_by: transaction, as: [
         content: "test"
       ]
 
@@ -99,12 +100,11 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
       code = """
       @version 1
 
-      export fun get_content() do 
+      export fun get_content() do
         contract.content
       end
 
-      condition transaction: [
-      ]
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
           Contract.set_content get_content()
@@ -146,7 +146,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
       code = """
       @version 1
 
-      export fun sum(list_of_number) do 
+      export fun sum(list_of_number) do
         sum = 0
         for number in list_of_number do
           sum = sum + number
@@ -154,8 +154,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
         sum
       end
 
-      condition transaction: [
-      ]
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
           Contract.set_content "toto"
@@ -198,16 +197,15 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
       code = """
       @version 1
 
-      export fun bob() do 
+      export fun bob() do
         "hello bob"
       end
 
-      export fun hello() do 
+      export fun hello() do
         bob()
       end
 
-      condition transaction: [
-      ]
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
           Contract.set_content hello()
@@ -250,15 +248,14 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
       code = """
       @version 1
 
-      fun bob() do 
+      fun bob() do
         "hello bob"
       end
-      export fun hello() do 
+      export fun hello() do
         bob()
       end
 
-      condition transaction: [
-      ]
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
           Contract.set_content hello()
@@ -301,8 +298,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
       code = """
       @version 1
 
-      condition transaction: [
-      ]
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
           Contract.set_content "hello"
@@ -345,11 +341,10 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
       code = """
       @version 1
 
-      export fun hello(a, b) do 
+      export fun hello(a, b) do
         a + b
       end
-      condition transaction: [
-      ]
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
           Contract.set_content "hello"
@@ -392,11 +387,10 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
       code = """
       @version 1
 
-      export fun hello(a, b) do 
+      export fun hello(a, b) do
         a + b
       end
-      condition transaction: [
-      ]
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
           Contract.set_content "hello"
@@ -438,11 +432,10 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
       code = """
       @version 1
 
-      fun hello(a, b) do 
+      fun hello(a, b) do
         a + b
       end
-      condition transaction: [
-      ]
+      condition triggered_by: transaction, as: []
 
       actions triggered_by: transaction do
           Contract.set_content "hello"

--- a/test/archethic_web/api/jsonrpc/methods/simulate_contract_execution_test.exs
+++ b/test/archethic_web/api/jsonrpc/methods/simulate_contract_execution_test.exs
@@ -60,7 +60,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
       code = """
       @version 1
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         content: "test content"
       ]
 
@@ -107,7 +107,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
       code = """
       @version 1
 
-      condition transaction, on: vote(candidate), as: []
+      condition triggered_by: transaction, on: vote(candidate), as: []
       actions triggered_by: transaction, on: vote(candidate) do
         Contract.set_content(candidate)
       end
@@ -150,7 +150,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
       code = """
       @version 1
 
-      condition transaction, on: vote(candidate), as: []
+      condition triggered_by: transaction, on: vote(candidate), as: []
       actions triggered_by: transaction, on: vote(candidate) do
         Contract.set_content(candidate)
       end
@@ -193,7 +193,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
       code = """
       @version 1
 
-      condition transaction, on: vote(candidate), as: []
+      condition triggered_by: transaction, on: vote(candidate), as: []
       actions triggered_by: transaction, on: vote(candidate) do
         Contract.set_content(candidate)
       end
@@ -236,7 +236,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
       code = """
       @version 1
 
-      condition transaction, on: vote(candidate), as: [
+      condition triggered_by: transaction, on: vote(candidate), as: [
         content: transaction.content == "some content"
       ]
       actions triggered_by: transaction, on: vote(candidate) do
@@ -284,7 +284,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
         content: false
       ]
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         content: "test"
       ]
 
@@ -333,7 +333,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
 
     test "should indicate faillure when failling parsing of contracts" do
       code = """
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         content: "test"
       ]
 
@@ -423,7 +423,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
       code = """
       @version 1
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         content: "test"
       ]
 
@@ -473,7 +473,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
       code1 = """
       @version 1
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         content: "test"
       ]
 
@@ -485,7 +485,7 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.SimulateContractExecutionTest do
       code2 = """
       @version 1
 
-      condition transaction: [
+      condition triggered_by: transaction, as: [
         content: "test"
       ]
 

--- a/test/support/contract_factory.ex
+++ b/test/support/contract_factory.ex
@@ -10,7 +10,7 @@ defmodule Archethic.ContractFactory do
       content: true
     ]
 
-    condition transaction: [
+    condition triggered_by: transaction, as: [
       uco_transfers: Map.size() > 0
     ]
 


### PR DESCRIPTION
# Description

New syntax: `condition triggered_by: transaction, as: []`
Legacy `condition transaction: []` is kept

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
