### PR TITLE
Handle inputs amount overflow over 2^64

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/evm.ex
+++ b/lib/archethic/contracts/interpreter/library/common/evm.ex
@@ -47,6 +47,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Evm do
     check_types(:abi_encode, [first]) && list_or_variable_or_function?(second)
   end
 
+  def check_types(:abi_decode, [first, second]) do
+    binary_or_variable_or_function?(first) && binary_or_variable_or_function?(second)
+  end
+
   def check_types(_, _), do: false
 
   defp binary_or_variable_or_function?(arg) do

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -27,7 +27,7 @@ defmodule Archethic.Mining do
 
   use Retry
 
-  @protocol_version 2
+  @protocol_version 3
 
   def protocol_version, do: @protocol_version
 

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -408,7 +408,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       0, 0, 34, 118, 242, 194, 93, 131, 130, 195, 9, 97, 237, 220, 195, 112, 1, 54, 221,
       86, 154, 234, 96, 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207,
       # Unspent output amount (2 UCO)
-      0, 0, 0, 0, 11, 235, 194, 0,
+      4, 11, 235, 194, 0,
       # Timestamp
       0, 0, 1, 131, 197, 240, 230, 191,
       # Unspent output type (UCO)
@@ -452,7 +452,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...> 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207, 0, 0, 0, 0, 60, 203, 247, 0, 0,
       ...> 1, 1, 0, 0, 34, 118, 242, 194, 93, 131, 130, 195, 9, 97, 237, 220, 195, 112, 1,
       ...> 54, 221, 86, 154, 234, 96, 217, 149, 84, 188, 63, 242, 166, 47, 158, 139, 207,
-      ...> 0, 0, 0, 0, 11, 235, 194, 0, 0, 0, 1, 131, 197, 240, 230, 191, 0>>
+      ...> 4, 11, 235, 194, 0, 0, 0, 1, 131, 197, 240, 230, 191, 0>>
       ...> |> LedgerOperations.deserialize(current_protocol_version())
       {
         %LedgerOperations{

--- a/test/archethic/p2p/message/validate_smart_contract_call_test.exs
+++ b/test/archethic/p2p/message/validate_smart_contract_call_test.exs
@@ -8,8 +8,6 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
   alias Archethic.P2P.Message.SmartContractCallValidation
   alias Archethic.P2P.Message.ValidateSmartContractCall
 
-  alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Recipient
 
   alias Archethic.ContractFactory
@@ -166,7 +164,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
       MockDB
       |> expect(:get_transaction, fn "@SC1", _, _ -> {:ok, tx} end)
 
-      incoming_tx = %Transaction{data: %TransactionData{content: "hola"}}
+      incoming_tx = TransactionFactory.create_valid_transaction([], content: "hola")
 
       assert %SmartContractCallValidation{valid?: false, fee: 0} =
                %ValidateSmartContractCall{
@@ -195,7 +193,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
       MockDB
       |> expect(:get_transaction, fn "@SC1", _, _ -> {:ok, tx} end)
 
-      incoming_tx = %Transaction{data: %TransactionData{content: "hi"}}
+      incoming_tx = TransactionFactory.create_valid_transaction([], content: "hi")
 
       assert %SmartContractCallValidation{valid?: false, fee: 0} =
                %ValidateSmartContractCall{


### PR DESCRIPTION
# Description

This PR handle the unspent outputs with an amount over 2^64 - 1. 
Now the amount of an utxo is encoded using VarInt

Fixes #1276

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Using blockchain and explorer normally.
Also started a node without the change, stopped the node, restarted it with the change.
Everything still work for old and new utxo serialization

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
