### PR TITLE
Fix aeweb referer

### DIFF
--- a/lib/archethic_web/explorer/controllers/explorer_root_controller.ex
+++ b/lib/archethic_web/explorer/controllers/explorer_root_controller.ex
@@ -10,7 +10,12 @@ defmodule ArchethicWeb.Explorer.ExplorerRootController do
         redirect(conn, to: "/explorer")
 
       address ->
-        path = Map.get(conn, :request_path)
+        path =
+          case Map.get(conn, :request_path, "/") do
+            "" -> "/"
+            path -> path
+          end
+
         redirect(conn, to: "/api/web_hosting/" <> address <> path)
     end
   end
@@ -23,7 +28,7 @@ defmodule ArchethicWeb.Explorer.ExplorerRootController do
         nil
 
       [referer] ->
-        case Regex.scan(~r/(?<=\/api\/web_hosting\/)[^\/]*(?!$)/, referer) do
+        case Regex.scan(~r/(?<=\/api\/web_hosting\/)[^\/]*/, referer) do
           [] ->
             nil
 


### PR DESCRIPTION
# Description

Fixes an issue where aeweb do not correctly retrieve the aeweb reference address on the referer header.
Error was caused by an incorrect Regex pattern when the url does not end with a slash after the address.

Also added "aeweb" endpoint in referer Regex pattern and use this new endpoint as default redirection.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with archethic website

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
