### PR TITLE
Worker uses origin from previous public key

### DIFF
--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -174,7 +174,8 @@ defmodule Archethic.Contracts.Contract do
             next_data,
             contract_seed,
             index,
-            Crypto.get_public_key_curve(previous_public_key)
+            Crypto.get_public_key_curve(previous_public_key),
+            Crypto.get_public_key_origin(previous_public_key)
           )
 
         {:ok, signed_tx}

--- a/lib/archethic/transaction_chain/transaction.ex
+++ b/lib/archethic/transaction_chain/transaction.ex
@@ -165,12 +165,23 @@ defmodule Archethic.TransactionChain.Transaction do
           type :: transaction_type(),
           data :: TransactionData.t(),
           seed :: binary(),
-          index :: non_neg_integer()
+          index :: non_neg_integer(),
+          curve :: Crypto.supported_curve(),
+          origin :: Crypto.supported_origin()
         ) :: t()
-  def new(type, data = %TransactionData{}, seed, index, curve \\ Crypto.default_curve())
+  def new(
+        type,
+        data = %TransactionData{},
+        seed,
+        index,
+        curve \\ Crypto.default_curve(),
+        origin \\ :software
+      )
       when type in @transaction_types and is_binary(seed) and is_integer(index) and index >= 0 do
-    {previous_public_key, previous_private_key} = Crypto.derive_keypair(seed, index, curve)
-    {next_public_key, _} = Crypto.derive_keypair(seed, index + 1, curve)
+    {previous_public_key, previous_private_key} =
+      Crypto.derive_keypair(seed, index, curve, origin)
+
+    {next_public_key, _} = Crypto.derive_keypair(seed, index + 1, curve, origin)
 
     %__MODULE__{
       address: Crypto.derive_address(next_public_key),

--- a/test/archethic/transaction_chain/transaction_test.exs
+++ b/test/archethic/transaction_chain/transaction_test.exs
@@ -54,11 +54,13 @@ defmodule Archethic.TransactionChain.TransactionTest do
     end
   end
 
-  test "new/4 should create transaction with specific seed and index" do
-    tx = Transaction.new(:node, %TransactionData{}, "seed", 0)
-    tx2 = Transaction.new(:node, %TransactionData{}, "seed", 1)
+  describe "new/4" do
+    test "should create transaction with specific seed and index" do
+      tx = Transaction.new(:node, %TransactionData{}, "seed", 0)
+      tx2 = Transaction.new(:node, %TransactionData{}, "seed", 1)
 
-    assert Crypto.derive_address(tx2.previous_public_key) == tx.address
+      assert Crypto.derive_address(tx2.previous_public_key) == tx.address
+    end
   end
 
   describe "valid_stamps_signature?/2" do


### PR DESCRIPTION
# Description

This PR fixes a bug when a Worker create a transaction for a contract where the previous public key of the contract is not the default origin `:software`.

This create the transaction with another previous public and so the previous address is different than the real previous address. So the validation retrieve a previous transaction nil and cannot validate the transaction.

To fix this, the function `Transaction.new` now take the origin in parameters

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
