### PR TITLE
Fix JSONRPC transaction schema for transaction v1

### DIFF
--- a/lib/archethic_web/api/jsonrpc/schemas/transaction.ex
+++ b/lib/archethic_web/api/jsonrpc/schemas/transaction.ex
@@ -106,6 +106,8 @@ defmodule ArchethicWeb.API.JsonRPC.TransactionSchema do
     end)
   end
 
+  defp put_original_recipients_args(params, []), do: params
+
   defp put_original_recipients_args(params, original_recipients) do
     update_in(params, [:data, :recipients], fn recipients ->
       recipients


### PR DESCRIPTION
Fix transaction schema for transaction v1. 
Without this, the Enum.zip will transform the list of recipients into en empty list (because original_recipients is always [] in v1)

Example of failing scenario:

```elixir
{
    "id": 0,
    "jsonrpc": "2.0",
    "method": "simulate_contract_execution",
    "params": {
        "transaction": {
            "address": "00001ff1733caa91336976ee7cef5aff6bb26c7682213b8e6770ab82272f966dac35",
            "data": {               
                "recipients": [
                    "000058C44C933FBD047BF694490371BB41DA037597FFD57970A1DE6832AF990B7752"
                ]
            },
            "originSignature": "3046022100fcbfa3fce779c97facecb06fde3ae586e8d41ae1a0552c4cb6d580ae632aa88b022100854c4c846ce5db1c909a3b06d0a2d01c4ae119141519e08aa6ddf386b98aecec",
            "previousPublicKey": "000161d6cd8da68207bd01198909c139c130a3df3a8bd20f4bacb123c46354ccd52c",
            "previousSignature": "e55c5372fc30555c895a831f81a5e31fad53f23db6ffc0161837514c5d8e0b69c109ab365e52c74ee7ff13fcc6dc39cacadfe544bd0625621bd41a36cb466c0d",
            "type": "token",
            "version": 1
        }
    }
}
```

Resulted in "There are no recipients in the transaction".