### PR TITLE
Add new SC function Crypto.hmac/2

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/crypto.ex
+++ b/lib/archethic/contracts/interpreter/library/common/crypto.ex
@@ -34,46 +34,95 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Crypto do
             message: "Crypto.sign_with_recovery had an invalid hash in parameter"
       end
 
-    case Scope.read_global([:encrypted_seed]) do
-      nil ->
-        raise Library.Error, message: "Contract seed has not been set for Crypto.sign"
+    seed = get_contract_seed("Crypto.sign")
 
-      {encrypted_seed, encrypted_key} ->
-        seed = get_seed(encrypted_seed, encrypted_key)
+    {_pub, <<_::16, priv::binary>>} = Crypto.derive_keypair(seed, 0, :secp256k1)
 
-        {_pub, <<_::16, priv::binary>>} = Crypto.derive_keypair(seed, 0, :secp256k1)
+    {:ok, {r, s, v}} = ExSecp256k1.sign(hash_payload, priv)
 
-        {:ok, {r, s, v}} = ExSecp256k1.sign(hash_payload, priv)
-
-        %{
-          "r" => Base.encode16(r),
-          "s" => Base.encode16(s),
-          "v" => v
-        }
-    end
+    %{
+      "r" => Base.encode16(r),
+      "s" => Base.encode16(s),
+      "v" => v
+    }
   end
 
-  defp get_seed(encrypted_seed, encrypted_key) do
-    with {:ok, aes_key} <- Crypto.ec_decrypt_with_storage_nonce(encrypted_key),
-         {:ok, seed} <- Crypto.aes_decrypt(encrypted_seed, aes_key) do
-      seed
-    else
-      _ -> raise Library.Error, message: "Unable to decrypt seed in Crypto.sign"
+  @spec hmac(data :: binary(), algo :: binary(), key :: binary()) :: binary()
+  def hmac(data, algo \\ "sha256", key \\ "")
+
+  def hmac(data, algo, key) do
+    key =
+      if key == "" do
+        payload = Crypto.storage_nonce() <> get_contract_seed("Crypto.hmac")
+        :crypto.hash(:sha256, payload)
+      else
+        UtilsInterpreter.maybe_decode_hex(key)
+      end
+
+    algo =
+      case algo do
+        "sha256" ->
+          :sha256
+
+        "sha512" ->
+          :sha512
+
+        "sha3_256" ->
+          :sha3_256
+
+        "sha3_512" ->
+          :sha3_512
+
+        algo ->
+          raise Library.Error, message: "Invalid hmac algorithm #{inspect(algo)}"
+      end
+
+    data = UtilsInterpreter.maybe_decode_hex(data)
+
+    :crypto.mac(:hmac, algo, key, data) |> Base.encode16()
+  end
+
+  defp get_contract_seed(function) do
+    case Scope.read_global([:encrypted_seed]) do
+      nil ->
+        raise Library.Error, message: "Contract seed has not been set for #{function}"
+
+      {encrypted_seed, encrypted_key} ->
+        with {:ok, aes_key} <- Crypto.ec_decrypt_with_storage_nonce(encrypted_key),
+             {:ok, seed} <- Crypto.aes_decrypt(encrypted_seed, aes_key) do
+          seed
+        else
+          _ -> raise Library.Error, message: "Unable to decrypt seed for #{function}"
+        end
     end
   end
 
   @spec check_types(atom(), list()) :: boolean()
-  def check_types(:hash, [first, second]) do
-    (AST.is_binary?(first) || AST.is_variable_or_function_call?(first)) &&
-      (AST.is_binary?(second) || AST.is_variable_or_function_call?(second))
-  end
-
   def check_types(:hash, [first]) do
     AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
   end
 
+  def check_types(:hash, [first, second]) do
+    check_types(:hash, [first]) &&
+      (AST.is_binary?(second) || AST.is_variable_or_function_call?(second))
+  end
+
   def check_types(:sign_with_recovery, [first]) do
     AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+  end
+
+  def check_types(:hmac, [first]) do
+    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+  end
+
+  def check_types(:hmac, [first, second]) do
+    check_types(:hmac, [first]) &&
+      (AST.is_binary?(second) || AST.is_variable_or_function_call?(second))
+  end
+
+  def check_types(:hmac, [first, second, third]) do
+    check_types(:hmac, [first, second]) &&
+      (AST.is_binary?(third) || AST.is_variable_or_function_call?(third))
   end
 
   def check_types(_, _), do: false


### PR DESCRIPTION
# Description

Add new Crypto function to perform HMAC.
This function takes 3 parameters:
- data => the data to be hashed
- algo => the algo to use (sha256, sha512, sha3_256, sha3_512), default sha256
- key => the secret key, default is the sha256 hash of the storage nonce <> seed of contract

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
