### PR TITLE
Recipient fees calculation on estimate transaction fee

### DIFF
--- a/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
@@ -3,9 +3,13 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
   JsonRPC method to estimate transaction fee for a given transaction
   """
 
+  alias Archethic.TransactionChain
   alias Archethic.Mining
+  alias Archethic.Mining.SmartContractValidation
   alias Archethic.OracleChain
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.TransactionData
+  alias Archethic.TransactionChain.TransactionData.Recipient
 
   alias ArchethicWeb.API.JsonRPC.Method
   alias ArchethicWeb.API.JsonRPC.TransactionSchema
@@ -45,9 +49,32 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
     uco_eur = previous_price |> Keyword.fetch!(:eur)
     uco_usd = previous_price |> Keyword.fetch!(:usd)
 
-    fee = Mining.get_transaction_fee(tx, nil, uco_usd, timestamp)
+    resolved_recipients = resolve_recipient_addresses(tx, timestamp)
+
+    {_valid?, recipients_fee} =
+      SmartContractValidation.validate_contract_calls(resolved_recipients, tx, timestamp)
+
+    fee = Mining.get_transaction_fee(tx, nil, uco_usd, timestamp) + recipients_fee
 
     result = %{"fee" => fee, "rates" => %{"usd" => uco_usd, "eur" => uco_eur}}
     {:ok, result}
+  end
+
+  defp resolve_recipient_addresses(
+         tx = %Transaction{data: %TransactionData{recipients: recipients}},
+         timestamp
+       ) do
+    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx, timestamp)
+
+    Enum.reduce(recipients, [], fn r = %Recipient{address: address}, acc ->
+      resolved = get_resolved_address_for_address(resolved_addresses, address)
+      [%Recipient{r | address: resolved} | acc]
+    end)
+    |> Enum.reverse()
+  end
+
+  defp get_resolved_address_for_address(resolved_addresses, address) do
+    {_to, resolved} = Enum.find(resolved_addresses, fn {to, _resolved} -> to == address end)
+    resolved
   end
 end


### PR DESCRIPTION
# Description

Since this PR https://github.com/archethic-foundation/archethic-node/pull/1288, users have to pay fees for the smart contract they trigger in the recipients. This fee calculation was not added to the estimate transaction fee API.

This PR fixes it by adding the same behavior in the estimation than in the validation context

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually with JSON RPC request

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
