### PR TITLE
Contract execution return explicit errors instead of contract_failure

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -51,9 +51,7 @@ defmodule Archethic.Contracts do
           nil | Transaction.t(),
           nil | Recipient.t(),
           Keyword.t()
-        ) ::
-          {:ok, nil | Transaction.t()}
-          | {:error, :contract_failure | :invalid_triggers_execution}
+        ) :: {:ok, nil | Transaction.t()} | {:error, String.t()}
   defdelegate execute_trigger(
                 trigger_type,
                 contract,

--- a/lib/archethic/contracts/interpreter/library/common/http_impl.ex
+++ b/lib/archethic/contracts/interpreter/library/common/http_impl.ex
@@ -38,6 +38,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImpl do
       {:ok, {:error, :threshold_reached}} ->
         raise Library.Error, message: "Http.fetch/1 response is bigger than threshold"
 
+      {:ok, {:error, :not_https}} ->
+        raise Library.Error, message: "Http.fetch/1 was called with a non https url"
+
       {:ok, {:error, _}} ->
         # Mint.HTTP.connect error
         # Mint.HTTP.stream error
@@ -49,7 +52,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImpl do
 
       nil ->
         # Task.shutdown
-        raise Library.Error, message: "Http.fetch/1 timed out for url: #{uri}"
+        raise Library.Error, message: "Http.fetch/1 timed out"
     end
   end
 
@@ -86,6 +89,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImpl do
         {{:ok, {:error, :threshold_reached}}, uri}, _ ->
           raise Library.Error,
             message: "Http.fetch_many/1 response is bigger than threshold for url: #{uri}"
+
+        {{:ok, {:error, :not_https}}, uri}, _ ->
+          raise Library.Error,
+            message: "Http.fetch_many/1 was called with a non https url: #{uri}"
 
         {{:ok, {:error, _}}, uri}, _ ->
           # Mint.HTTP.connect error

--- a/lib/archethic_web/api/jsonrpc/error.ex
+++ b/lib/archethic_web/api/jsonrpc/error.ex
@@ -37,7 +37,6 @@ defmodule ArchethicWeb.API.JsonRPC.Error do
   # Smart Contract context
   defp get_custom_code(:contract_failure), do: 203
   defp get_custom_code(:no_recipients), do: 204
-  defp get_custom_code(:invalid_triggers_execution), do: 205
   defp get_custom_code(:invalid_transaction_constraints), do: 206
   defp get_custom_code(:invalid_inherit_constraints), do: 207
   defp get_custom_code(:parsing_contract), do: 208

--- a/lib/archethic_web/api/rest/controllers/transaction_controller.ex
+++ b/lib/archethic_web/api/rest/controllers/transaction_controller.ex
@@ -248,22 +248,6 @@ defmodule ArchethicWeb.API.REST.TransactionController do
         {:error, "Network issue, please try again later."}
 
       # execute_contract errors
-      {:error, :contract_failure} ->
-        {:error, "Contract execution produced an error."}
-
-      {:error, :invalid_triggers_execution} ->
-        {:error, "Contract does not have a `actions triggered_by: transaction` block."}
-
-      {:error, :invalid_transaction_constraints} ->
-        {:error,
-         "Contract refused incoming transaction. Check the `condition transaction` block."}
-
-      {:error, :invalid_oracle_constraints} ->
-        {:error, "Contract refused incoming transaction. Check the `condition oracle` block."}
-
-      {:error, :invalid_inherit_constraints} ->
-        {:error, "Contract refused outcoming transaction. Check the `condition inherit` block."}
-
       # parse_contract errors
       {:error, reason} when is_binary(reason) ->
         {:error, reason}

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -669,18 +669,9 @@ defmodule Archethic.Contracts.InterpreterTest do
         end
       """
 
-      contract_tx = %Transaction{
-        type: :contract,
-        data: %TransactionData{
-          code: code
-        }
-      }
+      contract_tx = ContractFactory.create_valid_contract_tx(code)
 
-      incoming_tx = %Transaction{
-        type: :transfer,
-        data: %TransactionData{},
-        validation_stamp: ValidationStamp.generate_dummy()
-      }
+      incoming_tx = TransactionFactory.create_valid_transaction([])
 
       assert {:error, "division_by_zero - L8"} =
                Interpreter.execute_trigger(

--- a/test/archethic_web/api/jsonrpc/error_test.exs
+++ b/test/archethic_web/api/jsonrpc/error_test.exs
@@ -32,7 +32,6 @@ defmodule ArchethicWeb.API.JsonRPC.ErrorTest do
     test "should return custom error code for smart contract context" do
       assert %{"code" => 203} = Error.get_error({:custom_error, :contract_failure, ""})
       assert %{"code" => 204} = Error.get_error({:custom_error, :no_recipients, ""})
-      assert %{"code" => 205} = Error.get_error({:custom_error, :invalid_triggers_execution, ""})
 
       assert %{"code" => 206} =
                Error.get_error({:custom_error, :invalid_transaction_constraints, ""})


### PR DESCRIPTION
# Description

Contract execution error used to return always the same error. No more.
This is a first step in direction of #1197

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests + Playground

![Screenshot 2023-09-08 at 17-09-21 Archethic Playground](https://github.com/archethic-foundation/archethic-node/assets/74045243/2fa0a2bc-d6f3-43f7-9507-a5727ca4bb2d)


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
