### PR TITLE
Add new Chain functions get_last_transaction and get_last_address

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/chain.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain.ex
@@ -9,8 +9,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
 
   @callback get_genesis_address(binary()) :: binary()
   @callback get_first_transaction_address(binary()) :: binary() | nil
+  @callback get_last_address(binary()) :: binary()
   @callback get_genesis_public_key(binary()) :: binary() | nil
-  @callback get_transaction(binary()) :: map()
+  @callback get_transaction(binary()) :: map() | nil
+  @callback get_last_transaction(binary()) :: map() | nil
   @callback get_burn_address() :: binary()
   @callback get_previous_address(binary() | map()) :: binary()
   @callback get_balance(binary()) :: map()
@@ -29,11 +31,19 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Chain do
     binary_or_variable_or_function?(first)
   end
 
+  def check_types(:get_last_address, [first]) do
+    binary_or_variable_or_function?(first)
+  end
+
   def check_types(:get_genesis_public_key, [first]) do
     binary_or_variable_or_function?(first)
   end
 
   def check_types(:get_transaction, [first]) do
+    binary_or_variable_or_function?(first)
+  end
+
+  def check_types(:get_last_transaction, [first]) do
     binary_or_variable_or_function?(first)
   end
 

--- a/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
+++ b/lib/archethic/contracts/interpreter/library/common/chain_impl.ex
@@ -36,6 +36,34 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainImpl do
 
   @tag [:io]
   @impl Chain
+  def get_last_address(address) do
+    function = "Chain.get_last_address"
+
+    address
+    |> get_binary_address(function)
+    |> Archethic.get_last_transaction_address()
+    |> then(fn
+      {:ok, last_address} -> Base.encode16(last_address)
+      {:error, _} -> raise Library.Error, message: "Network issue in #{function}"
+    end)
+  end
+
+  @tag [:io]
+  @impl Chain
+  def get_last_transaction(address) do
+    function = "Chain.get_last_transaction"
+
+    address
+    |> get_binary_address(function)
+    |> Archethic.get_last_transaction()
+    |> then(fn
+      {:ok, tx} -> Constants.from_transaction(tx)
+      {:error, _} -> nil
+    end)
+  end
+
+  @tag [:io]
+  @impl Chain
   def get_genesis_public_key(public_key) do
     try do
       Legacy.Library.get_genesis_public_key(public_key)
@@ -155,7 +183,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainImpl do
   end
 
   defp get_binary_address(address_hex, function) do
-    with {:ok, address} <- Base.decode16(address_hex),
+    with {:ok, address} <- Base.decode16(address_hex, case: :mixed),
          true <- Crypto.valid_address?(address) do
       address
     else


### PR DESCRIPTION
# Description

Add new functions in SC Chain module:
- `get_last_address(address)` => return the last address of a chain
- `get_last_transaction(address)` => return the last transaction of chain or nil

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
