### PR TITLE
Smart Contracts: remove error logs that are coming from a user error

### DIFF
--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -186,8 +186,7 @@ defmodule Archethic.Contracts.Interpreter do
         {:ok, result}
     end
   rescue
-    err ->
-      Logger.error(Exception.format(:error, err, __STACKTRACE__))
+    _ ->
       # it's ok to loose the error because it's user-code
       {:error, :contract_failure}
   end


### PR DESCRIPTION
Remove the logs of 2 scenarios:
- Incorrect smart contract's code
- Incorrect public function call

 We don't want to see that in the logs.

Example of logs that are removed:

```
2023-09-07 12:32:23.479 [error] Task #PID<0.4837.0> started from #PID<0.4780.0> terminating
** (Protocol.UndefinedError) protocol String.Chars not implemented for %{"address" => 1} of type Map
    (elixir 1.14.1) lib/string/chars.ex:3: String.Chars.impl_for!/1
    (elixir 1.14.1) lib/string/chars.ex:22: String.Chars.to_string/1
    nofile:8: (file)
    (elixir 1.14.1) src/elixir.erl:298: anonymous fn/4 in :elixir.eval_external_handler/1
    (stdlib 4.1.1) erl_eval.erl:748: :erl_eval.do_apply/7
    (stdlib 4.1.1) eval_bits.erl:106: :eval_bits.eval_field/5
    (stdlib 4.1.1) eval_bits.erl:71: :eval_bits.expr_grp1/6
    (stdlib 4.1.1) eval_bits.erl:67: :eval_bits.expr_grp/5
    (stdlib 4.1.1) erl_eval.erl:543: :erl_eval.expr/6
    (stdlib 4.1.1) erl_eval.erl:492: :erl_eval.expr/6
    (stdlib 4.1.1) erl_eval.erl:136: :erl_eval.exprs/6
    (elixir 1.14.1) src/elixir.erl:288: :elixir.eval_forms/3
    (elixir 1.14.1) lib/module/parallel_checker.ex:107: Module.ParallelChecker.verify/1
    (elixir 1.14.1) lib/code.ex:825: Code.eval_quoted/3
    (archethic 1.3.0-rc3) lib/archethic/contracts/interpreter/scope.ex:117: Archethic.Contracts.Interpreter.Scope.execute/4
    (elixir 1.14.1) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (elixir 1.14.1) lib/task/supervised.ex:34: Task.Supervised.reply/4
Function: #Function<0.32505684/0 in Archethic.Contracts.execute_function/3>
    Args: []
```
