### PR TITLE
Update recipient fee calculation

### DIFF
--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -257,8 +257,16 @@ defmodule Archethic.Mining do
         contract_context,
         uco_price_in_usd,
         timestamp,
+        contract_recipient_fees \\ 0,
         proto_version \\ protocol_version()
       ) do
-    Fee.calculate(tx, contract_context, uco_price_in_usd, timestamp, proto_version)
+    Fee.calculate(
+      tx,
+      contract_context,
+      uco_price_in_usd,
+      timestamp,
+      contract_recipient_fees,
+      proto_version
+    )
   end
 end

--- a/lib/archethic/mining/fee.ex
+++ b/lib/archethic/mining/fee.ex
@@ -49,17 +49,19 @@ defmodule Archethic.Mining.Fee do
           contract_context :: Contract.Context.t() | nil,
           uco_usd_price :: float(),
           timestamp :: DateTime.t(),
+          contract_recipient_fee :: non_neg_integer(),
           protocol_version :: pos_integer()
         ) :: non_neg_integer()
-  def calculate(%Transaction{type: :keychain}, _, _, _, _), do: 0
-  def calculate(%Transaction{type: :keychain_access}, _, _, _, _), do: 0
-  def calculate(_, %Contract.Context{trigger: {:transaction, _, _}}, _, _, _), do: 0
+  def calculate(%Transaction{type: :keychain}, _, _, _, _, _), do: 0
+  def calculate(%Transaction{type: :keychain_access}, _, _, _, _, _), do: 0
+  def calculate(_, %Contract.Context{trigger: {:transaction, _, _}}, _, _, _, _), do: 0
 
   def calculate(
         tx = %Transaction{address: address, type: type},
         _contract_context,
         uco_price_in_usd,
         timestamp,
+        contract_recipient_fee,
         protocol_version
       ) do
     cond do
@@ -89,7 +91,7 @@ defmodule Archethic.Mining.Fee do
           minimum_fee(uco_price_in_usd) + storage_cost + replication_cost +
             get_additional_fee(tx, uco_price_in_usd)
 
-        trunc(fee * @unit_uco)
+        trunc(fee * @unit_uco + contract_recipient_fee)
     end
   end
 

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -767,8 +767,13 @@ defmodule Archethic.Mining.ValidationContext do
       |> OracleChain.get_uco_price()
       |> Keyword.fetch!(:usd)
 
-    Mining.get_transaction_fee(tx, contract_context, previous_usd_price, validation_time) +
+    Mining.get_transaction_fee(
+      tx,
+      contract_context,
+      previous_usd_price,
+      validation_time,
       contract_recipients_fee
+    )
   end
 
   defp get_ledger_operations(

--- a/lib/archethic/replication/transaction_validator.ex
+++ b/lib/archethic/replication/transaction_validator.ex
@@ -291,8 +291,13 @@ defmodule Archethic.Replication.TransactionValidator do
       |> OracleChain.get_uco_price()
       |> Keyword.fetch!(:usd)
 
-    Mining.get_transaction_fee(tx, contract_context, previous_usd_price, timestamp) +
+    Mining.get_transaction_fee(
+      tx,
+      contract_context,
+      previous_usd_price,
+      timestamp,
       contract_recipient_fees
+    )
   end
 
   defp validate_transaction_movements(

--- a/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
@@ -54,7 +54,7 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
     {_valid?, recipients_fee} =
       SmartContractValidation.validate_contract_calls(resolved_recipients, tx, timestamp)
 
-    fee = Mining.get_transaction_fee(tx, nil, uco_usd, timestamp) + recipients_fee
+    fee = Mining.get_transaction_fee(tx, nil, uco_usd, timestamp, recipients_fee)
 
     result = %{"fee" => fee, "rates" => %{"usd" => uco_usd, "eur" => uco_eur}}
     {:ok, result}

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -1274,7 +1274,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version()),
+          fee:
+            Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx),
           tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }

--- a/test/archethic/mining/fee_test.exs
+++ b/test/archethic/mining/fee_test.exs
@@ -41,6 +41,7 @@ defmodule Archethic.Mining.FeeTest do
                  nil,
                  0.2,
                  DateTime.utc_now(),
+                 0,
                  current_protocol_version()
                )
 
@@ -92,6 +93,7 @@ defmodule Archethic.Mining.FeeTest do
           nil,
           2.0,
           DateTime.utc_now(),
+          0,
           current_protocol_version()
         )
 
@@ -133,6 +135,7 @@ defmodule Archethic.Mining.FeeTest do
           nil,
           2.0,
           DateTime.utc_now(),
+          0,
           current_protocol_version()
         )
 
@@ -183,6 +186,7 @@ defmodule Archethic.Mining.FeeTest do
           nil,
           2.0,
           DateTime.utc_now(),
+          0,
           current_protocol_version()
         )
 
@@ -216,6 +220,7 @@ defmodule Archethic.Mining.FeeTest do
           nil,
           2.0,
           DateTime.utc_now(),
+          0,
           current_protocol_version()
         )
 
@@ -255,7 +260,7 @@ defmodule Archethic.Mining.FeeTest do
           """
         )
 
-      fee = Fee.calculate(tx, nil, 2.0, DateTime.utc_now(), current_protocol_version())
+      fee = Fee.calculate(tx, nil, 2.0, DateTime.utc_now(), 0, current_protocol_version())
 
       nb_bytes =
         tx.data
@@ -282,9 +287,9 @@ defmodule Archethic.Mining.FeeTest do
           }
         )
 
-      fee1 = Fee.calculate(tx, nil, 2.0, DateTime.utc_now(), current_protocol_version())
+      fee1 = Fee.calculate(tx, nil, 2.0, DateTime.utc_now(), 0, current_protocol_version())
 
-      fee2 = Fee.calculate(tx, nil, 10.0, DateTime.utc_now(), current_protocol_version())
+      fee2 = Fee.calculate(tx, nil, 10.0, DateTime.utc_now(), 0, current_protocol_version())
 
       assert fee2 < fee1
     end
@@ -295,14 +300,14 @@ defmodule Archethic.Mining.FeeTest do
           type: :transfer,
           content: :crypto.strong_rand_bytes(1_000)
         )
-        |> Fee.calculate(nil, 0.2, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 0.2, DateTime.utc_now(), 0, current_protocol_version())
 
       fee_tx_big =
         TransactionFactory.create_non_valided_transaction(
           type: :transfer,
           content: :crypto.strong_rand_bytes(10 * 1_000_000)
         )
-        |> Fee.calculate(nil, 0.2, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 0.2, DateTime.utc_now(), 0, current_protocol_version())
 
       assert fee_tx_big > fee_tx_small
     end
@@ -319,7 +324,7 @@ defmodule Archethic.Mining.FeeTest do
         status: :tx_output
       }
 
-      assert 0 == Fee.calculate(tx, contract_context, 0.2, timestamp, version)
+      assert 0 == Fee.calculate(tx, contract_context, 0.2, timestamp, 0, version)
     end
 
     test "should return fee for contract not triggered by transaction" do
@@ -334,15 +339,15 @@ defmodule Archethic.Mining.FeeTest do
         status: :tx_output
       }
 
-      assert 0 != Fee.calculate(tx, contract_context, 0.2, timestamp, version)
+      assert 0 != Fee.calculate(tx, contract_context, 0.2, timestamp, 0, version)
 
       contract_context = Map.put(contract_context, :trigger, {:datetime, DateTime.utc_now()})
-      assert 0 != Fee.calculate(tx, contract_context, 0.2, timestamp, version)
+      assert 0 != Fee.calculate(tx, contract_context, 0.2, timestamp, 0, version)
 
       contract_context =
         Map.put(contract_context, :trigger, {:interval, "* * * * *", DateTime.utc_now()})
 
-      assert 0 != Fee.calculate(tx, contract_context, 0.2, timestamp, version)
+      assert 0 != Fee.calculate(tx, contract_context, 0.2, timestamp, 0, version)
     end
 
     test "should cost more with more replication nodes" do
@@ -353,7 +358,7 @@ defmodule Archethic.Mining.FeeTest do
             uco: %UCOLedger{transfers: [%Transfer{amount: 100_000_000, to: random_address()}]}
           }
         )
-        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), 0, current_protocol_version())
 
       add_nodes(100)
 
@@ -364,7 +369,7 @@ defmodule Archethic.Mining.FeeTest do
             uco: %UCOLedger{transfers: [%Transfer{amount: 100_000_000, to: random_address()}]}
           }
         )
-        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), 0, current_protocol_version())
 
       assert tx_fee_50_nodes < tx_fee_100_nodes
     end
@@ -377,7 +382,7 @@ defmodule Archethic.Mining.FeeTest do
             uco: %UCOLedger{transfers: [%Transfer{amount: 100_000_000_000, to: random_address()}]}
           }
         )
-        |> Fee.calculate(nil, 0.2, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 0.2, DateTime.utc_now(), 0, current_protocol_version())
 
       batched_tx_fee =
         TransactionFactory.create_non_valided_transaction(
@@ -389,7 +394,7 @@ defmodule Archethic.Mining.FeeTest do
             }
           }
         )
-        |> Fee.calculate(nil, 0.2, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 0.2, DateTime.utc_now(), 0, current_protocol_version())
 
       assert batched_tx_fee > single_tx_fee
     end
@@ -408,7 +413,7 @@ defmodule Archethic.Mining.FeeTest do
               ]
             })
         )
-        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), 0, current_protocol_version())
 
       fee2 =
         TransactionFactory.create_non_valided_transaction(
@@ -426,7 +431,7 @@ defmodule Archethic.Mining.FeeTest do
               ]
             })
         )
-        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), 0, current_protocol_version())
 
       assert fee2 > fee1
     end
@@ -437,7 +442,7 @@ defmodule Archethic.Mining.FeeTest do
           type: :token,
           content: Jason.encode!(%{type: "fungible"})
         )
-        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), 0, current_protocol_version())
 
       fee2 =
         TransactionFactory.create_non_valided_transaction(
@@ -452,7 +457,7 @@ defmodule Archethic.Mining.FeeTest do
               ]
             })
         )
-        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 2.0, DateTime.utc_now(), 0, current_protocol_version())
 
       assert fee2 > fee1
     end
@@ -478,6 +483,7 @@ defmodule Archethic.Mining.FeeTest do
             nil,
             2.0,
             DateTime.utc_now(),
+            0,
             current_protocol_version()
           )
 
@@ -495,6 +501,7 @@ defmodule Archethic.Mining.FeeTest do
             nil,
             2.0,
             DateTime.utc_now(),
+            0,
             current_protocol_version()
           )
 

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -296,7 +296,8 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version()),
+          fee:
+            Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx),
           tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
@@ -319,7 +320,8 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version()),
+          fee:
+            Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx),
           tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
@@ -342,7 +344,8 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version()),
+          fee:
+            Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx),
           tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
         }
@@ -380,7 +383,7 @@ defmodule Archethic.Mining.ValidationContextTest do
          validation_time: timestamp,
          unspent_outputs: unspent_outputs
        }) do
-    fee = Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version())
+    fee = Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version())
 
     %ValidationStamp{
       timestamp: timestamp,
@@ -420,7 +423,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations: %LedgerOperations{
-        fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version()),
+        fee: Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version()),
         transaction_movements: Transaction.get_movements(tx),
         unspent_outputs: [
           %UnspentOutput{
@@ -448,7 +451,8 @@ defmodule Archethic.Mining.ValidationContextTest do
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
       ledger_operations:
         %LedgerOperations{
-          fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version()),
+          fee:
+            Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version()),
           transaction_movements: Transaction.get_movements(tx)
         }
         |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)

--- a/test/archethic/p2p/message/validate_smart_contract_call_test.exs
+++ b/test/archethic/p2p/message/validate_smart_contract_call_test.exs
@@ -141,7 +141,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
 
       expected_fee =
         ContractFactory.create_valid_contract_tx(code, content: "hello")
-        |> Fee.calculate(nil, 0.07, DateTime.utc_now(), current_protocol_version())
+        |> Fee.calculate(nil, 0.07, DateTime.utc_now(), 0, current_protocol_version())
 
       assert %SmartContractCallValidation{valid?: true, fee: expected_fee} ==
                %ValidateSmartContractCall{

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -75,7 +75,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version()),
+        fee: Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version()),
         transaction_movements: Transaction.get_movements(tx)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
@@ -117,7 +117,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version())
+        fee: Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version())
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
       |> elem(1)
@@ -152,7 +152,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version())
+        fee: Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version())
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
       |> elem(1)
@@ -188,7 +188,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version())
+        fee: Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version())
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)
       |> elem(1)
@@ -250,7 +250,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version()),
+        fee: Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version()),
         transaction_movements: [
           %TransactionMovement{to: "@Bob4", amount: 30_330_000_000, type: :UCO}
         ]
@@ -302,7 +302,7 @@ defmodule Archethic.TransactionFactory do
 
     ledger_operations =
       %LedgerOperations{
-        fee: Fee.calculate(tx, nil, 0.07, timestamp, ArchethicCase.current_protocol_version()),
+        fee: Fee.calculate(tx, nil, 0.07, timestamp, 0, ArchethicCase.current_protocol_version()),
         transaction_movements: Transaction.get_movements(tx)
       }
       |> LedgerOperations.consume_inputs(tx.address, inputs, timestamp)


### PR DESCRIPTION
# Description

Since the user pay the fee for a contract trigger in recipient, the control in the Worker to ensure the contract has the minimum fees is not relevant anymore so it is delete.

Also if a contract call another contract it's transaction was free but we added after the recipient fee which was not logical since the user should pay the fee for this as well

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with a contract that call another contract (bridge workflow) the contract has no fund but the transaction is still passing

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
