### PR TITLE
Fix WebUtils.to_float precision issue and rename it to from_bigint

### DIFF
--- a/lib/archethic_web/explorer/templates/explorer/chain.html.heex
+++ b/lib/archethic_web/explorer/templates/explorer/chain.html.heex
@@ -62,7 +62,7 @@
                         <div class="level-item has-text-centered">
                             <div>
                                 <p class="heading">UCO Balance</p>
-                                <p class="title"><%= to_float(@uco_balance) %> UCO
+                                <p class="title"><%= from_bigint(@uco_balance) %> UCO
                                 <%= if @uco_balance > 0 do %>
                                 (<%= format_usd_amount(@uco_balance, @uco_price[:usd]) %>)
                                 <% end %>

--- a/lib/archethic_web/explorer/templates/explorer/transaction_details.html.heex
+++ b/lib/archethic_web/explorer/templates/explorer/transaction_details.html.heex
@@ -183,7 +183,7 @@
                                             <div class="columns">
                                                 <div class="column is-1 heading">Amount</div>
                                                 <div class="column">
-                                                    <%= to_float(transfer.amount) %> UCO
+                                                    <%= from_bigint(transfer.amount) %> UCO
                                                     <%= if transfer.amount > 0 do %>
                                                         (<%= format_full_usd_amount(transfer.amount, @uco_price_at_time[:usd], @uco_price_now[:usd]) %>)
                                                     <% end %>
@@ -211,7 +211,7 @@
                                                 <div class="column is-1 heading">Amount</div>
                                                 <div class="column">
                                                     <%= decimals = Map.get(@token_properties, transfer.token_address, %{}) |> Map.get(:decimals, 8)
-                                                    to_float(transfer.amount, decimals) %>
+                                                    from_bigint(transfer.amount, decimals) %>
                                                 </div>
                                             </div>
                                             <div class="columns">
@@ -373,14 +373,14 @@
                                                 <div class="column">
                                                     <%= case movement.type do %>
                                                         <% :UCO -> %>
-                                                            <%= to_float(movement.amount) %>
+                                                            <%= from_bigint(movement.amount) %>
                                                             <span class="tag is-primary is-light ml-2">UCO</span>
                                                             <%= if movement.amount > 0 do %>
                                                                 (<%= format_full_usd_amount(movement.amount, @uco_price_at_time[:usd], @uco_price_now[:usd]) %>)
                                                             <% end %>
                                                         <% {:token, token_address, token_id} -> %>
                                                             <%= decimals = Map.get(@token_properties, token_address, %{}) |> Map.get(:decimals, 8)
-                                                            to_float(movement.amount, decimals) %>
+                                                            from_bigint(movement.amount, decimals) %>
                                                             <span class="tag is-success is-light ml-2">Token
                                                                 <%= if token_id >= 1 do %>
                                                                     (#<%= token_id %>)
@@ -419,14 +419,14 @@
                                                 <div class="column">
                                                     <%= case unspent_output.type do %>
                                                     <% :UCO -> %>
-                                                        <%= to_float(unspent_output.amount) %>
+                                                        <%= from_bigint(unspent_output.amount) %>
                                                         <span class="tag is-primary is-light ml-2">UCO</span>
                                                         <%= if unspent_output.amount > 0 do %>
                                                             (<%= format_full_usd_amount(unspent_output.amount, @uco_price_at_time[:usd], @uco_price_now[:usd]) %>)
                                                         <% end %>
                                                     <% {:token, token_address, token_id} -> %>
                                                         <%= decimals = Map.get(@token_properties, token_address, %{}) |> Map.get(:decimals, 8)
-                                                        to_float(unspent_output.amount, decimals) %>
+                                                        from_bigint(unspent_output.amount, decimals) %>
                                                         <span class="tag is-success is-light ml-2">Token
                                                             <%= if token_id >= 1 do %>
                                                                 (#<%= token_id %>)
@@ -450,7 +450,7 @@
                                     <div x-show="operation_section == 'transaction_fee' ">
                                         <p class="heading mb-4">Transaction fee</p>
                                         <p>
-                                            <%= to_float(@transaction.validation_stamp.ledger_operations.fee) %>
+                                            <%= from_bigint(@transaction.validation_stamp.ledger_operations.fee) %>
                                             <span class="tag is-primary is-light ml-2">UCO</span>
                                             <%= if @transaction.validation_stamp.ledger_operations.fee > 0 do %>
                                               (<%= format_full_usd_amount(@transaction.validation_stamp.ledger_operations.fee, @uco_price_at_time[:usd], @uco_price_now[:usd]) %>)
@@ -564,10 +564,10 @@
                                             <%= case input.type do
                                                 {:token, token_address, _} ->
                                                     decimals = Map.get(@token_properties, token_address, %{}) |> Map.get(:decimals, 8)
-                                                    to_float(input.amount, decimals)
+                                                    from_bigint(input.amount, decimals)
 
                                                 _ ->
-                                                     to_float(input.amount)
+                                                     from_bigint(input.amount)
                                             end %>
                                         </div>
                                       </div>

--- a/lib/archethic_web/web_utils.ex
+++ b/lib/archethic_web/web_utils.ex
@@ -54,14 +54,18 @@ defmodule ArchethicWeb.WebUtils do
     Sizeable.filesize(nb_bytes)
   end
 
-  def to_float(number, decimals \\ 8) when is_number(number) do
-    :erlang.float_to_binary(number / :math.pow(10, decimals), [:compact, decimals: decimals])
+  def from_bigint(int, decimals \\ 8) when is_integer(int) and decimals >= 0 do
+    Decimal.div(
+      Decimal.new(int),
+      Decimal.new(trunc(:math.pow(10, decimals)))
+    )
+    |> Decimal.to_string()
   end
 
   def format_usd_amount(uco_amount, uco_price) do
     usd_price =
       (uco_price * uco_amount)
-      |> to_float()
+      |> from_bigint()
       |> Float.parse()
       |> elem(0)
       |> Float.round(2)

--- a/test/archethic_web/web_utils_test.exs
+++ b/test/archethic_web/web_utils_test.exs
@@ -1,0 +1,11 @@
+defmodule ArchethicWeb.WebUtilsTest do
+  alias ArchethicWeb.WebUtils
+
+  use ExUnit.Case
+
+  describe "from_bigint/2" do
+    test "should format very big number correctly" do
+      assert "184467440737.09551615" == WebUtils.from_bigint(2 ** 64 - 1)
+    end
+  end
+end


### PR DESCRIPTION
# Description

Fix a round issue in UI.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

with the number 18446744073709500000, the displayed result was wrong:

BEFORE
<img width="915" alt="Capture d’écran 2023-10-11 à 17 32 38" src="https://github.com/archethic-foundation/archethic-node/assets/74045243/e7ceeaea-408b-4408-bab5-a61ccdb72fc1">
AFTER
<img width="831" alt="Capture d’écran 2023-10-11 à 17 43 20" src="https://github.com/archethic-foundation/archethic-node/assets/74045243/bd3e0765-ec60-403a-9380-470db167c60a">

+ unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
