### PR TITLE
Refactor contract ownerships

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -84,7 +84,7 @@ defmodule Archethic.Contracts do
     case get_function_from_contract(contract, function_name, args) do
       {:ok, function} ->
         constants = %{
-          "contract" => Constants.from_contract(contract_tx, contract_version),
+          "contract" => Constants.from_contract_transaction(contract_tx, contract_version),
           :time_now => DateTime.utc_now() |> DateTime.to_unix()
         }
 
@@ -357,8 +357,8 @@ defmodule Archethic.Contracts do
          datetime
        ) do
     %{
-      "previous" => Constants.from_contract(contract_tx, contract_version),
-      "next" => Constants.from_contract(transaction, contract_version),
+      "previous" => Constants.from_contract_transaction(contract_tx, contract_version),
+      "next" => Constants.from_contract_transaction(transaction, contract_version),
       :time_now => DateTime.to_unix(datetime),
       :functions => functions
     }
@@ -372,7 +372,7 @@ defmodule Archethic.Contracts do
        ) do
     %{
       "transaction" => Constants.from_transaction(transaction, contract_version),
-      "contract" => Constants.from_contract(contract_tx, contract_version),
+      "contract" => Constants.from_contract_transaction(contract_tx, contract_version),
       :time_now => DateTime.to_unix(datetime),
       :functions => functions
     }

--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -76,11 +76,15 @@ defmodule Archethic.Contracts do
           | {:error, :function_is_private}
           | {:error, :timeout}
 
-  def execute_function(contract = %Contract{transaction: contract_tx}, function_name, args) do
+  def execute_function(
+        contract = %Contract{transaction: contract_tx, version: contract_version},
+        function_name,
+        args
+      ) do
     case get_function_from_contract(contract, function_name, args) do
       {:ok, function} ->
         constants = %{
-          "contract" => Constants.from_contract(contract_tx),
+          "contract" => Constants.from_contract(contract_tx, contract_version),
           :time_now => DateTime.utc_now() |> DateTime.to_unix()
         }
 
@@ -348,13 +352,13 @@ defmodule Archethic.Contracts do
 
   defp get_condition_constants(
          :inherit,
-         %Contract{transaction: contract_tx, functions: functions},
+         %Contract{transaction: contract_tx, functions: functions, version: contract_version},
          transaction,
          datetime
        ) do
     %{
-      "previous" => Constants.from_contract(contract_tx),
-      "next" => Constants.from_contract(transaction),
+      "previous" => Constants.from_contract(contract_tx, contract_version),
+      "next" => Constants.from_contract(transaction, contract_version),
       :time_now => DateTime.to_unix(datetime),
       :functions => functions
     }
@@ -362,13 +366,13 @@ defmodule Archethic.Contracts do
 
   defp get_condition_constants(
          _,
-         %Contract{transaction: contract_tx, functions: functions},
+         %Contract{transaction: contract_tx, functions: functions, version: contract_version},
          transaction,
          datetime
        ) do
     %{
-      "transaction" => Constants.from_transaction(transaction),
-      "contract" => Constants.from_contract(contract_tx),
+      "transaction" => Constants.from_transaction(transaction, contract_version),
+      "contract" => Constants.from_contract(contract_tx, contract_version),
       :time_now => DateTime.to_unix(datetime),
       :functions => functions
     }

--- a/lib/archethic/contracts/contract/constants.ex
+++ b/lib/archethic/contracts/contract/constants.ex
@@ -10,7 +10,6 @@ defmodule Archethic.Contracts.ContractConstants do
   alias Archethic.TransactionChain.TransactionData.Ledger
   alias Archethic.TransactionChain.TransactionData.TokenLedger
   alias Archethic.TransactionChain.TransactionData.TokenLedger.Transfer, as: TokenTransfer
-  alias Archethic.TransactionChain.TransactionData.Ownership
   alias Archethic.TransactionChain.TransactionData.UCOLedger
   alias Archethic.TransactionChain.TransactionData.UCOLedger.Transfer, as: UCOTransfer
   alias Archethic.TransactionChain.Transaction.ValidationStamp
@@ -57,13 +56,7 @@ defmodule Archethic.Contracts.ContractConstants do
       "type" => Atom.to_string(type),
       "content" => content,
       "code" => code,
-      "authorized_keys" =>
-        ownerships
-        |> Enum.map(& &1.authorized_keys)
-        |> Enum.flat_map(& &1),
-      "authorized_public_keys" =>
-        Enum.flat_map(ownerships, &Ownership.list_authorized_public_keys(&1)),
-      "secrets" => Enum.map(ownerships, & &1.secret),
+      "ownerships" => ownerships,
       "previous_public_key" => previous_public_key,
       "recipients" => Enum.map(recipients, & &1.address),
       "uco_transfers" =>

--- a/lib/archethic/contracts/contract/constants.ex
+++ b/lib/archethic/contracts/contract/constants.ex
@@ -8,6 +8,7 @@ defmodule Archethic.Contracts.ContractConstants do
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Ledger
+  alias Archethic.TransactionChain.TransactionData.Ownership
   alias Archethic.TransactionChain.TransactionData.TokenLedger
   alias Archethic.TransactionChain.TransactionData.TokenLedger.Transfer, as: TokenTransfer
   alias Archethic.TransactionChain.TransactionData.UCOLedger
@@ -22,46 +23,59 @@ defmodule Archethic.Contracts.ContractConstants do
   @doc """
   Same as from_transaction but remove the contract_seed from ownerships
   """
-  @spec from_contract(contract_tx :: Transaction.t()) :: map()
-  def from_contract(contract_tx),
-    do: contract_tx |> Contract.remove_seed_ownership() |> from_transaction()
+  @spec from_contract(contract_tx :: Transaction.t(), contract_version :: non_neg_integer()) ::
+          map()
+  def from_contract(contract_tx, contract_version \\ 1),
+    do: contract_tx |> Contract.remove_seed_ownership() |> from_transaction(contract_version)
 
   @doc """
   Extract constants from a transaction into a map
   This is a destructive operation. Some fields are not present in the resulting map.
   """
-  @spec from_transaction(Transaction.t()) :: map()
-  def from_transaction(%Transaction{
-        address: address,
-        type: type,
-        previous_public_key: previous_public_key,
-        data: %TransactionData{
-          content: content,
-          code: code,
-          ownerships: ownerships,
-          ledger: %Ledger{
-            uco: %UCOLedger{
-              transfers: uco_transfers
+  @spec from_transaction(transaction :: Transaction.t(), contract_version :: non_neg_integer()) ::
+          map()
+  def from_transaction(
+        %Transaction{
+          address: address,
+          type: type,
+          previous_public_key: previous_public_key,
+          data: %TransactionData{
+            content: content,
+            code: code,
+            ownerships: ownerships,
+            ledger: %Ledger{
+              uco: %UCOLedger{
+                transfers: uco_transfers
+              },
+              token: %TokenLedger{
+                transfers: token_transfers
+              }
             },
-            token: %TokenLedger{
-              transfers: token_transfers
-            }
+            recipients: recipients
           },
-          recipients: recipients
+          validation_stamp: validation_stamp
         },
-        validation_stamp: validation_stamp
-      }) do
-    %{
-      "address" => address,
+        contract_version \\ 1
+      ) do
+    map = %{
+      "address" => Base.encode16(address),
       "type" => Atom.to_string(type),
       "content" => content,
       "code" => code,
-      "ownerships" => ownerships,
-      "previous_public_key" => previous_public_key,
-      "recipients" => Enum.map(recipients, & &1.address),
+      "ownerships" =>
+        Enum.map(ownerships, fn %Ownership{secret: secret, authorized_keys: authorized_keys} ->
+          authorized_keys =
+            Enum.into(authorized_keys, %{}, fn {public_key, encrypted_key} ->
+              {Base.encode16(public_key), Base.encode16(encrypted_key)}
+            end)
+
+          %{"secret" => Base.encode16(secret), "authorized_keys" => authorized_keys}
+        end),
+      "previous_public_key" => Base.encode16(previous_public_key),
+      "recipients" => Enum.map(recipients, &Base.encode16(&1.address)),
       "uco_transfers" =>
         Enum.reduce(uco_transfers, %{}, fn %UCOTransfer{to: to, amount: amount}, acc ->
-          Map.update(acc, to, amount, &(&1 + amount))
+          Map.update(acc, Base.encode16(to), amount, &(&1 + amount))
         end),
       "uco_movements" =>
         case validation_stamp do
@@ -74,7 +88,7 @@ defmodule Archethic.Contracts.ContractConstants do
             transaction_movements
             |> Enum.filter(&(&1.type == :UCO))
             |> Enum.reduce(%{}, fn %TransactionMovement{to: to, amount: amount}, acc ->
-              Map.update(acc, to, amount, &(&1 + amount))
+              Map.update(acc, Base.encode16(to), amount, &(&1 + amount))
             end)
         end,
       "token_transfers" =>
@@ -87,11 +101,11 @@ defmodule Archethic.Contracts.ContractConstants do
                                              acc ->
           token_transfer = %{
             "amount" => amount,
-            "token_address" => token_address,
+            "token_address" => Base.encode16(token_address),
             "token_id" => token_id
           }
 
-          Map.update(acc, to, [token_transfer], &[token_transfer | &1])
+          Map.update(acc, Base.encode16(to), [token_transfer], &[token_transfer | &1])
         end),
       "token_movements" =>
         case validation_stamp do
@@ -111,11 +125,11 @@ defmodule Archethic.Contracts.ContractConstants do
                                    acc ->
               token_transfer = %{
                 "amount" => amount,
-                "token_address" => token_address,
+                "token_address" => Base.encode16(token_address),
                 "token_id" => token_id
               }
 
-              Map.update(acc, to, [token_transfer], &[token_transfer | &1])
+              Map.update(acc, Base.encode16(to), [token_transfer], &[token_transfer | &1])
             end)
         end,
       "timestamp" =>
@@ -128,103 +142,11 @@ defmodule Archethic.Contracts.ContractConstants do
             DateTime.to_unix(timestamp)
         end
     }
+
+    if contract_version == 0, do: map, else: cast_transaction_amount_to_float(map)
   end
 
-  @doc """
-  Stringify binary transaction values
-  """
-  @spec stringify_transaction(map()) :: map()
-  def stringify_transaction(constants = %{}) do
-    %{
-      "address" => apply_not_nil(constants, "address", &Base.encode16/1),
-      "type" => Map.get(constants, "type"),
-      "content" => Map.get(constants, "content"),
-      "code" => Map.get(constants, "code"),
-      "authorized_keys" =>
-        apply_not_nil(constants, "authorized_keys", fn authorized_keys ->
-          authorized_keys
-          |> Enum.map(fn {public_key, encrypted_secret_key} ->
-            {Base.encode16(public_key), Base.encode16(encrypted_secret_key)}
-          end)
-          |> Enum.into(%{})
-        end),
-      "authorized_public_keys" =>
-        apply_not_nil(constants, "authorized_public_keys", fn public_keys ->
-          Enum.map(public_keys, &Base.encode16/1)
-        end),
-      "secrets" =>
-        apply_not_nil(constants, "secrets", fn secrets ->
-          Enum.map(secrets, &Base.encode16/1)
-        end),
-      "previous_public_key" => apply_not_nil(constants, "previous_public_key", &Base.encode16/1),
-      "recipients" =>
-        apply_not_nil(constants, "recipients", fn recipients ->
-          Enum.map(recipients, &Base.encode16/1)
-        end),
-      "uco_transfers" => apply_not_nil(constants, "uco_transfers", &uco_movements_to_string/1),
-      "uco_movements" => apply_not_nil(constants, "uco_movements", &uco_movements_to_string/1),
-      "token_transfers" =>
-        apply_not_nil(constants, "token_transfers", &token_movements_to_string/1),
-      "token_movements" =>
-        apply_not_nil(constants, "token_movements", &token_movements_to_string/1),
-      "timestamp" => Map.get(constants, "timestamp")
-    }
-  end
-
-  defp uco_movements_to_string(transfers) do
-    transfers
-    |> Enum.map(fn {to, amount} ->
-      {Base.encode16(to), amount}
-    end)
-    |> Enum.into(%{})
-  end
-
-  defp token_movements_to_string(transfers) do
-    transfers
-    |> Enum.map(fn {to, transfers} ->
-      {Base.encode16(to),
-       Enum.map(transfers, fn transfer ->
-         Map.update!(transfer, "token_address", &Base.encode16/1)
-       end)}
-    end)
-    |> Enum.into(%{})
-  end
-
-  @doc """
-  Apply a function on all transactions of the constants map
-  """
-  @spec map_transactions(map(), fun()) :: map()
-  def map_transactions(constants, func) do
-    Enum.map(constants, fn
-      {name, nil} ->
-        # ex: transaction might be nil when trigger=interval|datetime
-        {name, nil}
-
-      # conditions constants
-      {"next", map} ->
-        {"next", func.(map)}
-
-      {"previous", map} ->
-        {"previous", func.(map)}
-
-      # both
-      {"transaction", map} ->
-        {"transaction", func.(map)}
-
-      {"contract", map} ->
-        {"contract", func.(map)}
-
-      other ->
-        other
-    end)
-    |> Enum.into(%{})
-  end
-
-  @doc """
-  Divide every transfers' amount by 100_000_000 so the user can use `amount: 1` for 1 UCO/Token
-  """
-  @spec cast_transaction_amount_to_float(map()) :: map()
-  def cast_transaction_amount_to_float(transaction) do
+  defp cast_transaction_amount_to_float(transaction) do
     transaction
     |> Map.update!("uco_transfers", &cast_uco_movements_to_float/1)
     |> Map.update!("uco_movements", &cast_uco_movements_to_float/1)
@@ -250,15 +172,5 @@ defmodule Archethic.Contracts.ContractConstants do
 
   defp convert_token_transfer_amount_to_bigint(token_transfer) do
     Map.update!(token_transfer, "amount", &Utils.from_bigint/1)
-  end
-
-  defp apply_not_nil(map, key, fun) do
-    case Map.get(map, key) do
-      nil ->
-        nil
-
-      val ->
-        fun.(val)
-    end
   end
 end

--- a/lib/archethic/contracts/contract/constants.ex
+++ b/lib/archethic/contracts/contract/constants.ex
@@ -23,9 +23,12 @@ defmodule Archethic.Contracts.ContractConstants do
   @doc """
   Same as from_transaction but remove the contract_seed from ownerships
   """
-  @spec from_contract(contract_tx :: Transaction.t(), contract_version :: non_neg_integer()) ::
+  @spec from_contract_transaction(
+          contract_tx :: Transaction.t(),
+          contract_version :: non_neg_integer()
+        ) ::
           map()
-  def from_contract(contract_tx, contract_version \\ 1),
+  def from_contract_transaction(contract_tx, contract_version \\ 1),
     do: contract_tx |> Contract.remove_seed_ownership() |> from_transaction(contract_version)
 
   @doc """

--- a/lib/archethic/contracts/contract/constants.ex
+++ b/lib/archethic/contracts/contract/constants.ex
@@ -3,6 +3,8 @@ defmodule Archethic.Contracts.ContractConstants do
   Represents the smart contract constants and bindings
   """
 
+  alias Archethic.Contracts.Contract
+
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Ledger
@@ -17,6 +19,13 @@ defmodule Archethic.Contracts.ContractConstants do
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.TransactionMovement
 
   alias Archethic.Utils
+
+  @doc """
+  Same as from_transaction but remove the contract_seed from ownerships
+  """
+  @spec from_contract(contract_tx :: Transaction.t()) :: map()
+  def from_contract(contract_tx),
+    do: contract_tx |> Contract.remove_seed_ownership() |> from_transaction()
 
   @doc """
   Extract constants from a transaction into a map

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -159,10 +159,10 @@ defmodule Archethic.Contracts.Interpreter do
           case maybe_trigger_tx do
             nil -> nil
             # :oracle & :transaction
-            trigger_tx -> Constants.from_transaction(trigger_tx)
+            trigger_tx -> Constants.from_transaction(trigger_tx, version)
           end
 
-        contract_constants = Constants.from_contract(contract_tx)
+        contract_constants = Constants.from_contract(contract_tx, version)
 
         constants =
           named_action_constants

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -162,7 +162,7 @@ defmodule Archethic.Contracts.Interpreter do
             trigger_tx -> Constants.from_transaction(trigger_tx, version)
           end
 
-        contract_constants = Constants.from_contract(contract_tx, version)
+        contract_constants = Constants.from_contract_transaction(contract_tx, version)
 
         constants =
           named_action_constants

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -162,7 +162,7 @@ defmodule Archethic.Contracts.Interpreter do
             trigger_tx -> Constants.from_transaction(trigger_tx)
           end
 
-        contract_constants = Constants.from_transaction(contract_tx)
+        contract_constants = Constants.from_contract(contract_tx)
 
         constants =
           named_action_constants

--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -46,11 +46,11 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
   """
   @spec execute(ast :: any(), constants :: map(), previous_contract_tx :: Transaction.t()) ::
           Transaction.t() | nil
-  def execute(ast, constants, previous_contract_tx) do
+  def execute(ast, constants, %Transaction{data: %TransactionData{code: code}}) do
     :ok = Macro.validate(ast)
 
     # initiate a transaction that will be used by the "Contract" module
-    initial_next_tx = truncate_transaction(previous_contract_tx)
+    initial_next_tx = %Transaction{type: :contract, data: %TransactionData{code: code}}
 
     # Apply some transformations to the transactions
     # We do it here because the Constants module is still used by InterpreterLegacy
@@ -194,21 +194,4 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
   # ----------------------------------------------------------------------
 
   defp postwalk(node, acc), do: CommonInterpreter.postwalk(node, acc)
-
-  # keep only the transaction fields we are interested in
-  # these are all the fields that are copied from `prev_tx` to `next_tx`
-  defp truncate_transaction(%Transaction{
-         data: %TransactionData{
-           code: code,
-           ownerships: ownerships
-         }
-       }) do
-    %Transaction{
-      type: :contract,
-      data: %TransactionData{
-        code: code,
-        ownerships: ownerships
-      }
-    }
-  end
 end

--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -5,7 +5,6 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
   alias Archethic.TransactionChain.TransactionData
 
   alias Archethic.Contracts.Contract
-  alias Archethic.Contracts.ContractConstants, as: Constants
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.Contracts.Interpreter.CommonInterpreter
   alias Archethic.Contracts.Interpreter.FunctionKeys
@@ -52,16 +51,8 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
     # initiate a transaction that will be used by the "Contract" module
     initial_next_tx = %Transaction{type: :contract, data: %TransactionData{code: code}}
 
-    # Apply some transformations to the transactions
-    # We do it here because the Constants module is still used by InterpreterLegacy
-    # also, constants should already contains the global variables:
-    #   - "contract": current contract transaction
-    #   - "transaction": the incoming transaction (when trigger=transaction|oracle)
-    #   - :time_now: the time returned by Time.now()
     constants =
       constants
-      |> Constants.map_transactions(&Constants.stringify_transaction/1)
-      |> Constants.map_transactions(&Constants.cast_transaction_amount_to_float/1)
       |> Map.put(:next_transaction, initial_next_tx)
       |> Map.put(:next_transaction_changed, false)
 

--- a/lib/archethic/contracts/interpreter/condition_validator.ex
+++ b/lib/archethic/contracts/interpreter/condition_validator.ex
@@ -5,7 +5,6 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
 
   """
   alias Archethic.Contracts.ContractConditions.Subjects, as: ConditionsSubjects
-  alias Archethic.Contracts.ContractConstants, as: Constants
   alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.Scope
 
@@ -16,13 +15,6 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
   """
   @spec valid_conditions?(ConditionsSubjects.t(), map()) :: boolean()
   def valid_conditions?(conditions, constants = %{}) do
-    # Apply some transformations to the transactions
-    # We do it here because the Constants module is still used by InterpreterLegacy
-    constants =
-      constants
-      |> Constants.map_transactions(&Constants.stringify_transaction/1)
-      |> Constants.map_transactions(&Constants.cast_transaction_amount_to_float/1)
-
     conditions
     |> Map.from_struct()
     |> Enum.all?(fn {field, condition} ->

--- a/lib/archethic/contracts/interpreter/function_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/function_interpreter.ex
@@ -1,8 +1,6 @@
 defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @moduledoc false
 
-  alias Archethic.Contracts.ContractConstants, as: Constants
-
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.Contracts.Interpreter.CommonInterpreter
   alias Archethic.Contracts.Interpreter.FunctionKeys
@@ -58,11 +56,6 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @spec execute(ast :: any(), constants :: map(), args_names :: list(), args_ast :: list()) ::
           result :: any()
   def execute(ast, constants, args_names \\ [], args_ast \\ []) do
-    constants =
-      constants
-      |> Constants.map_transactions(&Constants.stringify_transaction/1)
-      |> Constants.map_transactions(&Constants.cast_transaction_amount_to_float/1)
-
     Scope.execute(ast, constants, args_names, args_ast)
   end
 

--- a/lib/archethic/contracts/interpreter/legacy.ex
+++ b/lib/archethic/contracts/interpreter/legacy.ex
@@ -599,11 +599,12 @@ defmodule Archethic.Contracts.Interpreter.Legacy do
   defp chain_ownerships(
          acc = %{
            next_transaction: %Transaction{data: %TransactionData{ownerships: []}},
-           previous_transaction: %Transaction{
-             data: %TransactionData{ownerships: previous_ownerships}
-           }
+           previous_transaction: prev_tx
          }
        ) do
+    %Transaction{data: %TransactionData{ownerships: previous_ownerships}} =
+      Contract.remove_seed_ownership!(prev_tx)
+
     put_in(
       acc,
       [:next_transaction, Access.key(:data, %{}), Access.key(:ownerships)],

--- a/lib/archethic/contracts/interpreter/legacy/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/legacy/action_interpreter.ex
@@ -213,26 +213,10 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreter do
   end
 
   defp prewalk(
-         node = {{:atom, "secret_key"}, secret_key},
-         _acc = {:ok, %{scope: {:function, "add_ownership", {:actions, _}}}}
-       )
-       when not is_tuple(secret_key) and not is_binary(secret_key) do
-    throw({:error, "invalid add_ownership arguments", node})
-  end
-
-  defp prewalk(
-         node = {{:atom, "authorized_public_keys"}, authorized_public_keys},
+         node = {{:atom, "authorized_keys"}, authorized_public_keys},
          _acc = {:ok, %{scope: {:function, "add_ownership", {:actions, _}}}}
        )
        when not is_tuple(authorized_public_keys) and not is_list(authorized_public_keys) do
-    throw({:error, "invalid add_ownership arguments", node})
-  end
-
-  defp prewalk(
-         node = {{:atom, atom}, _},
-         _acc = {:ok, %{scope: {:function, "add_ownership", {:actions, _}}}}
-       )
-       when atom != "secret" and atom != "secret_key" and atom != "authorized_public_keys" do
     throw({:error, "invalid add_ownership arguments", node})
   end
 

--- a/lib/archethic/contracts/interpreter/legacy/condition_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/legacy/condition_interpreter.ex
@@ -2,7 +2,6 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ConditionInterpreter do
   @moduledoc false
 
   alias Archethic.Contracts.ContractConditions.Subjects, as: ConditionsSubjects
-  alias Archethic.Contracts.ContractConstants, as: Constants
   alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.Legacy.Library
   alias Archethic.Contracts.Interpreter.Legacy.UtilsInterpreter
@@ -487,10 +486,6 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ConditionInterpreter do
   """
   @spec valid_conditions?(ConditionsSubjects.t(), map()) :: boolean()
   def valid_conditions?(conditions = %ConditionsSubjects{}, constants = %{}) do
-    constants =
-      constants
-      |> Constants.map_transactions(&Constants.stringify_transaction/1)
-
     result =
       conditions
       |> Map.from_struct()

--- a/lib/archethic_web/api/jsonrpc/methods/simulate_contract_execution.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/simulate_contract_execution.ex
@@ -81,7 +81,9 @@ defmodule ArchethicWeb.API.JsonRPC.Method.SimulateContractExecution do
          {:ok, contract} <- validate_and_parse_contract_tx(contract_tx),
          trigger <- Contract.get_trigger_for_recipient(recipient),
          :ok <- validate_contract_condition(trigger, contract, trigger_tx, recipient, timestamp),
-         {:ok, next_tx} <- validate_and_execute_trigger(trigger, contract, trigger_tx, recipient) do
+         {:ok, next_tx} <- validate_and_execute_trigger(trigger, contract, trigger_tx, recipient),
+         # Here the index to sign transaction is not accurate has we are in simulation
+         {:ok, next_tx} <- Contract.sign_next_transaction(contract, next_tx, 0) do
       validate_contract_condition(:inherit, contract, next_tx, nil, timestamp)
     end
   end

--- a/test/archethic/contracts/contract/constants_test.exs
+++ b/test/archethic/contracts/contract/constants_test.exs
@@ -141,7 +141,8 @@ defmodule Archethic.Contracts.ContractConstantsTest do
 
       assert length(contract_tx.data.ownerships) == 2
 
-      assert %{"ownerships" => [^ownership_hex]} = ContractConstants.from_contract(contract_tx)
+      assert %{"ownerships" => [^ownership_hex]} =
+               ContractConstants.from_contract_transaction(contract_tx)
     end
   end
 end

--- a/test/archethic/contracts/contract/constants_test.exs
+++ b/test/archethic/contracts/contract/constants_test.exs
@@ -130,7 +130,7 @@ defmodule Archethic.Contracts.ContractConstantsTest do
 
       assert length(contract_tx.data.ownerships) == 2
 
-      assert %{"secrets" => ["secret"]} = ContractConstants.from_contract(contract_tx)
+      assert %{"ownerships" => ^ownerships} = ContractConstants.from_contract(contract_tx)
     end
   end
 end

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -17,6 +17,8 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
   alias Archethic.TransactionChain.TransactionData.TokenLedger
   alias Archethic.TransactionChain.TransactionData.TokenLedger.Transfer, as: TokenTransfer
 
+  alias Archethic.TransactionFactory
+
   doctest ActionInterpreter
 
   # ----------------------------------------------
@@ -1123,34 +1125,26 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
       end
       """
 
-      tx = %Transaction{
-        data: %TransactionData{
-          ledger: %Ledger{
-            token: %TokenLedger{
-              transfers: [
-                %TokenTransfer{
-                  to: address2,
-                  amount: Archethic.Utils.to_bigint(3.12345),
-                  token_address: token_address,
-                  token_id: 1
-                }
-              ]
-            },
-            uco: %UCOLedger{
-              transfers: [
-                %UCOTransfer{to: address, amount: Archethic.Utils.to_bigint(2)}
-              ]
+      ledger = %Ledger{
+        token: %TokenLedger{
+          transfers: [
+            %TokenTransfer{
+              to: address2,
+              amount: Archethic.Utils.to_bigint(3.12345),
+              token_address: token_address,
+              token_id: 1
             }
-          }
+          ]
+        },
+        uco: %UCOLedger{
+          transfers: [%UCOTransfer{to: address, amount: Archethic.Utils.to_bigint(2)}]
         }
       }
 
-      # FIXME: keys of transfers are binaries (should be hex), why?
+      tx = TransactionFactory.create_valid_transaction([], ledger: ledger)
 
       assert %Transaction{data: %TransactionData{content: "ok"}} =
-               sanitize_parse_execute(code, %{
-                 "transaction" => Constants.from_transaction(tx)
-               })
+               sanitize_parse_execute(code, %{"transaction" => Constants.from_transaction(tx)})
     end
 
     test "should keep the code by default" do

--- a/test/archethic/contracts/interpreter/condition_validator_test.exs
+++ b/test/archethic/contracts/interpreter/condition_validator_test.exs
@@ -51,8 +51,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
     end
 
@@ -91,8 +91,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
     end
 
@@ -110,8 +110,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
     end
 
@@ -140,8 +140,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
 
       code = ~s"""
@@ -156,8 +156,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
     end
 
@@ -294,8 +294,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
 
       code = ~s"""
@@ -313,8 +313,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
     end
 
@@ -334,8 +334,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
 
       code = ~s"""
@@ -353,8 +353,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
 
       code = ~s"""
@@ -372,8 +372,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
     end
 
@@ -396,8 +396,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
     end
 
@@ -439,8 +439,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
              |> ConditionInterpreter.parse([])
              |> elem(2)
              |> ConditionValidator.valid_conditions?(%{
-               "previous" => Constants.from_contract(previous_tx),
-               "next" => Constants.from_contract(next_tx)
+               "previous" => Constants.from_contract_transaction(previous_tx),
+               "next" => Constants.from_contract_transaction(next_tx)
              })
     end
   end

--- a/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
@@ -35,27 +35,53 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
                        [line: 2],
                        [
                          {:scope, [line: 2], nil},
-                         {:update_in, [line: 2],
-                          [
-                            {:scope, [line: 2], nil},
-                            ["next_transaction"],
-                            {:&, [line: 2],
-                             [
-                               {{:., [line: 2],
-                                 [
-                                   {:__aliases__,
-                                    [
-                                      alias:
-                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                    ], [:TransactionStatements]},
-                                   :set_type
-                                 ]}, [line: 2], [{:&, [line: 2], [1]}, "transfer"]}
-                             ]}
-                          ]}
+                         {
+                           :update_in,
+                           [line: 2],
+                           [
+                             {:scope, [line: 2], nil},
+                             ["next_transaction"],
+                             {
+                               :&,
+                               [line: 2],
+                               [
+                                 {
+                                   {
+                                     :.,
+                                     [line: 2],
+                                     [
+                                       {
+                                         :__aliases__,
+                                         [
+                                           alias:
+                                             Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                         ],
+                                         [:TransactionStatements]
+                                       },
+                                       :set_type
+                                     ]
+                                   },
+                                   [line: 2],
+                                   [{:&, [line: 2], [1]}, "transfer"]
+                                 }
+                               ]
+                             }
+                           ]
+                         }
                        ]
                      },
-                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
-                      [{:scope, [], nil}]}
+                     {
+                       {
+                         :.,
+                         [],
+                         [
+                           {:__aliases__, [alias: false], [:Function]},
+                           :identity
+                         ]
+                       },
+                       [],
+                       [{:scope, [], nil}]
+                     }
                    ]
                  },
                  {
@@ -67,35 +93,62 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
                        [line: 3],
                        [
                          {:scope, [line: 3], nil},
-                         {:update_in, [line: 3],
-                          [
-                            {:scope, [line: 3], nil},
-                            ["next_transaction"],
-                            {:&, [line: 3],
-                             [
-                               {{:., [line: 3],
-                                 [
-                                   {:__aliases__,
-                                    [
-                                      alias:
-                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                    ], [:TransactionStatements]},
-                                   :add_uco_transfer
-                                 ]}, [line: 3],
-                                [
-                                  {:&, [line: 3], [1]},
-                                  [
-                                    {"to",
-                                     "7F6661ACE282F947ACA2EF947D01BDDC90C65F09EE828BDADE2E3ED4258470B3"},
-                                    {"amount", 1_040_000_000}
-                                  ]
-                                ]}
-                             ]}
-                          ]}
+                         {
+                           :update_in,
+                           [line: 3],
+                           [
+                             {:scope, [line: 3], nil},
+                             ["next_transaction"],
+                             {
+                               :&,
+                               [line: 3],
+                               [
+                                 {
+                                   {
+                                     :.,
+                                     [line: 3],
+                                     [
+                                       {
+                                         :__aliases__,
+                                         [
+                                           alias:
+                                             Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                         ],
+                                         [:TransactionStatements]
+                                       },
+                                       :add_uco_transfer
+                                     ]
+                                   },
+                                   [line: 3],
+                                   [
+                                     {:&, [line: 3], [1]},
+                                     [
+                                       {
+                                         "to",
+                                         "7F6661ACE282F947ACA2EF947D01BDDC90C65F09EE828BDADE2E3ED4258470B3"
+                                       },
+                                       {"amount", 1_040_000_000}
+                                     ]
+                                   ]
+                                 }
+                               ]
+                             }
+                           ]
+                         }
                        ]
                      },
-                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
-                      [{:scope, [], nil}]}
+                     {
+                       {
+                         :.,
+                         [],
+                         [
+                           {:__aliases__, [alias: false], [:Function]},
+                           :identity
+                         ]
+                       },
+                       [],
+                       [{:scope, [], nil}]
+                     }
                    ]
                  },
                  {
@@ -107,38 +160,67 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
                        [line: 4],
                        [
                          {:scope, [line: 4], nil},
-                         {:update_in, [line: 4],
-                          [
-                            {:scope, [line: 4], nil},
-                            ["next_transaction"],
-                            {:&, [line: 4],
-                             [
-                               {{:., [line: 4],
-                                 [
-                                   {:__aliases__,
-                                    [
-                                      alias:
-                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                    ], [:TransactionStatements]},
-                                   :add_token_transfer
-                                 ]}, [line: 4],
-                                [
-                                  {:&, [line: 4], [1]},
-                                  [
-                                    {"to",
-                                     "30670455713E2CBECF94591226A903651ED8625635181DDA236FECC221D1E7E4"},
-                                    {"amount", 20_000_000_000},
-                                    {"token_address",
-                                     "AEB4A6F5AB6D82BE223C5867EBA5FE616F52F410DCF83B45AFF158DD40AE8AC3"},
-                                    {"token_id", 0}
-                                  ]
-                                ]}
-                             ]}
-                          ]}
+                         {
+                           :update_in,
+                           [line: 4],
+                           [
+                             {:scope, [line: 4], nil},
+                             ["next_transaction"],
+                             {
+                               :&,
+                               [line: 4],
+                               [
+                                 {
+                                   {
+                                     :.,
+                                     [line: 4],
+                                     [
+                                       {
+                                         :__aliases__,
+                                         [
+                                           alias:
+                                             Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                         ],
+                                         [:TransactionStatements]
+                                       },
+                                       :add_token_transfer
+                                     ]
+                                   },
+                                   [line: 4],
+                                   [
+                                     {:&, [line: 4], [1]},
+                                     [
+                                       {
+                                         "to",
+                                         "30670455713E2CBECF94591226A903651ED8625635181DDA236FECC221D1E7E4"
+                                       },
+                                       {"amount", 20_000_000_000},
+                                       {
+                                         "token_address",
+                                         "AEB4A6F5AB6D82BE223C5867EBA5FE616F52F410DCF83B45AFF158DD40AE8AC3"
+                                       },
+                                       {"token_id", 0}
+                                     ]
+                                   ]
+                                 }
+                               ]
+                             }
+                           ]
+                         }
                        ]
                      },
-                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
-                      [{:scope, [], nil}]}
+                     {
+                       {
+                         :.,
+                         [],
+                         [
+                           {:__aliases__, [alias: false], [:Function]},
+                           :identity
+                         ]
+                       },
+                       [],
+                       [{:scope, [], nil}]
+                     }
                    ]
                  },
                  {
@@ -150,27 +232,53 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
                        [line: 5],
                        [
                          {:scope, [line: 5], nil},
-                         {:update_in, [line: 5],
-                          [
-                            {:scope, [line: 5], nil},
-                            ["next_transaction"],
-                            {:&, [line: 5],
-                             [
-                               {{:., [line: 5],
-                                 [
-                                   {:__aliases__,
-                                    [
-                                      alias:
-                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                    ], [:TransactionStatements]},
-                                   :set_content
-                                 ]}, [line: 5], [{:&, [line: 5], [1]}, "Receipt"]}
-                             ]}
-                          ]}
+                         {
+                           :update_in,
+                           [line: 5],
+                           [
+                             {:scope, [line: 5], nil},
+                             ["next_transaction"],
+                             {
+                               :&,
+                               [line: 5],
+                               [
+                                 {
+                                   {
+                                     :.,
+                                     [line: 5],
+                                     [
+                                       {
+                                         :__aliases__,
+                                         [
+                                           alias:
+                                             Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                         ],
+                                         [:TransactionStatements]
+                                       },
+                                       :set_content
+                                     ]
+                                   },
+                                   [line: 5],
+                                   [{:&, [line: 5], [1]}, "Receipt"]
+                                 }
+                               ]
+                             }
+                           ]
+                         }
                        ]
                      },
-                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
-                      [{:scope, [], nil}]}
+                     {
+                       {
+                         :.,
+                         [],
+                         [
+                           {:__aliases__, [alias: false], [:Function]},
+                           :identity
+                         ]
+                       },
+                       [],
+                       [{:scope, [], nil}]
+                     }
                    ]
                  },
                  {
@@ -182,38 +290,65 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
                        [line: 6],
                        [
                          {:scope, [line: 6], nil},
-                         {:update_in, [line: 6],
-                          [
-                            {:scope, [line: 6], nil},
-                            ["next_transaction"],
-                            {:&, [line: 6],
-                             [
-                               {{:., [line: 6],
-                                 [
-                                   {:__aliases__,
-                                    [
-                                      alias:
-                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                    ], [:TransactionStatements]},
-                                   :add_ownership
-                                 ]}, [line: 6],
-                                [
-                                  {:&, [line: 6], [1]},
-                                  [
-                                    {"secret", "MyEncryptedSecret"},
-                                    {"secret_key", "MySecretKey"},
-                                    {"authorized_public_keys",
+                         {
+                           :update_in,
+                           [line: 6],
+                           [
+                             {:scope, [line: 6], nil},
+                             ["next_transaction"],
+                             {
+                               :&,
+                               [line: 6],
+                               [
+                                 {
+                                   {
+                                     :.,
+                                     [line: 6],
                                      [
-                                       "70C245E5D970B59DF65638BDD5D963EE22E6D892EA224D8809D0FB75D0B1907A"
-                                     ]}
-                                  ]
-                                ]}
-                             ]}
-                          ]}
+                                       {
+                                         :__aliases__,
+                                         [
+                                           alias:
+                                             Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                         ],
+                                         [:TransactionStatements]
+                                       },
+                                       :add_ownership
+                                     ]
+                                   },
+                                   [line: 6],
+                                   [
+                                     {:&, [line: 6], [1]},
+                                     [
+                                       {"secret", "MyEncryptedSecret"},
+                                       {
+                                         "authorized_keys",
+                                         [
+                                           {"70C245E5D970B59DF65638BDD5D963EE22E6D892EA224D8809D0FB75D0B1907A",
+                                            "MySecretKey"}
+                                         ]
+                                       }
+                                     ]
+                                   ]
+                                 }
+                               ]
+                             }
+                           ]
+                         }
                        ]
                      },
-                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
-                      [{:scope, [], nil}]}
+                     {
+                       {
+                         :.,
+                         [],
+                         [
+                           {:__aliases__, [alias: false], [:Function]},
+                           :identity
+                         ]
+                       },
+                       [],
+                       [{:scope, [], nil}]
+                     }
                    ]
                  },
                  {
@@ -222,34 +357,59 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
                    [
                      {
                        :=,
-                       [line: 7],
+                       [line: 10],
                        [
-                         {:scope, [line: 7], nil},
-                         {:update_in, [line: 7],
-                          [
-                            {:scope, [line: 7], nil},
-                            ["next_transaction"],
-                            {:&, [line: 7],
-                             [
-                               {{:., [line: 7],
-                                 [
-                                   {:__aliases__,
-                                    [
-                                      alias:
-                                        Archethic.Contracts.Interpreter.Legacy.TransactionStatements
-                                    ], [:TransactionStatements]},
-                                   :add_recipient
-                                 ]}, [line: 7],
-                                [
-                                  {:&, [line: 7], [1]},
-                                  "78273C5CBCEB8617F54380CC2F173DF2404DB676C9F10D546B6F395E6F3BDDEE"
-                                ]}
-                             ]}
-                          ]}
+                         {:scope, [line: 10], nil},
+                         {
+                           :update_in,
+                           [line: 10],
+                           [
+                             {:scope, [line: 10], nil},
+                             ["next_transaction"],
+                             {
+                               :&,
+                               [line: 10],
+                               [
+                                 {
+                                   {
+                                     :.,
+                                     [line: 10],
+                                     [
+                                       {
+                                         :__aliases__,
+                                         [
+                                           alias:
+                                             Archethic.Contracts.Interpreter.Legacy.TransactionStatements
+                                         ],
+                                         [:TransactionStatements]
+                                       },
+                                       :add_recipient
+                                     ]
+                                   },
+                                   [line: 10],
+                                   [
+                                     {:&, [line: 10], [1]},
+                                     "78273C5CBCEB8617F54380CC2F173DF2404DB676C9F10D546B6F395E6F3BDDEE"
+                                   ]
+                                 }
+                               ]
+                             }
+                           ]
+                         }
                        ]
                      },
-                     {{:., [], [{:__aliases__, [alias: false], [:Function]}, :identity]}, [],
-                      [{:scope, [], nil}]}
+                     {
+                       {
+                         :.,
+                         [],
+                         [
+                           {:__aliases__, [alias: false], [:Function]},
+                           :identity
+                         ]
+                       },
+                       [],
+                       [{:scope, [], nil}]
+                     }
                    ]
                  }
                ]
@@ -261,7 +421,10 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
                add_uco_transfer to: \"7F6661ACE282F947ACA2EF947D01BDDC90C65F09EE828BDADE2E3ED4258470B3\", amount: 1040000000
                add_token_transfer to: \"30670455713E2CBECF94591226A903651ED8625635181DDA236FECC221D1E7E4\", amount: 20000000000, token_address: \"AEB4A6F5AB6D82BE223C5867EBA5FE616F52F410DCF83B45AFF158DD40AE8AC3\", token_id: 0
                set_content \"Receipt\"
-               add_ownership secret: \"MyEncryptedSecret\", secret_key: \"MySecretKey\", authorized_public_keys: ["70C245E5D970B59DF65638BDD5D963EE22E6D892EA224D8809D0FB75D0B1907A"]
+               add_ownership(
+                secret: \"MyEncryptedSecret\",
+                authorized_keys: ["70C245E5D970B59DF65638BDD5D963EE22E6D892EA224D8809D0FB75D0B1907A": \"MySecretKey\"]
+               )
                add_recipient \"78273C5CBCEB8617F54380CC2F173DF2404DB676C9F10D546B6F395E6F3BDDEE\"
              end
              """
@@ -578,10 +741,10 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
                |> elem(1)
                |> ActionInterpreter.parse()
 
-      assert {:error, "invalid add_ownership arguments - authorized_public_keys"} =
+      assert {:error, "invalid add_ownership arguments - authorized_keys"} =
                ~S"""
                actions triggered_by: transaction do
-                add_ownership secret: "ABC123", secret_key: "s3cr3t", authorized_public_keys: 42
+                add_ownership secret: "ABC123", authorized_keys: 42
                end
                """
                |> Interpreter.sanitize_code()

--- a/test/archethic/contracts/interpreter/legacy/transaction_statements_test.exs
+++ b/test/archethic/contracts/interpreter/legacy/transaction_statements_test.exs
@@ -14,5 +14,7 @@ defmodule Archethic.Contracts.Interpreter.Legacy.TransactionStatementsTest do
   alias Archethic.TransactionChain.TransactionData.UCOLedger
   alias Archethic.TransactionChain.TransactionData.UCOLedger.Transfer, as: UCOTransfer
 
+  import ArchethicCase
+
   doctest TransactionStatements
 end

--- a/test/archethic/contracts/interpreter/library/common/chain_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/chain_test.exs
@@ -25,6 +25,8 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
 
+  alias Archethic.TransactionFactory
+
   import Mox
 
   doctest Chain
@@ -165,19 +167,13 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
 
   describe "get_transaction/1" do
     test "should return the existing transaction" do
-      address = random_address()
+      tx =
+        %Transaction{address: address} =
+        TransactionFactory.create_valid_transaction([], content: "Gloubi-Boulga")
 
       MockClient
       |> expect(:send_message, fn
-        _, %GetTransaction{address: ^address}, _ ->
-          {:ok,
-           %Transaction{
-             address: address,
-             type: :data,
-             data: %TransactionData{
-               content: "Gloubi-Boulga"
-             }
-           }}
+        _, %GetTransaction{address: ^address}, _ -> {:ok, tx}
       end)
 
       code = ~s"""

--- a/test/archethic/contracts/interpreter/library/common/contract_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/contract_test.exs
@@ -432,9 +432,7 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
                        ^pub_key1 => _
                      },
                      secret: "ENCODED_SECRET1"
-                   },
-                   # Contract seed
-                   %Ownership{}
+                   }
                  ]
                }
              } = sanitize_parse_execute(code)
@@ -465,9 +463,7 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
                        ^pub_key1 => _
                      },
                      secret: "ENCODED_SECRET1"
-                   },
-                   # Contract seed
-                   %Ownership{}
+                   }
                  ]
                }
              } = sanitize_parse_execute(code)
@@ -491,9 +487,7 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
                        ^pub_key1 => _
                      },
                      secret: "ENCODED_SECRET1"
-                   },
-                   # Contract seed
-                   %Ownership{}
+                   }
                  ]
                }
              } = sanitize_parse_execute(code)
@@ -661,9 +655,7 @@ defmodule Archethic.Contracts.Interpreter.Library.ContractTest do
                        ^pub_key1 => _
                      },
                      secret: "ENCODED_SECRET1"
-                   },
-                   # Contract seed
-                   %Ownership{}
+                   }
                  ]
                }
              } = sanitize_parse_execute(code)

--- a/test/archethic/contracts/interpreter/library/common/regex_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/regex_test.exs
@@ -64,7 +64,6 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.RegexTest do
       actions triggered_by: transaction do
         x = Regex.extract("Michael,twelve", "\\\\d+")
         if x == "" do
-          # FIXME: I can't do set_content("") apparently
           Contract.set_content "no match"
         end
       end

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -370,6 +370,36 @@ defmodule Archethic.Contracts.InterpreterTest do
                )
     end
 
+    test "should execute a contract v0 with constants" do
+      code = """
+      condition transaction: []
+      actions triggered_by: transaction do
+        toto = transaction.address
+        set_content toto
+      end
+      """
+
+      contract_tx = ContractFactory.create_valid_contract_tx(code)
+
+      incoming_tx =
+        %Transaction{address: tx_address} = TransactionFactory.create_valid_transaction([])
+
+      tx_address_hex = Base.encode16(tx_address)
+
+      assert {:ok,
+              %Transaction{
+                data: %TransactionData{
+                  content: ^tx_address_hex
+                }
+              }} =
+               Interpreter.execute_trigger(
+                 {:transaction, nil, nil},
+                 Contract.from_transaction!(contract_tx),
+                 incoming_tx,
+                 nil
+               )
+    end
+
     test "should be able to use a custom function call as parameter" do
       code = """
       @version 1

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -5,9 +5,6 @@ defmodule Archethic.ContractsTest do
   alias Archethic.Contracts.Contract
   alias Archethic.P2P
   alias Archethic.P2P.Node
-  alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.Transaction.ValidationStamp
-  alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Ledger
   alias Archethic.TransactionChain.TransactionData.Recipient
   alias Archethic.TransactionChain.TransactionData.UCOLedger
@@ -15,8 +12,6 @@ defmodule Archethic.ContractsTest do
 
   alias Archethic.ContractFactory
   alias Archethic.TransactionFactory
-
-  import ArchethicCase
 
   @moduletag capture_log: true
 
@@ -486,11 +481,7 @@ defmodule Archethic.ContractsTest do
 
       contract_tx = ContractFactory.create_valid_contract_tx(code)
 
-      incoming_tx = %Transaction{
-        type: :transfer,
-        data: %TransactionData{},
-        validation_stamp: ValidationStamp.generate_dummy()
-      }
+      incoming_tx = TransactionFactory.create_valid_transaction([])
 
       assert Contracts.valid_condition?(
                {:transaction, nil, nil},
@@ -517,13 +508,7 @@ defmodule Archethic.ContractsTest do
 
       contract_tx = ContractFactory.create_valid_contract_tx(code)
 
-      incoming_tx = %Transaction{
-        type: :transfer,
-        data: %TransactionData{
-          content: "I'm a content"
-        },
-        validation_stamp: ValidationStamp.generate_dummy()
-      }
+      incoming_tx = TransactionFactory.create_valid_transaction([], content: "I'm a content")
 
       refute Contracts.valid_condition?(
                {:transaction, nil, nil},
@@ -552,13 +537,7 @@ defmodule Archethic.ContractsTest do
 
       contract_tx = ContractFactory.create_valid_contract_tx(code)
 
-      incoming_tx = %Transaction{
-        type: :transfer,
-        data: %TransactionData{
-          content: "tresor"
-        },
-        validation_stamp: ValidationStamp.generate_dummy()
-      }
+      incoming_tx = TransactionFactory.create_valid_transaction([], content: "tresor")
 
       assert Contracts.valid_condition?(
                {:transaction, nil, nil},
@@ -583,12 +562,7 @@ defmodule Archethic.ContractsTest do
 
       contract_tx = ContractFactory.create_valid_contract_tx(code)
 
-      oracle_tx = %Transaction{
-        type: :oracle,
-        address: random_address(),
-        data: %TransactionData{},
-        validation_stamp: ValidationStamp.generate_dummy()
-      }
+      oracle_tx = TransactionFactory.create_valid_transaction([], type: :oracle)
 
       assert Contracts.valid_condition?(
                :oracle,
@@ -613,12 +587,7 @@ defmodule Archethic.ContractsTest do
 
       contract_tx = ContractFactory.create_valid_contract_tx(code)
 
-      oracle_tx = %Transaction{
-        address: random_address(),
-        type: :oracle,
-        data: %TransactionData{content: "{}"},
-        validation_stamp: ValidationStamp.generate_dummy()
-      }
+      oracle_tx = TransactionFactory.create_valid_transaction([], type: :oracle, content: "{}")
 
       assert Contracts.valid_condition?(
                :oracle,
@@ -643,12 +612,7 @@ defmodule Archethic.ContractsTest do
 
       contract_tx = ContractFactory.create_valid_contract_tx(code)
 
-      oracle_tx = %Transaction{
-        address: random_address(),
-        type: :oracle,
-        data: %TransactionData{content: ""},
-        validation_stamp: ValidationStamp.generate_dummy()
-      }
+      oracle_tx = TransactionFactory.create_valid_transaction([], type: :oracle, content: "")
 
       refute Contracts.valid_condition?(
                :oracle,

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -132,6 +132,7 @@ defmodule Archethic.ContractsTest do
 
     test "should return true when the inherit constraint match and when no trigger is specified" do
       code = """
+      @version 1
       condition inherit: [
         content: "hello"
       ]
@@ -209,6 +210,28 @@ defmodule Archethic.ContractsTest do
       @version 1
       actions triggered_by: datetime, at: #{DateTime.to_unix(now)} do
         Contract.set_content "wake up"
+      end
+      """
+
+      prev_tx = ContractFactory.create_valid_contract_tx(code)
+
+      next_tx = ContractFactory.create_next_contract_tx(prev_tx, content: "wake up")
+
+      contract_context = %Contract.Context{
+        trigger: {:datetime, now},
+        status: :tx_output,
+        timestamp: now
+      }
+
+      assert Contracts.valid_execution?(prev_tx, next_tx, contract_context)
+    end
+
+    test "should work with contract version 0" do
+      now = %DateTime{DateTime.utc_now() | second: 0, microsecond: {0, 0}}
+
+      code = """
+      actions triggered_by: datetime, at: #{DateTime.to_unix(now)} do
+        set_content "wake up"
       end
       """
 

--- a/test/archethic/p2p/message/validate_smart_contract_call_test.exs
+++ b/test/archethic/p2p/message/validate_smart_contract_call_test.exs
@@ -11,6 +11,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
   alias Archethic.TransactionChain.TransactionData.Recipient
 
   alias Archethic.ContractFactory
+  alias Archethic.TransactionFactory
 
   doctest ValidateSmartContractCall
 
@@ -79,11 +80,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
       MockDB
       |> expect(:get_transaction, fn "@SC1", _, _ -> {:ok, tx} end)
 
-      incoming_tx = %Transaction{
-        data: %TransactionData{
-          content: "hola"
-        }
-      }
+      incoming_tx = TransactionFactory.create_valid_transaction([], content: "hola")
 
       assert %SmartContractCallValidation{valid?: true} =
                %ValidateSmartContractCall{
@@ -109,7 +106,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
       MockDB
       |> expect(:get_transaction, fn "@SC1", _, _ -> {:ok, tx} end)
 
-      incoming_tx = %Transaction{data: %TransactionData{content: "hola"}}
+      incoming_tx = TransactionFactory.create_valid_transaction([], content: "hola")
 
       assert %SmartContractCallValidation{valid?: true} =
                %ValidateSmartContractCall{

--- a/test/archethic/transaction_chain/transaction_data/ownership_test.exs
+++ b/test/archethic/transaction_chain/transaction_data/ownership_test.exs
@@ -1,7 +1,7 @@
 defmodule Archethic.TransactionChain.TransactionData.OwnershipTest do
   use ArchethicCase
+  import ArchethicCase
 
-  import ArchethicCase, only: [current_transaction_version: 0]
   use ExUnitProperties
 
   alias Archethic.Crypto

--- a/test/support/contract_factory.ex
+++ b/test/support/contract_factory.ex
@@ -86,7 +86,7 @@ defmodule Archethic.ContractFactory do
     if Map.has_key?(constants, "contract") do
       constants
     else
-      Map.put(constants, "contract", Constants.from_contract(contract_tx))
+      Map.put(constants, "contract", Constants.from_contract_transaction(contract_tx))
     end
   end
 end

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -255,6 +255,18 @@ defmodule ArchethicCase do
     <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
   end
 
+  def random_secret() do
+    :rand.uniform(134) |> :crypto.strong_rand_bytes()
+  end
+
+  def random_encrypted_key(_public_key = <<0::8, _rest::binary>>) do
+    :crypto.strong_rand_bytes(80)
+  end
+
+  def random_encrypted_key(_) do
+    :crypto.strong_rand_bytes(113)
+  end
+
   # sugar for readability
   def expect_not(mock, function_name, function) do
     expect(mock, function_name, 0, function)

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -27,10 +27,17 @@ defmodule Archethic.TransactionFactory do
     code = Keyword.get(opts, :code, "")
     ledger = Keyword.get(opts, :ledger, %Ledger{})
     recipients = Keyword.get(opts, :recipients, [])
+    ownerships = Keyword.get(opts, :ownerships, [])
 
     Transaction.new(
       type,
-      %TransactionData{content: content, code: code, ledger: ledger, recipients: recipients},
+      %TransactionData{
+        content: content,
+        code: code,
+        ledger: ledger,
+        recipients: recipients,
+        ownerships: ownerships
+      },
       seed,
       index
     )


### PR DESCRIPTION
# Description

This PR improve the usability of the ownerships in the smart contracts. It also do some refactor about the contract constants.
- Contract seed ownership is not accessible in the variable `contract` (removing it before creating the constant)
- Contract ownerships are not anymore chained in the initial_tx (including the seed one)
- When signing the new contract transaction, the seed ownership is automatically added in first place (creating a new ownership with new encrypted_key)
- Owerships constant is now the same format as the `Ownership` module, used in `contract.ownership` variable. `secrets`, `secret_keys` and `authorized_public_keys` does not exist anymore
- `Contract.add_ownership` has a new api with `secret` and `authorized_keys` as a map of public_key => encrypted_key
- `Contract.add_ownership` keeps the order specified by the contract code
- Refactor constant module for legacy code as well
- Many tests has been updated to use `TransactionFactory` as the constants are now more strict (cannot have a nil address for example)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Units tests
Manual testing by creating contract and using ownerships

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
