### PR TITLE
Catch the exit of the load_missed_transactions function

### DIFF
--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -84,6 +84,11 @@ defmodule Archethic.SelfRepair do
           Logger.error("Error during bootstrap self repair")
           Logger.error(Exception.format(:error, error, __STACKTRACE__))
           {:cont, :error}
+      catch
+        :exit, error ->
+          Logger.error("Error during bootstrap self repair")
+          Logger.error(Exception.format(:error, error, __STACKTRACE__))
+          {:cont, :error}
       end
     end)
   end


### PR DESCRIPTION
# Description

Because the load_missed_transactions can exit, it does not retry as expected. I added the catch so it does retry properly.
Fixes #1294

## Type of change


- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<img width="1114" alt="Capture d’écran 2023-10-11 à 11 25 21" src="https://github.com/archethic-foundation/archethic-node/assets/74045243/b04ec7bf-ee56-4607-8bdf-7a9764a7ce56">


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
