### PR TITLE
Fix validation stamp resolved recipient order

### DIFF
--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -232,9 +232,8 @@ defmodule Archethic.Contracts.Interpreter do
     #
     # this code return this:
     # List.empty?(12)
-    args_str = Enum.map_join(args, ", ", &Macro.to_string/1)
 
-    do_format_error_reason(reason, "#{module_name}.#{function_name}(#{args_str})", metadata)
+    do_format_error_reason(reason, "#{module_name}.#{function_name}/#{length(args)}", metadata)
   end
 
   def format_error_reason(ast_node = {_, metadata, _}, reason) do

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1437,6 +1437,7 @@ defmodule Archethic.Mining.ValidationContext do
           [%Recipient{r | address: resolved} | acc]
       end
     end)
+    |> Enum.reverse()
   end
 
   defp get_resolved_address_for_address(resolved_addresses, address) do

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -84,7 +84,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     end
 
     test "should return an human readable error if lib fn is called with bad arg" do
-      assert {:error, "invalid function arguments - List.empty?(12) - L4"} =
+      assert {:error, "invalid function arguments - List.empty?/1 - L4"} =
                """
                @version 1
                condition triggered_by: transaction, as: []
@@ -196,7 +196,7 @@ defmodule Archethic.Contracts.InterpreterTest do
 
     test "should return an human readable error if lib fn is called with bad arity" do
       assert {:error,
-              "Function List.empty? does not exists with 2 arguments - List.empty?([1], \"foobar\") - L4"} =
+              "Function List.empty? does not exists with 2 arguments - List.empty?/2 - L4"} =
                """
                @version 1
                condition triggered_by: transaction, as: []
@@ -208,8 +208,7 @@ defmodule Archethic.Contracts.InterpreterTest do
     end
 
     test "should return an human readable error if lib fn does not exists" do
-      assert {:error,
-              "Function List.non_existing does not exists - List.non_existing([1, 2, 3]) - L4"} =
+      assert {:error, "Function List.non_existing does not exists - List.non_existing/1 - L4"} =
                """
                @version 1
                condition triggered_by: transaction, as: []


### PR DESCRIPTION
# Description

In the transaction, the user can put many recipients with named actions.
In the validation stamp, the list of resolved address for the recipient was not sorted in the same order. This was causing error in the contract loader triggering a contract with the wrong named action

Also fix a bug where the error formatter fail if a parameter is a map

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a transaction with 2 recipient for different contract with different named action.
The contracts are called with the right parameters

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
