### PR TITLE
Add function Contract.clear_ownerships in SC

### DIFF
--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -46,6 +46,7 @@ defmodule Archethic.TransactionFactory do
     content = Keyword.get(opts, :content, "")
     code = Keyword.get(opts, :code, "")
     ledger = Keyword.get(opts, :ledger, %Ledger{})
+    ownerships = Keyword.get(opts, :ownerships, [])
 
     timestamp =
       Keyword.get(opts, :timestamp, DateTime.utc_now()) |> DateTime.truncate(:millisecond)
@@ -53,7 +54,7 @@ defmodule Archethic.TransactionFactory do
     tx =
       Transaction.new(
         type,
-        %TransactionData{content: content, code: code, ledger: ledger},
+        %TransactionData{content: content, code: code, ledger: ledger, ownerships: ownerships},
         seed,
         index
       )


### PR DESCRIPTION
# Description

Currenty ownerships are chainned when creating a new smart contract transaction.
This create problem when we want to use them mainly to remove one or update one.

To have a quick fix waiting a proper solution I created a function `Contract.clear_ownerships` to clear all the ownerships (expect the contract seed) from the next transaction

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
