### PR TITLE
Fix arithmetic with float

### DIFF
--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -296,7 +296,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       function_constant = %{:functions => %{{"hello", 0} => %{args: [], ast: ast_hello}}}
 
-      assert 4.0 = FunctionInterpreter.execute(ast_test, function_constant)
+      assert 4 = FunctionInterpreter.execute(ast_test, function_constant)
     end
 
     test "should be able to execute function with arg" do


### PR DESCRIPTION
# Description

This PR improve the return of an arithmetic expression in SC language.
Now the function return an integer of both operands are integer (if result does not contains decimals), if one operand is a float, expression returns a float

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Doctests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
