### PR TITLE
Fixes SC Evm library

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/evm.ex
+++ b/lib/archethic/contracts/interpreter/library/common/evm.ex
@@ -47,6 +47,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Evm do
     check_types(:abi_encode, [first]) && list_or_variable_or_function?(second)
   end
 
+  def check_types(:abi_decode, [first, second]) do
+    binary_or_variable_or_function?(first) && binary_or_variable_or_function?(second)
+  end
+
   def check_types(_, _), do: false
 
   defp binary_or_variable_or_function?(arg) do


### PR DESCRIPTION
# Description

Some modifications regarding Evm library:
- Fix a bug where the check_type of `abi_decode` was not set
- `abi_encode` returns the hex string with "0x"

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
