### PR TITLE
Smart Contracts: Use atoms instead of strings for scope_hierarchy & context_list

### DIFF
--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -4,7 +4,7 @@ defmodule Archethic.Contracts.Interpreter.Scope do
   """
 
   defp init(global_variables) do
-    global_variables = Map.put(global_variables, "context_list", [])
+    global_variables = Map.put(global_variables, :context_list, [])
 
     Process.put(
       :scope,
@@ -26,7 +26,7 @@ defmodule Archethic.Contracts.Interpreter.Scope do
     new_scope =
       Process.get(:scope)
       |> put_in([current_context] ++ current_scope_hierarchy ++ [ref], %{})
-      |> update_in([current_context, "scope_hierarchy"], &(&1 ++ [ref]))
+      |> update_in([current_context, :scope_hierarchy], &(&1 ++ [ref]))
 
     Process.put(
       :scope,
@@ -44,14 +44,14 @@ defmodule Archethic.Contracts.Interpreter.Scope do
     context_ref = new_ref()
 
     new_context = %{
-      "scope_hierarchy" => []
+      scope_hierarchy: []
     }
 
     # add context to scope and update context list
     new_scope =
       Process.get(:scope)
       |> Map.put(context_ref, new_context)
-      |> Map.update!("context_list", &[context_ref | &1])
+      |> Map.update!(:context_list, &[context_ref | &1])
 
     Process.put(:scope, new_scope)
 
@@ -68,7 +68,7 @@ defmodule Archethic.Contracts.Interpreter.Scope do
 
     new_scope =
       Process.get(:scope)
-      |> update_in([current_context, "scope_hierarchy"], &List.delete_at(&1, -1))
+      |> update_in([current_context, :scope_hierarchy], &List.delete_at(&1, -1))
       |> pop_in([current_context] ++ current_scope_hierarchy)
       |> elem(1)
 
@@ -87,7 +87,7 @@ defmodule Archethic.Contracts.Interpreter.Scope do
     new_scope =
       Process.get(:scope)
       |> Map.delete(current_context)
-      |> Map.update!("context_list", fn [_first | rest] -> rest end)
+      |> Map.update!(:context_list, fn [_first | rest] -> rest end)
 
     Process.put(:scope, new_scope)
 
@@ -218,12 +218,12 @@ defmodule Archethic.Contracts.Interpreter.Scope do
   end
 
   defp get_current_context() do
-    get_in(Process.get(:scope), ["context_list"])
+    get_in(Process.get(:scope), [:context_list])
     |> List.first()
   end
 
   defp get_context_scope_hierarchy(context) do
-    get_in(Process.get(:scope), [context, "scope_hierarchy"])
+    get_in(Process.get(:scope), [context, :scope_hierarchy])
   end
 
   defp new_ref() do

--- a/test/archethic/contracts/interpreter/scope_test.exs
+++ b/test/archethic/contracts/interpreter/scope_test.exs
@@ -10,47 +10,47 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
 
   describe "create_context/0" do
     test "should create empty context to existing scope" do
-      Process.put(:scope, %{"context_list" => [], "var1" => %{"prop" => 1}, "var2" => 4})
+      Process.put(:scope, %{"var1" => %{"prop" => 1}, "var2" => 4, context_list: []})
 
       Scope.create_context()
 
-      assert %{"context_list" => [context_ref]} = Process.get(:scope)
+      assert %{context_list: [context_ref]} = Process.get(:scope)
 
       assert %{
-               "context_list" => [context_ref],
                "var1" => %{"prop" => 1},
                "var2" => 4,
                context_ref => %{
-                 "scope_hierarchy" => []
-               }
+                 scope_hierarchy: []
+               },
+               context_list: [context_ref]
              } == Process.get(:scope)
     end
 
     test "should create new context if one already exists" do
       # create scope with existing context
       Process.put(:scope, %{
-        "context_list" => ["context_1"],
         "var1" => %{"prop" => 1},
         "var2" => 4,
         "context_1" => %{
-          "scope_hierarchy" => []
-        }
+          scope_hierarchy: []
+        },
+        context_list: ["context_1"]
       })
 
       Scope.create_context()
 
-      assert %{"context_list" => [context_ref_2, _]} = Process.get(:scope)
+      assert %{context_list: [context_ref_2, _]} = Process.get(:scope)
 
       assert %{
-               "context_list" => [context_ref_2, "context_1"],
                "var1" => %{"prop" => 1},
                "var2" => 4,
                "context_1" => %{
-                 "scope_hierarchy" => []
+                 scope_hierarchy: []
                },
                context_ref_2 => %{
-                 "scope_hierarchy" => []
-               }
+                 scope_hierarchy: []
+               },
+               context_list: [context_ref_2, "context_1"]
              } == Process.get(:scope)
     end
   end
@@ -58,45 +58,45 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
   describe "leave_context/0" do
     test "should remove the only existing context" do
       Process.put(:scope, %{
-        "context_list" => ["context_1"],
         "var1" => %{"prop" => 1},
         "var2" => 4,
         "context_1" => %{
-          "scope_hierarchy" => []
-        }
+          scope_hierarchy: []
+        },
+        context_list: ["context_1"]
       })
 
       Scope.leave_context()
 
       assert %{
-               "context_list" => [],
                "var1" => %{"prop" => 1},
-               "var2" => 4
+               "var2" => 4,
+               context_list: []
              } == Process.get(:scope)
     end
 
     test "should remove the current context when multiple contexts exist" do
       Process.put(:scope, %{
-        "context_list" => ["context_1", "context_2"],
         "var1" => %{"prop" => 1},
         "var2" => 4,
         "context_1" => %{
-          "scope_hierarchy" => []
+          scope_hierarchy: []
         },
         "context_2" => %{
-          "scope_hierarchy" => []
-        }
+          scope_hierarchy: []
+        },
+        context_list: ["context_1", "context_2"]
       })
 
       Scope.leave_context()
 
       assert %{
-               "context_list" => ["context_2"],
                "var1" => %{"prop" => 1},
                "var2" => 4,
                "context_2" => %{
-                 "scope_hierarchy" => []
-               }
+                 scope_hierarchy: []
+               },
+               context_list: ["context_2"]
              } == Process.get(:scope)
     end
   end
@@ -104,15 +104,15 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
   describe "create/0" do
     test "should create scope in current context" do
       scope = %{
-        "context_list" => ["current_context", "other_context"],
         "var1" => %{"prop" => 1},
         "var2" => 4,
         "current_context" => %{
-          "scope_hierarchy" => []
+          scope_hierarchy: []
         },
         "other_context" => %{
-          "scope_hierarchy" => []
-        }
+          scope_hierarchy: []
+        },
+        context_list: ["current_context", "other_context"]
       }
 
       Process.put(:scope, scope)
@@ -121,34 +121,34 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
 
       assert %{
                "current_context" => %{
-                 "scope_hierarchy" => [scope_ref]
+                 scope_hierarchy: [scope_ref]
                }
              } = Process.get(:scope)
 
       assert %{
-               "context_list" => ["current_context", "other_context"],
                "var1" => %{"prop" => 1},
                "var2" => 4,
                "current_context" => %{
-                 "scope_hierarchy" => [scope_ref],
-                 scope_ref => %{}
+                 scope_ref => %{},
+                 scope_hierarchy: [scope_ref]
                },
                "other_context" => %{
-                 "scope_hierarchy" => []
-               }
+                 scope_hierarchy: []
+               },
+               context_list: ["current_context", "other_context"]
              } == Process.get(:scope)
     end
 
     test "should add another scope to an existing context hierarchy, inside current scope" do
       # Setup with an existing scope in the current context
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["first_scope", "second_scope"],
           "first_scope" => %{
             "second_scope" => %{}
-          }
-        }
+          },
+          scope_hierarchy: ["first_scope", "second_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -157,20 +157,20 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
 
       assert %{
                "current_context" => %{
-                 "scope_hierarchy" => ["first_scope", "second_scope", new_scope_ref]
+                 scope_hierarchy: ["first_scope", "second_scope", new_scope_ref]
                }
              } = Process.get(:scope)
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => ["first_scope", "second_scope", new_scope_ref],
                  "first_scope" => %{
                    "second_scope" => %{
                      new_scope_ref => %{}
                    }
-                 }
-               }
+                 },
+                 scope_hierarchy: ["first_scope", "second_scope", new_scope_ref]
+               },
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
   end
@@ -179,13 +179,13 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
     test "should remove the last scope from the scope_hierarchy and delete the corresponding map" do
       # Setup with a context that has two scopes
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["first_scope", "second_scope"],
           "first_scope" => %{
             "second_scope" => %{}
-          }
-        }
+          },
+          scope_hierarchy: ["first_scope", "second_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -193,22 +193,22 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.leave_scope()
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => ["first_scope"],
-                 "first_scope" => %{}
-               }
+                 "first_scope" => %{},
+                 scope_hierarchy: ["first_scope"]
+               },
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
 
     test "should handle removing the only scope from the scope_hierarchy correctly" do
       # Setup with a context that has one scope
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["only_scope"],
-          "only_scope" => %{}
-        }
+          "only_scope" => %{},
+          scope_hierarchy: ["only_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -216,10 +216,10 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.leave_scope()
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => []
-               }
+                 scope_hierarchy: []
+               },
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
   end
@@ -228,11 +228,11 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
     test "should write a variable in the current scope of the current context" do
       # Setup with a single context and a single scope
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["only_scope"],
-          "only_scope" => %{}
-        }
+          "only_scope" => %{},
+          scope_hierarchy: ["only_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -240,26 +240,26 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.write_at("my_var", 42)
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => ["only_scope"],
                  "only_scope" => %{
                    "my_var" => 42
-                 }
-               }
+                 },
+                 scope_hierarchy: ["only_scope"]
+               },
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
 
     test "should write a variable in the most nested scope" do
       # Setup with a single context but multiple scopes
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["first_scope", "second_scope"],
           "first_scope" => %{
             "second_scope" => %{}
-          }
-        }
+          },
+          scope_hierarchy: ["first_scope", "second_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -267,29 +267,29 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.write_at("my_var", 42)
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => ["first_scope", "second_scope"],
                  "first_scope" => %{
                    "second_scope" => %{
                      "my_var" => 42
                    }
-                 }
-               }
+                 },
+                 scope_hierarchy: ["first_scope", "second_scope"]
+               },
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
 
     test "should correctly write in the current scope the current context" do
       # Setup with multiple contexts
       scope = %{
-        "context_list" => ["current_context", "other_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["my_scope"],
-          "my_scope" => %{}
+          "my_scope" => %{},
+          scope_hierarchy: ["my_scope"]
         },
         "other_context" => %{
-          "scope_hierarchy" => []
-        }
+          scope_hierarchy: []
+        },
+        context_list: ["current_context", "other_context"]
       }
 
       Process.put(:scope, scope)
@@ -297,16 +297,16 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.write_at("my_var", 42)
 
       assert %{
-               "context_list" => ["current_context", "other_context"],
                "current_context" => %{
-                 "scope_hierarchy" => ["my_scope"],
                  "my_scope" => %{
                    "my_var" => 42
-                 }
+                 },
+                 scope_hierarchy: ["my_scope"]
                },
                "other_context" => %{
-                 "scope_hierarchy" => []
-               }
+                 scope_hierarchy: []
+               },
+               context_list: ["current_context", "other_context"]
              } == Process.get(:scope)
     end
   end
@@ -314,11 +314,11 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
   describe "write_cascade/2" do
     test "should write the variable in the current scope if it doesn't exist anywhere" do
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["only_scope"],
-          "only_scope" => %{}
-        }
+          "only_scope" => %{},
+          scope_hierarchy: ["only_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -326,28 +326,28 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.write_cascade("my_var", 42)
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => ["only_scope"],
                  "only_scope" => %{
                    "my_var" => 42
-                 }
-               }
+                 },
+                 scope_hierarchy: ["only_scope"]
+               },
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
 
     test "should be able to write value where current value is nil" do
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["first_scope", "second_scope"],
           "first_scope" => %{
             "my_var" => nil,
             "second_scope" => %{
               "another_var" => 99
             }
-          }
-        }
+          },
+          scope_hierarchy: ["first_scope", "second_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -355,31 +355,31 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.write_cascade("my_var", 42)
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => ["first_scope", "second_scope"],
                  "first_scope" => %{
                    "my_var" => 42,
                    "second_scope" => %{
                      "another_var" => 99
                    }
-                 }
-               }
+                 },
+                 scope_hierarchy: ["first_scope", "second_scope"]
+               },
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
 
     test "should overwrite the variable in the closest parent scope" do
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["first_scope", "second_scope"],
           "first_scope" => %{
             "my_var" => 24,
             "second_scope" => %{
               "another_var" => 99
             }
-          }
-        }
+          },
+          scope_hierarchy: ["first_scope", "second_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -387,32 +387,32 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.write_cascade("my_var", 42)
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => ["first_scope", "second_scope"],
                  "first_scope" => %{
                    "my_var" => 42,
                    "second_scope" => %{
                      "another_var" => 99
                    }
-                 }
-               }
+                 },
+                 scope_hierarchy: ["first_scope", "second_scope"]
+               },
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
 
     test "should not overwrite protected global variable" do
       scope = %{
-        "context_list" => ["current_context"],
-        :im_protected => 123,
         "current_context" => %{
-          "scope_hierarchy" => ["first_scope", "second_scope"],
           "first_scope" => %{
             "my_var" => 24,
             "second_scope" => %{
               "another_var" => 99
             }
-          }
-        }
+          },
+          scope_hierarchy: ["first_scope", "second_scope"]
+        },
+        context_list: ["current_context"],
+        im_protected: 123
       }
 
       Process.put(:scope, scope)
@@ -420,34 +420,34 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.write_cascade("im_protected", 42)
 
       assert %{
-               "context_list" => ["current_context"],
-               :im_protected => 123,
                "current_context" => %{
-                 "scope_hierarchy" => ["first_scope", "second_scope"],
                  "first_scope" => %{
                    "my_var" => 24,
                    "second_scope" => %{
                      "another_var" => 99,
                      "im_protected" => 42
                    }
-                 }
-               }
+                 },
+                 scope_hierarchy: ["first_scope", "second_scope"]
+               },
+               context_list: ["current_context"],
+               im_protected: 123
              } == Process.get(:scope)
     end
 
     test "should correctly overwrite variable in closest parent scope among multiple parent scopes" do
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["parent_scope", "child_scope", "grandchild_scope"],
           "parent_scope" => %{
             "my_var" => 11,
             "child_scope" => %{
               "my_var" => 24,
               "grandchild_scope" => %{}
             }
-          }
-        }
+          },
+          scope_hierarchy: ["parent_scope", "child_scope", "grandchild_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -455,27 +455,27 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.write_cascade("my_var", 42)
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => ["parent_scope", "child_scope", "grandchild_scope"],
                  "parent_scope" => %{
                    "my_var" => 11,
                    "child_scope" => %{
                      "my_var" => 42,
                      "grandchild_scope" => %{}
                    }
-                 }
-               }
+                 },
+                 scope_hierarchy: ["parent_scope", "child_scope", "grandchild_scope"]
+               },
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
 
     test "should overwrite global variable at the root level of scope" do
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => []
+          scope_hierarchy: []
         },
-        "global_var" => 55
+        "global_var" => 55,
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -483,11 +483,11 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Scope.write_cascade("global_var", 100)
 
       assert %{
-               "context_list" => ["current_context"],
                "current_context" => %{
-                 "scope_hierarchy" => []
+                 scope_hierarchy: []
                },
-               "global_var" => 100
+               "global_var" => 100,
+               context_list: ["current_context"]
              } == Process.get(:scope)
     end
   end
@@ -496,17 +496,17 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
     test "should read a variable from the current context's deepest scope" do
       # Initial scope setup with nested scopes and contexts
       scope = %{
-        "context_list" => ["current_context"],
         "global_var" => "global_value",
         "current_context" => %{
-          "scope_hierarchy" => ["first_scope", "second_scope"],
           "first_scope" => %{
             "var_in_first" => "value_in_first",
             "second_scope" => %{
               "var_in_second" => "value_in_second"
             }
-          }
-        }
+          },
+          scope_hierarchy: ["first_scope", "second_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -518,20 +518,20 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
     test "should read a variable from the current context when multiple contexts exist" do
       # Initial scope setup with nested scopes and multiple contexts
       scope = %{
-        "context_list" => ["current_context", "another_context"],
         "global_var" => "global_value",
         "current_context" => %{
-          "scope_hierarchy" => ["current_first_scope"],
           "current_first_scope" => %{
             "var_in_current" => "value_in_current"
-          }
+          },
+          scope_hierarchy: ["current_first_scope"]
         },
         "another_context" => %{
-          "scope_hierarchy" => ["another_first_scope"],
           "another_first_scope" => %{
             "var_in_another" => "value_in_another"
-          }
-        }
+          },
+          scope_hierarchy: ["another_first_scope"]
+        },
+        context_list: ["current_context", "another_context"]
       }
 
       Process.put(:scope, scope)
@@ -542,12 +542,12 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
 
     test "should cascade until the global scope when variable not found in context's scope" do
       scope = %{
-        "context_list" => ["current_context"],
         "global_var" => "global_value",
         "current_context" => %{
-          "scope_hierarchy" => ["only_scope"],
-          "only_scope" => %{}
-        }
+          "only_scope" => %{},
+          scope_hierarchy: ["only_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -557,13 +557,13 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
 
     test "should not be able to read protected global variables" do
       scope = %{
-        "context_list" => ["current_context"],
-        :time_now => 123,
         "global_var" => "global_value",
         "current_context" => %{
-          "scope_hierarchy" => ["only_scope"],
-          "only_scope" => %{}
-        }
+          "only_scope" => %{},
+          scope_hierarchy: ["only_scope"]
+        },
+        time_now: 123,
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -573,11 +573,11 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
 
     test "should return nil if variable not found even in the global scope" do
       scope = %{
-        "context_list" => ["current_context"],
         "current_context" => %{
-          "scope_hierarchy" => ["only_scope"],
-          "only_scope" => %{}
-        }
+          "only_scope" => %{},
+          scope_hierarchy: ["only_scope"]
+        },
+        context_list: ["current_context"]
       }
 
       Process.put(:scope, scope)
@@ -590,23 +590,23 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
     test "should read a map's property from the current context's scope when multiple contexts exist" do
       # Initial scope setup with nested scopes and multiple contexts
       scope = %{
-        "context_list" => ["current_context", "another_context"],
         "global_map" => %{"global_key" => "global_value"},
         "current_context" => %{
-          "scope_hierarchy" => ["current_first_scope", "current_second_scope"],
           "current_first_scope" => %{
             "map_in_current" => %{"key_in_current" => "value_in_current"},
             "current_second_scope" => %{
               "another_map" => %{"another_key" => "another_value"}
             }
-          }
+          },
+          scope_hierarchy: ["current_first_scope", "current_second_scope"]
         },
         "another_context" => %{
-          "scope_hierarchy" => ["another_first_scope"],
           "another_first_scope" => %{
             "map_in_another" => %{"key_in_another" => "value_in_another"}
-          }
-        }
+          },
+          scope_hierarchy: ["another_first_scope"]
+        },
+        context_list: ["current_context", "another_context"]
       }
 
       Process.put(:scope, scope)
@@ -712,7 +712,7 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
       Process.put(
         :scope,
         %{
-          "context_list" => [],
+          context_list: [],
           functions: %{
             {function_name, length(args_names)} => %{
               args: args_names,


### PR DESCRIPTION
To avoid having them available as "global variables".