### PR TITLE
Bug: Merging utxos updates the timestamp

### DIFF
--- a/test/archethic/transaction_chain/transaction/validation_stamp/ledger_operations_test.exs
+++ b/test/archethic/transaction_chain/transaction/validation_stamp/ledger_operations_test.exs
@@ -797,5 +797,62 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
                  now
                )
     end
+
+    test "should merge two similar tokens and update the from & timestamp" do
+      transaction_address = random_address()
+      transaction_timestamp = DateTime.utc_now()
+
+      from = random_address()
+      token_address = random_address()
+      old_timestamp = ~U[2023-11-09 10:39:10Z]
+
+      assert {true,
+              %LedgerOperations{
+                transaction_movements: [],
+                unspent_outputs: [
+                  %UnspentOutput{
+                    from: ^transaction_address,
+                    amount: 160_000_000,
+                    type: :UCO,
+                    timestamp: ^transaction_timestamp
+                  },
+                  %UnspentOutput{
+                    from: ^transaction_address,
+                    amount: 200_000_000,
+                    type: {:token, ^token_address, 0},
+                    timestamp: ^transaction_timestamp
+                  }
+                ],
+                fee: 40_000_000
+              }} =
+               LedgerOperations.consume_inputs(
+                 %LedgerOperations{
+                   transaction_movements: [],
+                   fee: 40_000_000
+                 },
+                 transaction_address,
+                 [
+                   %UnspentOutput{
+                     from: from,
+                     amount: 200_000_000,
+                     type: :UCO,
+                     timestamp: old_timestamp
+                   },
+                   %UnspentOutput{
+                     from: from,
+                     amount: 100_000_000,
+                     type: {:token, token_address, 0},
+                     timestamp: old_timestamp
+                   },
+                   %UnspentOutput{
+                     from: from,
+                     amount: 100_000_000,
+                     type: {:token, token_address, 0},
+                     timestamp: old_timestamp
+                   }
+                 ],
+                 transaction_timestamp
+               )
+    end
   end
 end


### PR DESCRIPTION
# Description

There is a bug on 1.3.0 when merging multiple same utxos together. This was not updating the timestamp and depending on the order of the inputs list, different nodes get differents utxos resulting in a consensus issue. Which mean some transaction cannot be validated even though they are valid.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
