### PR TITLE
fix and refactor format_usd_amount

### DIFF
--- a/lib/archethic_web/web_utils.ex
+++ b/lib/archethic_web/web_utils.ex
@@ -63,15 +63,13 @@ defmodule ArchethicWeb.WebUtils do
   end
 
   def format_usd_amount(uco_amount, uco_price) do
-    usd_price =
-      (uco_price * uco_amount)
-      |> from_bigint()
-      |> Float.parse()
-      |> elem(0)
-      |> Float.round(2)
-      |> :erlang.float_to_binary(decimals: 2)
-
-    "#{usd_price}$"
+    uco_amount
+    |> Decimal.new()
+    |> Decimal.div(Decimal.new(100_000_000))
+    |> Decimal.mult(Decimal.from_float(uco_price))
+    |> Decimal.round(2)
+    |> Decimal.to_string()
+    |> then(fn usd_price -> "#{usd_price}$" end)
   end
 
   def format_full_usd_amount(uco_amount, uco_price_at_time, uco_price_now) do

--- a/test/archethic_web/web_utils_test.exs
+++ b/test/archethic_web/web_utils_test.exs
@@ -8,4 +8,11 @@ defmodule ArchethicWeb.WebUtilsTest do
       assert "184467440737.09551615" == WebUtils.from_bigint(2 ** 64 - 1)
     end
   end
+
+  describe "format_usd_amount/2" do
+    test "should format very big number correctly" do
+      assert "184467440737.10$" == WebUtils.format_usd_amount(2 ** 64 - 1, 1.0)
+      assert "18446744073.71$" == WebUtils.format_usd_amount(2 ** 64 - 1, 0.1)
+    end
+  end
 end


### PR DESCRIPTION
# Description

Bug I introduced on develop last week. The `from_bigint` function is more strict than before and do no accept float anymore. This introduced a bug because the `format_usd_amount` function used the `from_bigint` incorrectly.

## Type of change


- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test & test on the explorer (transaction page)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
