### PR TITLE
SC new Chain functions

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/chain.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain.ex
@@ -15,6 +15,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
   @callback get_transaction(binary()) :: map()
   @callback get_burn_address() :: Crypto.prepended_hash()
   @callback get_previous_address(Crypto.key() | map()) :: Crypto.prepended_hash()
+  @callback get_balance(Crypto.prepended_hash()) :: map()
 
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:get_genesis_address, [first]) do
@@ -37,6 +38,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
 
   def check_types(:get_previous_address, [first]) do
     AST.is_map?(first) || AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+  end
+
+  def check_types(:get_balance, [first]) do
+    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
   end
 
   def check_types(_, _), do: false

--- a/lib/archethic/contracts/interpreter/library/common/chain.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain.ex
@@ -16,33 +16,42 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
   @callback get_burn_address() :: Crypto.prepended_hash()
   @callback get_previous_address(Crypto.key() | map()) :: Crypto.prepended_hash()
   @callback get_balance(Crypto.prepended_hash()) :: map()
+  @callback get_uco_balance(Crypto.prepended_hash()) :: float()
 
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:get_genesis_address, [first]) do
-    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+    binary_or_variable_or_function?(first)
   end
 
   def check_types(:get_first_transaction_address, [first]) do
-    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+    binary_or_variable_or_function?(first)
   end
 
   def check_types(:get_genesis_public_key, [first]) do
-    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+    binary_or_variable_or_function?(first)
   end
 
   def check_types(:get_transaction, [first]) do
-    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+    binary_or_variable_or_function?(first)
   end
 
   def check_types(:get_burn_address, []), do: true
 
   def check_types(:get_previous_address, [first]) do
-    AST.is_map?(first) || AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+    AST.is_map?(first) || binary_or_variable_or_function?(first)
   end
 
   def check_types(:get_balance, [first]) do
-    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+    binary_or_variable_or_function?(first)
+  end
+
+  def check_types(:get_uco_balance, [first]) do
+    binary_or_variable_or_function?(first)
   end
 
   def check_types(_, _), do: false
+
+  defp binary_or_variable_or_function?(arg) do
+    AST.is_binary?(arg) || AST.is_variable_or_function_call?(arg)
+  end
 end

--- a/lib/archethic/contracts/interpreter/library/common/chain.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain.ex
@@ -17,6 +17,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
   @callback get_previous_address(Crypto.key() | map()) :: Crypto.prepended_hash()
   @callback get_balance(Crypto.prepended_hash()) :: map()
   @callback get_uco_balance(Crypto.prepended_hash()) :: float()
+  @callback get_token_balance(Crypto.prepended_hash(), Crypto.prepended_hash()) :: float()
+  @callback get_token_balance(Crypto.prepended_hash(), Crypto.prepended_hash(), non_neg_integer()) ::
+              float()
 
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:get_genesis_address, [first]) do
@@ -49,9 +52,21 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
     binary_or_variable_or_function?(first)
   end
 
+  def check_types(:get_token_balance, [first, second]) do
+    binary_or_variable_or_function?(first) && binary_or_variable_or_function?(second)
+  end
+
+  def check_types(:get_token_balance, [first, second, third]) do
+    check_types(:get_token_balance, [first, second]) && number_or_variable_or_function?(third)
+  end
+
   def check_types(_, _), do: false
 
   defp binary_or_variable_or_function?(arg) do
     AST.is_binary?(arg) || AST.is_variable_or_function_call?(arg)
+  end
+
+  defp number_or_variable_or_function?(arg) do
+    AST.is_number?(arg) || AST.is_variable_or_function_call?(arg)
   end
 end

--- a/lib/archethic/contracts/interpreter/library/common/chain.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain.ex
@@ -14,6 +14,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
   @callback get_genesis_public_key(binary()) :: Crypto.key() | nil
   @callback get_transaction(binary()) :: map()
   @callback get_burn_address() :: Crypto.prepended_hash()
+  @callback get_previous_address(Crypto.key() | map()) :: Crypto.prepended_hash()
 
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:get_genesis_address, [first]) do
@@ -33,6 +34,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
   end
 
   def check_types(:get_burn_address, []), do: true
+
+  def check_types(:get_previous_address, [first]) do
+    AST.is_map?(first) || AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
+  end
 
   def check_types(_, _), do: false
 end

--- a/lib/archethic/contracts/interpreter/library/common/chain.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain.ex
@@ -17,6 +17,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
   @callback get_uco_balance(binary()) :: float()
   @callback get_token_balance(binary(), binary()) :: float()
   @callback get_token_balance(binary(), binary(), non_neg_integer()) :: float()
+  @callback get_tokens_balance(binary()) :: list()
   @callback get_tokens_balance(binary(), list()) :: list()
 
   @spec check_types(atom(), list()) :: boolean()
@@ -58,8 +59,12 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
     check_types(:get_token_balance, [first, second]) && number_or_variable_or_function?(third)
   end
 
+  def check_types(:get_tokens_balance, [first]) do
+    binary_or_variable_or_function?(first)
+  end
+
   def check_types(:get_tokens_balance, [first, second]) do
-    binary_or_variable_or_function?(first) && list_or_variable_or_function?(second)
+    check_types(:get_tokens_balance, [first]) && list_or_variable_or_function?(second)
   end
 
   def check_types(_, _), do: false

--- a/lib/archethic/contracts/interpreter/library/common/chain.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain.ex
@@ -17,6 +17,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
   @callback get_uco_balance(binary()) :: float()
   @callback get_token_balance(binary(), binary()) :: float()
   @callback get_token_balance(binary(), binary(), non_neg_integer()) :: float()
+  @callback get_tokens_balance(binary(), list()) :: list()
 
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:get_genesis_address, [first]) do
@@ -57,6 +58,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
     check_types(:get_token_balance, [first, second]) && number_or_variable_or_function?(third)
   end
 
+  def check_types(:get_tokens_balance, [first, second]) do
+    binary_or_variable_or_function?(first) && list_or_variable_or_function?(second)
+  end
+
   def check_types(_, _), do: false
 
   defp binary_or_variable_or_function?(arg) do
@@ -65,5 +70,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
 
   defp number_or_variable_or_function?(arg) do
     AST.is_number?(arg) || AST.is_variable_or_function_call?(arg)
+  end
+
+  defp list_or_variable_or_function?(arg) do
+    AST.is_list?(arg) || AST.is_variable_or_function_call?(arg)
   end
 end

--- a/lib/archethic/contracts/interpreter/library/common/chain.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain.ex
@@ -2,24 +2,21 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
   @moduledoc false
   @behaviour Archethic.Contracts.Interpreter.Library
 
-  alias Archethic.Crypto
-
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
   alias Archethic.Contracts.Interpreter.Library.Common.ChainImpl
 
   use Knigge, otp_app: :archethic, default: ChainImpl, delegate_at_runtime?: true
 
-  @callback get_genesis_address(binary()) :: Crypto.prepended_hash()
-  @callback get_first_transaction_address(binary()) :: Crypto.prepended_hash() | nil
-  @callback get_genesis_public_key(binary()) :: Crypto.key() | nil
+  @callback get_genesis_address(binary()) :: binary()
+  @callback get_first_transaction_address(binary()) :: binary() | nil
+  @callback get_genesis_public_key(binary()) :: binary() | nil
   @callback get_transaction(binary()) :: map()
-  @callback get_burn_address() :: Crypto.prepended_hash()
-  @callback get_previous_address(Crypto.key() | map()) :: Crypto.prepended_hash()
-  @callback get_balance(Crypto.prepended_hash()) :: map()
-  @callback get_uco_balance(Crypto.prepended_hash()) :: float()
-  @callback get_token_balance(Crypto.prepended_hash(), Crypto.prepended_hash()) :: float()
-  @callback get_token_balance(Crypto.prepended_hash(), Crypto.prepended_hash(), non_neg_integer()) ::
-              float()
+  @callback get_burn_address() :: binary()
+  @callback get_previous_address(binary() | map()) :: binary()
+  @callback get_balance(binary()) :: map()
+  @callback get_uco_balance(binary()) :: float()
+  @callback get_token_balance(binary(), binary()) :: float()
+  @callback get_token_balance(binary(), binary(), non_neg_integer()) :: float()
 
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:get_genesis_address, [first]) do

--- a/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
@@ -128,23 +128,17 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainImpl do
   def get_tokens_balance(address_hex, requested_tokens) do
     function = "Chain.get_tokens_balance"
 
-    requested_tokens =
-      Enum.map(
-        requested_tokens,
-        fn %{"token_address" => token_address_hex, "token_id" => token_id} ->
-          {get_binary_address(token_address_hex, function), token_id}
-        end
-      )
-
     %{token: tokens} = address_hex |> get_binary_address(function) |> fetch_balance(function)
 
-    tokens
-    |> Map.take(requested_tokens)
-    |> Enum.map(fn {{token_address, token_id}, amount} ->
-      key_map = %{"token_address" => Base.encode16(token_address), "token_id" => token_id}
-      {key_map, Utils.from_bigint(amount)}
-    end)
-    |> Enum.into(%{})
+    Enum.reduce(
+      requested_tokens,
+      %{},
+      fn token = %{"token_address" => token_address_hex, "token_id" => token_id}, acc ->
+        key = {get_binary_address(token_address_hex, function), token_id}
+        amount = Map.get(tokens, key, 0) |> Utils.from_bigint()
+        Map.put(acc, token, amount)
+      end
+    )
   end
 
   defp get_binary_address(address_hex, function) do

--- a/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
@@ -111,6 +111,18 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainImpl do
     Utils.from_bigint(uco_amount)
   end
 
+  @impl Chain
+  @tag [:io]
+  def get_token_balance(address_hex, token_address_hex, token_id \\ 0)
+
+  def get_token_balance(address_hex, token_address_hex, token_id) do
+    function = "Chain.get_token_balance"
+    token_address = get_binary_address(token_address_hex, function)
+    %{token: tokens} = address_hex |> get_binary_address(function) |> fetch_balance(function)
+
+    tokens |> Map.get({token_address, token_id}, 0) |> Utils.from_bigint()
+  end
+
   defp get_binary_address(address_hex, function) do
     with {:ok, address} <- Base.decode16(address_hex),
          true <- Crypto.valid_address?(address) do

--- a/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
@@ -2,10 +2,15 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainImpl do
   @moduledoc false
 
   alias Archethic.Contracts.Interpreter.Legacy
+  alias Archethic.Contracts.Interpreter.Library
   alias Archethic.Contracts.Interpreter.Library.Common.Chain
   alias Archethic.Contracts.Interpreter.Legacy.UtilsInterpreter
   alias Archethic.Contracts.ContractConstants, as: Constants
+
+  alias Archethic.Crypto
+
   alias Archethic.Tag
+
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
 
   @behaviour Chain
@@ -44,14 +49,37 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainImpl do
     |> UtilsInterpreter.get_address("Chain.get_transaction/1")
     |> Archethic.search_transaction()
     |> then(fn
-      {:ok, tx} ->
-        Constants.from_transaction(tx)
-
-      {:error, _} ->
-        nil
+      {:ok, tx} -> Constants.from_transaction(tx)
+      {:error, _} -> nil
     end)
   end
 
   @impl Chain
   def get_burn_address(), do: LedgerOperations.burning_address() |> Base.encode16()
+
+  @impl Chain
+  def get_previous_address(previous_public_key) when is_binary(previous_public_key),
+    do: previous_address(previous_public_key)
+
+  def get_previous_address(%{"previous_public_key" => previous_public_key}),
+    do: previous_address(previous_public_key)
+
+  def get_previous_address(arg),
+    do:
+      raise(Library.Error,
+        message:
+          "Invalid arg for Chain.get_previous_address(), expected string or map, got #{inspect(arg)}"
+      )
+
+  defp previous_address(previous_public_key) do
+    with {:ok, pub_key} <- Base.decode16(previous_public_key),
+         true <- Crypto.valid_public_key?(pub_key) do
+      pub_key |> Crypto.derive_address() |> Base.encode16()
+    else
+      _ ->
+        raise Library.Error,
+          message:
+            "Invalid previous public key in Chain.get_previous_address(), got #{inspect(previous_public_key)}"
+    end
+  end
 end

--- a/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
@@ -125,6 +125,19 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainImpl do
 
   @impl Chain
   @tag [:io]
+  def get_tokens_balance(address_hex) do
+    function = "Chain.get_tokens_balance"
+
+    %{token: tokens} = address_hex |> get_binary_address(function) |> fetch_balance(function)
+
+    Enum.reduce(tokens, %{}, fn {{token_address, token_id}, amount}, acc ->
+      key = %{"token_address" => Base.encode16(token_address), "token_id" => token_id}
+      Map.put(acc, key, Utils.from_bigint(amount))
+    end)
+  end
+
+  @impl Chain
+  @tag [:io]
   def get_tokens_balance(address_hex, requested_tokens) do
     function = "Chain.get_tokens_balance"
 

--- a/test/archethic/contracts/interpreter/library/common/chain_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/chain_test.exs
@@ -309,4 +309,21 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
       end)
     end
   end
+
+  describe "get_uco_balance/1" do
+    test "should return uco balance" do
+      address = random_address()
+      last_address = random_address()
+
+      balance = %Balance{uco: Utils.to_bigint(14.35), token: %{}}
+
+      MockClient
+      |> expect(:send_message, fn _, %GetLastTransactionAddress{address: ^address}, _ ->
+        {:ok, %LastTransactionAddress{address: last_address}}
+      end)
+      |> expect(:send_message, fn _, %GetBalance{address: ^last_address}, _ -> {:ok, balance} end)
+
+      assert 14.35 == address |> Base.encode16() |> Chain.get_uco_balance()
+    end
+  end
 end

--- a/test/archethic/contracts/interpreter/library/common/chain_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/chain_test.exs
@@ -397,9 +397,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
 
       token_key1 = %{"token_address" => fungible_token_address_hex, "token_id" => 0}
       token_key2 = %{"token_address" => non_fungible_token_address_hex, "token_id" => 6}
+      token_key3 = %{"token_address" => non_fungible_token_address_hex, "token_id" => 12}
 
-      assert %{token_key1 => 134.489, token_key2 => 1} ==
-               Chain.get_tokens_balance(address_hex, [token_key1, token_key2])
+      assert %{token_key1 => 134.489, token_key2 => 1, token_key3 => 0} ==
+               Chain.get_tokens_balance(address_hex, [token_key1, token_key2, token_key3])
     end
   end
 end


### PR DESCRIPTION
# Description

Add new functions in Chain module:
- get_previous_address => return the previous address from previous public key or a transaction
- get_balance => return a map containing the balance of uco and tokens
- get_uco_balance => return the amount of uco
- get_token_balance => return the amount of token
- get_tokens_balance => return a map of token as for the get_balance but only with selected tokens

balance returns a map as 
```elixir
[
  uco: 1234,
  tokens: [
    [token_address: "1234", token_id: 0]: 1234,
    [token_address: "123456", token_id: 1]: 1,
  ]
]
```
It can be used like this 
```elixir
    balance = Chain.get_balance(previous_address)
    token = [
      token_address: 0x000123...,
      token_id: 0
    ]

    token_balance = Map.get(balance.tokens, token, 0)
    token_balance >= amount
```

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit test and tested with real bridge smart contract

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
