### PR TITLE
NetworkSync.validate_address ask more nodes about the latest address

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -80,7 +80,7 @@ defmodule Archethic do
 
       true ->
         Logger.debug("Transaction has not been forwarded",
-          transaction_address: address,
+          transaction_address: Base.encode16(address),
           transaction_type: type
         )
     end
@@ -97,7 +97,7 @@ defmodule Archethic do
         SharedSecrets.genesis_address(:node_shared_secrets) |> SelfRepair.resync(addresses, [])
         false
 
-      _ ->
+      :error ->
         false
     end
   end

--- a/test/archethic/p2p_test.exs
+++ b/test/archethic/p2p_test.exs
@@ -152,7 +152,7 @@ defmodule Archethic.P2PTest do
         end
       )
 
-      assert {:error, :network_issue} =
+      assert {:error, :acceptance_failed} =
                P2P.quorum_read(
                  nodes,
                  %GetTransaction{address: ""},

--- a/test/archethic/self_repair/network_chain_test.exs
+++ b/test/archethic/self_repair/network_chain_test.exs
@@ -40,15 +40,16 @@ defmodule Archethic.SelfRepair.NetworkChainTest do
 
     test "should start a resync when remote /= local" do
       last_address = random_address()
+      now = DateTime.utc_now()
 
       MockDB
       |> expect(:get_last_chain_address, 2, fn address ->
-        {address, DateTime.utc_now()}
+        {address, DateTime.add(now, -1, :minute)}
       end)
 
       MockClient
       |> expect(:send_message, fn _, %GetLastTransactionAddress{}, _ ->
-        {:ok, %LastTransactionAddress{address: last_address}}
+        {:ok, %LastTransactionAddress{address: last_address, timestamp: now}}
       end)
 
       with_mock(SelfRepair, replicate_transaction: fn _ -> :ok end) do
@@ -59,15 +60,16 @@ defmodule Archethic.SelfRepair.NetworkChainTest do
 
     test "should not start a resync when remote == local" do
       last_address = random_address()
+      now = DateTime.utc_now()
 
       MockDB
       |> expect(:get_last_chain_address, 2, fn _ ->
-        {last_address, DateTime.utc_now()}
+        {last_address, now}
       end)
 
       MockClient
       |> expect(:send_message, fn _, %GetLastTransactionAddress{}, _ ->
-        {:ok, %LastTransactionAddress{address: last_address}}
+        {:ok, %LastTransactionAddress{address: last_address, timestamp: now}}
       end)
 
       with_mock(SelfRepair, replicate_transaction: fn _ -> :ok end) do

--- a/test/archethic_test.exs
+++ b/test/archethic_test.exs
@@ -196,7 +196,7 @@ defmodule ArchethicTest do
 
       MockDB
       |> stub(:get_last_chain_address, fn ^nss_genesis_address ->
-        {nss_last_address, DateTime.utc_now()}
+        {nss_last_address, DateTime.utc_now() |> DateTime.add(-20_000)}
       end)
       |> stub(
         :get_transaction,
@@ -221,7 +221,8 @@ defmodule ArchethicTest do
         # validate nss chain from network
         # anticippated to be failed
         _, %GetLastTransactionAddress{}, _ ->
-          {:ok, %LastTransactionAddress{address: "willnotmatchaddress"}}
+          {:ok,
+           %LastTransactionAddress{address: "willnotmatchaddress", timestamp: DateTime.utc_now()}}
 
         _, %NewTransaction{transaction: _, welcome_node: _}, _ ->
           # forward the tx
@@ -264,7 +265,7 @@ defmodule ArchethicTest do
 
       MockDB
       |> stub(:get_last_chain_address, fn ^nss_genesis_address ->
-        {nss_last_address, DateTime.utc_now()}
+        {nss_last_address, DateTime.utc_now() |> DateTime.add(-20_000)}
       end)
       |> stub(
         :get_transaction,
@@ -289,7 +290,8 @@ defmodule ArchethicTest do
       MockClient
       |> expect(:send_message, 4, fn
         _, %GetLastTransactionAddress{}, _ ->
-          {:ok, %LastTransactionAddress{address: "willnotmatchaddress"}}
+          {:ok,
+           %LastTransactionAddress{address: "willnotmatchaddress", timestamp: DateTime.utc_now()}}
 
         %Node{first_public_key: ^second_node_first_public_key},
         %NewTransaction{transaction: ^tx, welcome_node: ^welcome_node},


### PR DESCRIPTION
# Description

We were only asking the 3 closest nodes, but that's a mistake. For example, if multiple close nodes are desynchronized, they will never be able to be synchronized since they all ask each other.

Fixes #1320

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
