### PR TITLE
GetNetworkStats improvment: timeout & caching

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -22,6 +22,7 @@ config :archethic, Archethic.BeaconChain.SummaryTimer,
   interval: "0 * * * * *"
 
 config :archethic, Archethic.BeaconChain.Subset.SummaryCache, enabled: false
+config :archethic, Archethic.BeaconChain.Subset.StatsCollector, enabled: false
 
 config :archethic, Archethic.Bootstrap, enabled: false
 

--- a/lib/archethic/application.ex
+++ b/lib/archethic/application.ex
@@ -104,7 +104,8 @@ defmodule Archethic.Application do
       MetricSupervisor,
 
       # a registry used in Utils to ensure a function is executed at most once concurrently
-      {Registry, keys: :unique, name: Archethic.RunExclusiveRegistry}
+      {Registry, keys: :unique, name: Archethic.RunExclusiveRegistry},
+      {Registry, keys: :unique, name: Archethic.Utils.JobCacheRegistry}
     ]
 
     opts = [strategy: :rest_for_one, name: Archethic.Supervisor]

--- a/lib/archethic/beacon_chain/network_coordinates.ex
+++ b/lib/archethic/beacon_chain/network_coordinates.ex
@@ -261,7 +261,7 @@ defmodule Archethic.BeaconChain.NetworkCoordinates do
       fn {node, subsets} ->
         P2P.send_message(node, %GetNetworkStats{subsets: subsets}, 5_000)
       end,
-      timeout: 5_000,
+      timeout: 6_000,
       ordered: false,
       on_timeout: :kill_task,
       max_concurrency: 256

--- a/lib/archethic/beacon_chain/network_coordinates.ex
+++ b/lib/archethic/beacon_chain/network_coordinates.ex
@@ -259,8 +259,9 @@ defmodule Archethic.BeaconChain.NetworkCoordinates do
       TaskSupervisor,
       subsets_by_node,
       fn {node, subsets} ->
-        P2P.send_message(node, %GetNetworkStats{subsets: subsets})
+        P2P.send_message(node, %GetNetworkStats{subsets: subsets}, 5_000)
       end,
+      timeout: 5_000,
       ordered: false,
       on_timeout: :kill_task,
       max_concurrency: 256

--- a/lib/archethic/beacon_chain/subset.ex
+++ b/lib/archethic/beacon_chain/subset.ex
@@ -394,7 +394,7 @@ defmodule Archethic.BeaconChain.Subset do
       Logger.debug("Create beacon summary", beacon_subset: Base.encode16(subset))
 
       patch_task =
-        Task.Supervisor.async_nolink(TaskSupervisor, fn -> get_network_patches(subset) end)
+        Task.Supervisor.async_nolink(TaskSupervisor, fn -> get_network_patches(time, subset) end)
 
       summary =
         %Summary{subset: subset, summary_time: time}
@@ -428,7 +428,7 @@ defmodule Archethic.BeaconChain.Subset do
     end
   end
 
-  defp get_network_patches(subset) do
+  defp get_network_patches(summary_time, subset) do
     with true <- length(P2P.authorized_and_available_nodes()) > 1,
          sampling_nodes when sampling_nodes != [] <- P2PSampling.list_nodes_to_sample(subset) do
       sampling_nodes_indexes =
@@ -440,7 +440,7 @@ defmodule Archethic.BeaconChain.Subset do
         end)
         |> Enum.map(fn {_, index} -> index end)
 
-      StatsCollector.fetch()
+      StatsCollector.fetch(summary_time)
       |> NetworkCoordinates.get_patch_from_latencies()
       |> Enum.with_index()
       |> Enum.filter(fn {_, index} ->

--- a/lib/archethic/beacon_chain/subset/stats_collector.ex
+++ b/lib/archethic/beacon_chain/subset/stats_collector.ex
@@ -1,65 +1,180 @@
 defmodule Archethic.BeaconChain.Subset.StatsCollector do
   @moduledoc """
-  Process responsible to collect subset network stats
-  and reply to parallels requests to reduce the network load.
+  Get the networks stats locally and remotely
+
+  Uses 2 job caches:
+  - cache_get: cache the aggregation of local stats
+  - cache_fetch: cache the I/O
   """
 
   @vsn Mix.Project.config()[:version]
+  @timeout :timer.minutes(1)
   use GenServer
 
+  alias Archethic.P2P
+  alias Archethic.Election
+  alias Archethic.BeaconChain
   alias Archethic.BeaconChain.NetworkCoordinates
-  alias Archethic.TaskSupervisor
+  alias Archethic.Utils.JobCache
+  alias Archethic.PubSub
 
   require Logger
 
-  def start_link(_arg \\ []) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  defstruct [:cache_fetch, :cache_get]
+
+  # ------------------------------------------------------------
+  #     _    ____ ___
+  #    / \  |  _ |_ _|
+  #   / _ \ | |_) | |
+  #  / ___ \|  __/| |
+  # /_/   \_|_|  |___|
+  # ------------------------------------------------------------
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  @spec get(DateTime.t()) :: Nx.Tensor.t()
-  def get(summary_time) do
-    try do
-      GenServer.call(__MODULE__, {:get, summary_time})
-    catch
-      :exit, {:timeout, _} ->
-        Logger.warning("Fetching network stats take longer than 5s")
-        Nx.tensor(0)
-    end
+  @doc """
+  Get the local stats for the subsets this node is elected
+  """
+  @spec get(pos_integer()) :: %{binary() => Nx.Tensor.t()}
+  def get(timeout \\ @timeout) do
+    GenServer.call(__MODULE__, :get, timeout)
   end
 
+  @doc """
+  Fetch the stats from all subsets
+  """
+  @spec fetch(pos_integer()) :: Nx.Tensor.t()
+  def fetch(timeout \\ @timeout) do
+    GenServer.call(__MODULE__, :fetch, timeout)
+  end
+
+  # ------------------------------------------------------------
+  #            _ _ _                _
+  #   ___ __ _| | | |__   __ _  ___| | _____
+  #  / __/ _` | | | '_ \ / _` |/ __| |/ / __|
+  # | (_| (_| | | | |_) | (_| | (__|   <\__ \
+  #  \___\__,_|_|_|_.__/ \__,_|\___|_|\_|___/
+  # ------------------------------------------------------------
   def init(_) do
-    {:ok, %{fetching_task: nil, clients: []}}
+    PubSub.register_to_next_summary_time()
+    PubSub.register_to_self_repair()
+    {:ok, %__MODULE__{}}
   end
 
-  def handle_call({:get, summary_time}, from, state = %{fetching_task: nil}) do
-    task =
-      Task.Supervisor.async_nolink(TaskSupervisor, fn ->
-        start_time = System.monotonic_time()
-        stats = NetworkCoordinates.fetch_network_stats(summary_time)
-        {stats, start_time}
-      end)
+  def handle_call(:get, _from, state = %__MODULE__{cache_get: pid}) do
+    stats =
+      try do
+        JobCache.get!(pid, @timeout)
+      catch
+        :exit, _ ->
+          %{}
+      end
 
+    {:reply, stats, state}
+  end
+
+  def handle_call(:fetch, _from, state = %__MODULE__{cache_fetch: pid}) do
+    stats =
+      try do
+        JobCache.get!(pid, @timeout)
+      catch
+        :exit, _ ->
+          Nx.tensor(0)
+      end
+
+    {:reply, stats, state}
+  end
+
+  # When the summary happens, we fetch the stats
+  # and keep the result in a cache
+  def handle_info({:next_summary_time, next_summary_time}, state) do
+    summary_time = BeaconChain.previous_summary_time(next_summary_time)
+
+    # election of current node subsets
     new_state =
-      state
-      |> Map.update!(:clients, &[from | &1])
-      |> Map.put(:fetching_task, task)
+      case get_current_node_subsets(summary_time) do
+        [] ->
+          Logger.debug("Current node is elected to store 0 beacon subset")
+          state
+
+        subsets ->
+          Logger.debug("Current node is elected to store #{length(subsets)} beacon subsets")
+
+          {:ok, cache_fetch_pid} =
+            JobCache.start_link(immediate: true, function: fn -> do_fetch_stats(summary_time) end)
+
+          {:ok, cache_get_pid} =
+            JobCache.start_link(immediate: true, function: fn -> do_get_stats(subsets) end)
+
+          %__MODULE__{state | cache_fetch: cache_fetch_pid, cache_get: cache_get_pid}
+      end
 
     {:noreply, new_state}
   end
 
-  def handle_call({:get, _summary_time}, from, state = %{fetching_task: _}) do
-    new_state =
-      state
-      |> Map.update!(:clients, &[from | &1])
-
-    {:noreply, new_state}
-  end
-
+  # When a self repair happens, nobody will ask us for the stats anymore
+  # We can clear the caches
   def handle_info(
-        {ref, {stats, start_time}},
-        state = %{clients: clients, fetching_task: %Task{ref: ref_task}}
-      )
-      when ref_task == ref do
+        :self_repair_sync,
+        state = %__MODULE__{
+          cache_fetch: cache_fetch_pid,
+          cache_get: cache_get_pid
+        }
+      ) do
+    if is_pid(cache_fetch_pid) do
+      JobCache.stop(cache_fetch_pid)
+    end
+
+    if is_pid(cache_get_pid) do
+      JobCache.stop(cache_get_pid)
+    end
+
+    {:noreply, %__MODULE__{state | cache_fetch: nil, cache_get: nil}}
+  end
+
+  # ------------------------------------------------------------
+  #              _            _
+  #   _ __  _ __(___   ____ _| |_ ___
+  #  | '_ \| '__| \ \ / / _` | __/ _ \
+  #  | |_) | |  | |\ V | (_| | ||  __/
+  #  | .__/|_|  |_| \_/ \__,_|\__\___|
+  #  |_|
+  # ------------------------------------------------------------
+  defp do_get_stats(subsets) do
+    subsets
+    |> Task.async_stream(
+      fn subset ->
+        stats = BeaconChain.get_network_stats(subset)
+
+        {subset, stats}
+      end,
+      timeout: 10_000,
+      on_timeout: :kill_task,
+      ordered: false,
+      max_concurrency: 256
+    )
+    |> Stream.filter(fn
+      {:exit, :timeout} -> false
+      _ -> true
+    end)
+    |> Stream.map(fn {:ok, res} -> res end)
+    |> Enum.to_list()
+    |> Enum.reduce(%{}, fn
+      {subset, stats}, acc when map_size(stats) > 0 ->
+        Map.put(acc, subset, stats)
+
+      _, acc ->
+        acc
+    end)
+  end
+
+  defp do_fetch_stats(summary_time) do
+    start_time = System.monotonic_time()
+    stats = NetworkCoordinates.fetch_network_stats(summary_time)
+
     :telemetry.execute(
       [:archethic, :beacon_chain, :network_coordinates, :collect_stats],
       %{
@@ -68,15 +183,21 @@ defmodule Archethic.BeaconChain.Subset.StatsCollector do
       %{matrix_size: Nx.size(stats)}
     )
 
-    Enum.each(clients, &GenServer.reply(&1, stats))
-
-    new_state =
-      state
-      |> Map.put(:clients, [])
-      |> Map.put(:fetching_task, nil)
-
-    {:noreply, new_state}
+    stats
   end
 
-  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state), do: {:noreply, state}
+  defp get_current_node_subsets(summary_time) do
+    authorized_nodes = P2P.authorized_and_available_nodes(summary_time, true)
+    current_node = P2P.get_node_info()
+
+    Enum.reduce(BeaconChain.list_subsets(), [], fn subset, acc ->
+      beacon_nodes = Election.beacon_storage_nodes(subset, summary_time, authorized_nodes)
+
+      if current_node in beacon_nodes do
+        [subset | acc]
+      else
+        acc
+      end
+    end)
+  end
 end

--- a/lib/archethic/beacon_chain/subset/supervisor.ex
+++ b/lib/archethic/beacon_chain/subset/supervisor.ex
@@ -18,12 +18,13 @@ defmodule Archethic.BeaconChain.SubsetSupervisor do
     subset_children = subset_child_specs(BeaconChain.list_subsets())
 
     children =
-      [
+      Utils.configurable_children([
         {Registry,
-         keys: :unique, name: BeaconChain.SubsetRegistry, partitions: System.schedulers_online()}
-        | Utils.configurable_children([SummaryCache | subset_children])
-      ]
-      |> Enum.concat([StatsCollector])
+         keys: :unique, name: BeaconChain.SubsetRegistry, partitions: System.schedulers_online()},
+        SummaryCache,
+        StatsCollector
+        | subset_children
+      ])
 
     Supervisor.init(children, strategy: :one_for_one)
   end

--- a/lib/archethic/p2p/message/get_network_stats.ex
+++ b/lib/archethic/p2p/message/get_network_stats.ex
@@ -6,11 +6,9 @@ defmodule Archethic.P2P.Message.GetNetworkStats do
   @enforce_keys :subsets
   defstruct subsets: []
 
-  alias Archethic.BeaconChain
+  alias Archethic.BeaconChain.Subset.StatsCollector
   alias Archethic.Crypto
   alias Archethic.P2P.Message.NetworkStats
-  alias Archethic.Utils.JobCache
-  alias Archethic.TaskSupervisor
 
   @type t :: %__MODULE__{
           subsets: list(binary())
@@ -60,48 +58,9 @@ defmodule Archethic.P2P.Message.GetNetworkStats do
   Process the message to get the network stats from the summary cache
   """
   @spec process(t(), Crypto.key()) :: NetworkStats.t()
-  def process(%__MODULE__{subsets: subsets}, _node_public_key) do
-    # We use a JobCache because many nodes will send this message at the same time
-    # The message that spawned the JobCache also spawn a process that will terminate it
-    case JobCache.start(name: __MODULE__, function: fn -> do_get_stats(subsets) end) do
-      {:ok, pid} ->
-        Task.Supervisor.async_nolink(TaskSupervisor, fn ->
-          Process.sleep(30_000)
-          JobCache.clear(pid)
-        end)
-
-      _ ->
-        :ok
-    end
-
-    JobCache.get!(__MODULE__)
-  end
-
-  defp do_get_stats(subsets) do
-    stats =
-      subsets
-      |> Task.async_stream(
-        fn subset ->
-          stats = BeaconChain.get_network_stats(subset)
-
-          {subset, stats}
-        end,
-        on_timeout: :kill_task,
-        max_concurrency: 256
-      )
-      |> Stream.filter(fn
-        {:exit, :timeout} -> false
-        _ -> true
-      end)
-      |> Stream.map(fn {:ok, res} -> res end)
-      |> Enum.reduce(%{}, fn
-        {subset, stats}, acc when map_size(stats) > 0 ->
-          Map.put(acc, subset, stats)
-
-        _, acc ->
-          acc
-      end)
-
-    %NetworkStats{stats: stats}
+  def process(%__MODULE__{}, _node_public_key) do
+    # we do not use the `subsets` argument anymore.
+    # the node will always reply with the stats from the subsets it is elected to store
+    %NetworkStats{stats: StatsCollector.get()}
   end
 end

--- a/lib/archethic/p2p/message/get_network_stats.ex
+++ b/lib/archethic/p2p/message/get_network_stats.ex
@@ -3,53 +3,34 @@ defmodule Archethic.P2P.Message.GetNetworkStats do
   Represents a message to get the network stats from the beacon summary cache
   """
 
-  @enforce_keys :subsets
-  defstruct subsets: []
+  @enforce_keys [:summary_time]
+  defstruct [:summary_time]
 
   alias Archethic.BeaconChain.Subset.StatsCollector
   alias Archethic.Crypto
   alias Archethic.P2P.Message.NetworkStats
 
   @type t :: %__MODULE__{
-          subsets: list(binary())
+          summary_time: DateTime.t()
         }
 
   @doc """
   Serialize the get network stats message into binary
-
-  ## Examples
-
-      iex> %GetNetworkStats{subsets: [<<0>>, <<255>>]} |> GetNetworkStats.serialize()
-      <<
-      # Length of subsets
-      0, 2,
-      # Subset
-      0, 255
-      >>
   """
-  def serialize(%__MODULE__{subsets: subsets}) do
-    <<length(subsets)::16, :erlang.list_to_binary(subsets)::binary>>
+  @spec serialize(t()) :: bitstring()
+  def serialize(%__MODULE__{summary_time: summary_time}) do
+    <<DateTime.to_unix(summary_time)::32>>
   end
 
   @doc """
   Deserialize the binary into the get network stats message
-
-  ## Examples
-
-      iex> <<0, 2, 0, 255>> |> GetNetworkStats.deserialize()
-      {
-        %GetNetworkStats{subsets: [<<0>>, <<255>>]},
-        ""
-      }
   """
-  def deserialize(<<length::16, subsets_binary::binary-size(length), rest::bitstring>>) do
-    subsets =
-      subsets_binary
-      |> :erlang.binary_to_list()
-      |> Enum.map(&<<&1>>)
+  @spec deserialize(bitstring) :: {t(), bitstring()}
+  def deserialize(<<unix::32, rest::bitstring>>) do
+    summary_time = DateTime.from_unix!(unix)
 
     {
-      %__MODULE__{subsets: subsets},
+      %__MODULE__{summary_time: summary_time},
       rest
     }
   end
@@ -58,9 +39,7 @@ defmodule Archethic.P2P.Message.GetNetworkStats do
   Process the message to get the network stats from the summary cache
   """
   @spec process(t(), Crypto.key()) :: NetworkStats.t()
-  def process(%__MODULE__{}, _node_public_key) do
-    # we do not use the `subsets` argument anymore.
-    # the node will always reply with the stats from the subsets it is elected to store
-    %NetworkStats{stats: StatsCollector.get()}
+  def process(%__MODULE__{summary_time: summary_time}, _node_public_key) do
+    %NetworkStats{stats: StatsCollector.get(summary_time)}
   end
 end

--- a/lib/archethic/pub_sub.ex
+++ b/lib/archethic/pub_sub.ex
@@ -116,6 +116,18 @@ defmodule Archethic.PubSub do
   def register_to_node_status(), do: Registry.register(PubSubRegistry, :node_status, [])
 
   @doc """
+  Notify that a self repair synchronization is starting
+  """
+  @spec notify_self_repair() :: :ok
+  def notify_self_repair(), do: dispatch(:self_repair_sync, :self_repair_sync)
+
+  @doc """
+  Register a process to self repair synchronizations starts
+  """
+  @spec register_to_self_repair :: {:error, {:already_registered, pid}} | {:ok, pid}
+  def register_to_self_repair(), do: Registry.register(PubSubRegistry, :self_repair_sync, [])
+
+  @doc """
   Register a process to a new transaction publication by type
   """
   @spec register_to_new_transaction_by_type(Transaction.transaction_type()) :: {:ok, pid()}

--- a/lib/archethic/self_repair/scheduler.ex
+++ b/lib/archethic/self_repair/scheduler.ex
@@ -93,6 +93,8 @@ defmodule Archethic.SelfRepair.Scheduler do
       "Self-Repair synchronization started from #{last_sync_date_to_string(last_sync_date)}"
     )
 
+    PubSub.notify_self_repair()
+
     Task.Supervisor.async_nolink(TaskSupervisor, fn ->
       # Loading transactions can take a lot of time to be achieve and can overpass an epoch.
       # So to avoid missing a beacon summary epoch, we save the starting date and update the last sync date with it

--- a/lib/archethic/utils/job_cache.ex
+++ b/lib/archethic/utils/job_cache.ex
@@ -111,6 +111,11 @@ defmodule Archethic.Utils.JobCache do
     GenServer.start(__MODULE__, opts, Keyword.take(opts, [:name]))
   end
 
+  @spec stop(GenServer.server()) :: :ok
+  def stop(pid) do
+    GenServer.stop(pid)
+  end
+
   @impl GenServer
   def init(opts) do
     function = Keyword.fetch!(opts, :function)

--- a/lib/archethic/utils/job_cache.ex
+++ b/lib/archethic/utils/job_cache.ex
@@ -113,7 +113,14 @@ defmodule Archethic.Utils.JobCache do
 
   @impl GenServer
   def init(opts) do
-    {:ok, %S{function: Keyword.fetch!(opts, :function)}}
+    function = Keyword.fetch!(opts, :function)
+    immediate = Keyword.get(opts, :immediate, false)
+
+    if immediate do
+      {:ok, %S{function: function, task: Task.async(function)}}
+    else
+      {:ok, %S{function: function}}
+    end
   end
 
   @impl GenServer

--- a/lib/archethic/utils/job_cache.ex
+++ b/lib/archethic/utils/job_cache.ex
@@ -105,6 +105,12 @@ defmodule Archethic.Utils.JobCache do
     GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
   end
 
+  @spec start(Keyword.t()) :: GenServer.on_start()
+  def start(opts) do
+    Keyword.has_key?(opts, :function) || raise ArgumentError, "expected :function in options"
+    GenServer.start(__MODULE__, opts, Keyword.take(opts, [:name]))
+  end
+
   @impl GenServer
   def init(opts) do
     {:ok, %S{function: Keyword.fetch!(opts, :function)}}

--- a/test/archethic/beacon_chain/network_coordinates_test.exs
+++ b/test/archethic/beacon_chain/network_coordinates_test.exs
@@ -45,7 +45,7 @@ defmodule Archethic.BeaconChain.NetworkCoordinatesTest do
     test "should retrieve the stats for a given summary time" do
       MockClient
       |> expect(:send_message, 3, fn
-        _, %GetNetworkStats{subsets: _}, _ ->
+        _, %GetNetworkStats{}, _ ->
           {:ok,
            %NetworkStats{
              stats: %{
@@ -117,13 +117,13 @@ defmodule Archethic.BeaconChain.NetworkCoordinatesTest do
 
       MockClient
       |> expect(:send_message, 3, fn
-        ^wrong_node, %GetNetworkStats{subsets: _}, _ ->
+        ^wrong_node, %GetNetworkStats{}, _ ->
           {:ok, wrong_stats}
 
-        ^ok_node_1, %GetNetworkStats{subsets: _}, _ ->
+        ^ok_node_1, %GetNetworkStats{}, _ ->
           {:ok, ok_stats_1}
 
-        ^ok_node_2, %GetNetworkStats{subsets: _}, _ ->
+        ^ok_node_2, %GetNetworkStats{}, _ ->
           {:ok, ok_stats_2}
       end)
 

--- a/test/archethic/beacon_chain/subset/stats_collector_test.exs
+++ b/test/archethic/beacon_chain/subset/stats_collector_test.exs
@@ -50,14 +50,7 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
     %StatsCollector{cache_fetch: nil, cache_get: nil} = :sys.get_state(pid)
   end
 
-  test "should return empty when timeout" do
-    timeout = 10
-
-    assert %{} = StatsCollector.get(timeout)
-    assert Nx.to_binary(Nx.tensor(0)) == Nx.to_binary(StatsCollector.fetch(timeout))
-  end
-
-  test "get/0 should return the stats of the subsets current node is elected to store" do
+  test "get/1 should return the stats of the subsets current node is elected to store" do
     subset1 = :binary.encode_unsigned(0)
     subset2 = :binary.encode_unsigned(1)
     node1_public_key = random_public_key()
@@ -88,7 +81,8 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
          _, _, _ -> []
        end}
     ]) do
-      PubSub.notify_next_summary_time(DateTime.utc_now())
+      summary_time = DateTime.utc_now()
+      PubSub.notify_next_summary_time(summary_time)
 
       assert %{
                ^subset1 => %{
@@ -107,11 +101,70 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
                    %{latency: 10}
                  ]
                }
-             } = StatsCollector.get()
+             } = StatsCollector.get(summary_time)
     end
   end
 
-  test "fetch/0 should return the stats of all subsets" do
+  test "get/1 should start the jobs and reply if requested before the event happens", %{pid: pid} do
+    subset1 = :binary.encode_unsigned(0)
+    subset2 = :binary.encode_unsigned(1)
+    node1_public_key = random_public_key()
+    node2_public_key = random_public_key()
+    node3_public_key = random_public_key()
+    node4_public_key = random_public_key()
+    current_node = P2P.get_node_info()
+
+    %StatsCollector{cache_fetch: nil, cache_get: nil} = :sys.get_state(pid)
+
+    with_mocks([
+      {BeaconChain, [:passthrough],
+       get_network_stats: fn
+         ^subset1 ->
+           %{
+             node1_public_key => [%{latency: 1}],
+             node2_public_key => [%{latency: 1}]
+           }
+
+         ^subset2 ->
+           %{
+             node3_public_key => [%{latency: 10}],
+             node4_public_key => [%{latency: 10}]
+           }
+       end},
+      {Election, [],
+       beacon_storage_nodes: fn
+         ^subset1, _, _ -> [current_node]
+         ^subset2, _, _ -> [current_node]
+         _, _, _ -> []
+       end}
+    ]) do
+      assert %{
+               ^subset1 => %{
+                 ^node1_public_key => [
+                   %{latency: 1}
+                 ],
+                 ^node2_public_key => [
+                   %{latency: 1}
+                 ]
+               },
+               ^subset2 => %{
+                 ^node3_public_key => [
+                   %{latency: 10}
+                 ],
+                 ^node4_public_key => [
+                   %{latency: 10}
+                 ]
+               }
+             } = StatsCollector.get(DateTime.utc_now())
+    end
+
+    %StatsCollector{cache_fetch: pid1, cache_get: pid2} = :sys.get_state(pid)
+
+    assert is_pid(pid1)
+    assert is_pid(pid2)
+  end
+
+  test "fetch/1 should return the stats of all subsets" do
     subset1 = :binary.encode_unsigned(0)
     subset2 = :binary.encode_unsigned(1)
     current_node = P2P.get_node_info()
@@ -148,9 +201,62 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
          _, _, _ -> []
        end}
     ]) do
-      PubSub.notify_next_summary_time(DateTime.utc_now())
+      summary_time = DateTime.utc_now()
+      PubSub.notify_next_summary_time(summary_time)
 
-      assert ^tensor = StatsCollector.fetch()
+      assert ^tensor = StatsCollector.fetch(summary_time)
     end
+  end
+
+  test "fetch/1 should start the jobs and reply if requested before the event happens", %{
+    pid: pid
+  } do
+    subset1 = :binary.encode_unsigned(0)
+    subset2 = :binary.encode_unsigned(1)
+    current_node = P2P.get_node_info()
+
+    tensor =
+      Nx.tensor([
+        [0, 0, 36, 67, 45, 64, 0, 176, 43, 63, 190, 44, 75, 0, 146],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [36, 0, 0, 44, 63, 38, 0, 176, 47, 76, 167, 50, 65, 0, 142],
+        [67, 0, 44, 0, 47, 75, 0, 169, 52, 70, 186, 58, 70, 0, 159],
+        [45, 0, 63, 47, 0, 51, 0, 182, 53, 83, 187, 58, 107, 0, 142],
+        [64, 0, 38, 75, 51, 0, 0, 178, 46, 48, 193, 80, 72, 0, 149],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [176, 0, 176, 169, 182, 178, 0, 0, 151, 162, 196, 191, 143, 0, 195],
+        [43, 0, 47, 52, 53, 46, 0, 151, 0, 182, 166, 115, 91, 0, 109],
+        [63, 0, 76, 70, 83, 48, 0, 162, 182, 0, 167, 105, 144, 0, 124],
+        [190, 0, 167, 186, 187, 193, 0, 196, 166, 167, 0, 182, 165, 0, 109],
+        [44, 0, 50, 58, 58, 80, 0, 191, 115, 105, 182, 0, 82, 0, 154],
+        [75, 0, 65, 70, 107, 72, 0, 143, 91, 144, 165, 82, 0, 0, 160],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [146, 0, 142, 159, 142, 149, 0, 195, 109, 124, 109, 154, 160, 0, 0]
+      ])
+
+    %StatsCollector{cache_fetch: nil, cache_get: nil} = :sys.get_state(pid)
+
+    with_mocks([
+      {BeaconChain, [:passthrough], get_network_stats: fn _ -> %{} end},
+      {NetworkCoordinates, [],
+       fetch_network_stats: fn _summary_time ->
+         tensor
+       end},
+      {Election, [],
+       beacon_storage_nodes: fn
+         ^subset1, _, _ -> [current_node]
+         ^subset2, _, _ -> [current_node]
+         _, _, _ -> []
+       end}
+    ]) do
+      summary_time = DateTime.utc_now()
+
+      assert ^tensor = StatsCollector.fetch(summary_time)
+    end
+
+    %StatsCollector{cache_fetch: pid1, cache_get: pid2} = :sys.get_state(pid)
+
+    assert is_pid(pid1)
+    assert is_pid(pid2)
   end
 end

--- a/test/archethic/beacon_chain/subset/stats_collector_test.exs
+++ b/test/archethic/beacon_chain/subset/stats_collector_test.exs
@@ -1,0 +1,156 @@
+defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
+  use ArchethicCase, async: false
+
+  alias Archethic.BeaconChain
+  alias Archethic.BeaconChain.NetworkCoordinates
+  alias Archethic.BeaconChain.Subset.StatsCollector
+  alias Archethic.BeaconChain.SummaryTimer
+  alias Archethic.Crypto
+  alias Archethic.Election
+  alias Archethic.P2P
+  alias Archethic.P2P.Node
+  alias Archethic.PubSub
+
+  import ArchethicCase
+  import Mock
+
+  setup do
+    {:ok, pid} = StatsCollector.start_link([])
+    {:ok, _} = SummaryTimer.start_link([interval: "0 * * * * * *"], [])
+
+    P2P.add_and_connect_node(%Node{
+      ip: {127, 0, 0, 1},
+      port: 3000,
+      first_public_key: Crypto.first_node_public_key(),
+      last_public_key: Crypto.first_node_public_key(),
+      network_patch: "AAA",
+      geo_patch: "AAA",
+      available?: true,
+      authorized?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-1, :day)
+    })
+
+    on_exit(fn -> Process.exit(pid, :kill) end)
+
+    {:ok, %{pid: pid}}
+  end
+
+  test "should react to summary_time/self_repair events", %{pid: pid} do
+    %StatsCollector{cache_fetch: nil, cache_get: nil} = :sys.get_state(pid)
+
+    PubSub.notify_next_summary_time(DateTime.utc_now())
+
+    %StatsCollector{cache_fetch: pid1, cache_get: pid2} = :sys.get_state(pid)
+
+    assert is_pid(pid1)
+    assert is_pid(pid2)
+
+    PubSub.notify_self_repair()
+
+    %StatsCollector{cache_fetch: nil, cache_get: nil} = :sys.get_state(pid)
+  end
+
+  test "should return empty when timeout" do
+    timeout = 10
+
+    assert %{} = StatsCollector.get(timeout)
+    assert Nx.to_binary(Nx.tensor(0)) == Nx.to_binary(StatsCollector.fetch(timeout))
+  end
+
+  test "get/0 should return the stats of the subsets current node is elected to store" do
+    subset1 = :binary.encode_unsigned(0)
+    subset2 = :binary.encode_unsigned(1)
+    node1_public_key = random_public_key()
+    node2_public_key = random_public_key()
+    node3_public_key = random_public_key()
+    node4_public_key = random_public_key()
+    current_node = P2P.get_node_info()
+
+    with_mocks([
+      {BeaconChain, [:passthrough],
+       get_network_stats: fn
+         ^subset1 ->
+           %{
+             node1_public_key => [%{latency: 1}],
+             node2_public_key => [%{latency: 1}]
+           }
+
+         ^subset2 ->
+           %{
+             node3_public_key => [%{latency: 10}],
+             node4_public_key => [%{latency: 10}]
+           }
+       end},
+      {Election, [],
+       beacon_storage_nodes: fn
+         ^subset1, _, _ -> [current_node]
+         ^subset2, _, _ -> [current_node]
+         _, _, _ -> []
+       end}
+    ]) do
+      PubSub.notify_next_summary_time(DateTime.utc_now())
+
+      assert %{
+               ^subset1 => %{
+                 ^node1_public_key => [
+                   %{latency: 1}
+                 ],
+                 ^node2_public_key => [
+                   %{latency: 1}
+                 ]
+               },
+               ^subset2 => %{
+                 ^node3_public_key => [
+                   %{latency: 10}
+                 ],
+                 ^node4_public_key => [
+                   %{latency: 10}
+                 ]
+               }
+             } = StatsCollector.get()
+    end
+  end
+
+  test "fetch/0 should return the stats of all subsets" do
+    subset1 = :binary.encode_unsigned(0)
+    subset2 = :binary.encode_unsigned(1)
+    current_node = P2P.get_node_info()
+
+    tensor =
+      Nx.tensor([
+        [0, 0, 36, 67, 45, 64, 0, 176, 43, 63, 190, 44, 75, 0, 146],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [36, 0, 0, 44, 63, 38, 0, 176, 47, 76, 167, 50, 65, 0, 142],
+        [67, 0, 44, 0, 47, 75, 0, 169, 52, 70, 186, 58, 70, 0, 159],
+        [45, 0, 63, 47, 0, 51, 0, 182, 53, 83, 187, 58, 107, 0, 142],
+        [64, 0, 38, 75, 51, 0, 0, 178, 46, 48, 193, 80, 72, 0, 149],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [176, 0, 176, 169, 182, 178, 0, 0, 151, 162, 196, 191, 143, 0, 195],
+        [43, 0, 47, 52, 53, 46, 0, 151, 0, 182, 166, 115, 91, 0, 109],
+        [63, 0, 76, 70, 83, 48, 0, 162, 182, 0, 167, 105, 144, 0, 124],
+        [190, 0, 167, 186, 187, 193, 0, 196, 166, 167, 0, 182, 165, 0, 109],
+        [44, 0, 50, 58, 58, 80, 0, 191, 115, 105, 182, 0, 82, 0, 154],
+        [75, 0, 65, 70, 107, 72, 0, 143, 91, 144, 165, 82, 0, 0, 160],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [146, 0, 142, 159, 142, 149, 0, 195, 109, 124, 109, 154, 160, 0, 0]
+      ])
+
+    with_mocks([
+      {BeaconChain, [:passthrough], get_network_stats: fn _ -> %{} end},
+      {NetworkCoordinates, [],
+       fetch_network_stats: fn _summary_time ->
+         tensor
+       end},
+      {Election, [],
+       beacon_storage_nodes: fn
+         ^subset1, _, _ -> [current_node]
+         ^subset2, _, _ -> [current_node]
+         _, _, _ -> []
+       end}
+    ]) do
+      PubSub.notify_next_summary_time(DateTime.utc_now())
+
+      assert ^tensor = StatsCollector.fetch()
+    end
+  end
+end

--- a/test/archethic/beacon_chain/subset/stats_collector_test.exs
+++ b/test/archethic/beacon_chain/subset/stats_collector_test.exs
@@ -15,6 +15,10 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
   import Mock
 
   setup do
+    # global process to reset
+    Registry.select(Archethic.Utils.JobCacheRegistry, [{{:_, :"$1", :_}, [], [:"$1"]}])
+    |> Enum.each(fn pid -> Process.exit(pid, :kill) end)
+
     {:ok, pid} = StatsCollector.start_link([])
     {:ok, _} = SummaryTimer.start_link([interval: "0 * * * * * *"], [])
 
@@ -35,19 +39,32 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
     {:ok, %{pid: pid}}
   end
 
-  test "should react to summary_time/self_repair events", %{pid: pid} do
-    %StatsCollector{cache_fetch: nil, cache_get: nil} = :sys.get_state(pid)
+  test "is subscribed to events", %{pid: pid} do
+    assert [:self_repair_sync, :next_summary_time] = Registry.keys(Archethic.PubSubRegistry, pid)
+  end
 
-    PubSub.notify_next_summary_time(DateTime.utc_now())
+  test "should react to events" do
+    next_summary_time = DateTime.utc_now()
 
-    %StatsCollector{cache_fetch: pid1, cache_get: pid2} = :sys.get_state(pid)
+    with_mocks([
+      {BeaconChain, [:passthrough], get_network_stats: fn _ -> %{} end},
+      {NetworkCoordinates, [], fetch_network_stats: fn _summary_time -> Nx.tensor(0) end}
+    ]) do
+      assert 0 = Registry.count(Archethic.Utils.JobCacheRegistry)
 
-    assert is_pid(pid1)
-    assert is_pid(pid2)
+      send(StatsCollector, {:next_summary_time, next_summary_time})
+      _ = :sys.get_state(StatsCollector)
 
-    PubSub.notify_self_repair()
+      assert 2 = Registry.count(Archethic.Utils.JobCacheRegistry)
 
-    %StatsCollector{cache_fetch: nil, cache_get: nil} = :sys.get_state(pid)
+      send(StatsCollector, :self_repair_sync)
+      _ = :sys.get_state(StatsCollector)
+      # sleep a little because the JobCacheRegistry is informed asynchronously
+      # of the processes stopped
+      Process.sleep(50)
+
+      assert 0 = Registry.count(Archethic.Utils.JobCacheRegistry)
+    end
   end
 
   test "get/1 should return the stats of the subsets current node is elected to store" do
@@ -105,7 +122,7 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
     end
   end
 
-  test "get/1 should start the jobs and reply if requested before the event happens", %{pid: pid} do
+  test "get/1 should start the job and reply if requested before the event happens" do
     subset1 = :binary.encode_unsigned(0)
     subset2 = :binary.encode_unsigned(1)
     node1_public_key = random_public_key()
@@ -114,7 +131,7 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
     node4_public_key = random_public_key()
     current_node = P2P.get_node_info()
 
-    %StatsCollector{cache_fetch: nil, cache_get: nil} = :sys.get_state(pid)
+    assert 0 = Registry.count(Archethic.Utils.JobCacheRegistry)
 
     with_mocks([
       {BeaconChain, [:passthrough],
@@ -158,10 +175,7 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
              } = StatsCollector.get(DateTime.utc_now())
     end
 
-    %StatsCollector{cache_fetch: pid1, cache_get: pid2} = :sys.get_state(pid)
-
-    assert is_pid(pid1)
-    assert is_pid(pid2)
+    assert 1 = Registry.count(Archethic.Utils.JobCacheRegistry)
   end
 
   test "fetch/1 should return the stats of all subsets" do
@@ -208,39 +222,18 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
     end
   end
 
-  test "fetch/1 should start the jobs and reply if requested before the event happens", %{
-    pid: pid
-  } do
+  test "fetch/1 should start the job and reply if requested before the event happens" do
     subset1 = :binary.encode_unsigned(0)
     subset2 = :binary.encode_unsigned(1)
     current_node = P2P.get_node_info()
 
-    tensor =
-      Nx.tensor([
-        [0, 0, 36, 67, 45, 64, 0, 176, 43, 63, 190, 44, 75, 0, 146],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [36, 0, 0, 44, 63, 38, 0, 176, 47, 76, 167, 50, 65, 0, 142],
-        [67, 0, 44, 0, 47, 75, 0, 169, 52, 70, 186, 58, 70, 0, 159],
-        [45, 0, 63, 47, 0, 51, 0, 182, 53, 83, 187, 58, 107, 0, 142],
-        [64, 0, 38, 75, 51, 0, 0, 178, 46, 48, 193, 80, 72, 0, 149],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [176, 0, 176, 169, 182, 178, 0, 0, 151, 162, 196, 191, 143, 0, 195],
-        [43, 0, 47, 52, 53, 46, 0, 151, 0, 182, 166, 115, 91, 0, 109],
-        [63, 0, 76, 70, 83, 48, 0, 162, 182, 0, 167, 105, 144, 0, 124],
-        [190, 0, 167, 186, 187, 193, 0, 196, 166, 167, 0, 182, 165, 0, 109],
-        [44, 0, 50, 58, 58, 80, 0, 191, 115, 105, 182, 0, 82, 0, 154],
-        [75, 0, 65, 70, 107, 72, 0, 143, 91, 144, 165, 82, 0, 0, 160],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [146, 0, 142, 159, 142, 149, 0, 195, 109, 124, 109, 154, 160, 0, 0]
-      ])
-
-    %StatsCollector{cache_fetch: nil, cache_get: nil} = :sys.get_state(pid)
+    assert 0 = Registry.count(Archethic.Utils.JobCacheRegistry)
 
     with_mocks([
       {BeaconChain, [:passthrough], get_network_stats: fn _ -> %{} end},
       {NetworkCoordinates, [],
        fetch_network_stats: fn _summary_time ->
-         tensor
+         Nx.tensor(1)
        end},
       {Election, [],
        beacon_storage_nodes: fn
@@ -249,14 +242,11 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
          _, _, _ -> []
        end}
     ]) do
-      summary_time = DateTime.utc_now()
-
-      assert ^tensor = StatsCollector.fetch(summary_time)
+      # can't compare tensor directly so we compare serialization
+      expected = Nx.tensor(1) |> Nx.to_binary()
+      assert ^expected = StatsCollector.fetch(DateTime.utc_now()) |> Nx.to_binary()
     end
 
-    %StatsCollector{cache_fetch: pid1, cache_get: pid2} = :sys.get_state(pid)
-
-    assert is_pid(pid1)
-    assert is_pid(pid2)
+    assert 1 = Registry.count(Archethic.Utils.JobCacheRegistry)
   end
 end

--- a/test/archethic/beacon_chain/subset_test.exs
+++ b/test/archethic/beacon_chain/subset_test.exs
@@ -271,6 +271,9 @@ defmodule Archethic.BeaconChain.SubsetTest do
       MockDB
       |> expect(:write_beacon_summary, fn summary -> send(me, {:summary_stored, summary}) end)
 
+      # subset process is dependant of stats collector
+      send(Process.whereis(StatsCollector), {:next_summary_time, ~U[2023-07-11 02:00:00Z]})
+
       send(pid, {:current_epoch_of_slot_timer, slot_time})
 
       assert_receive {:summary_stored, summary}, 2000
@@ -281,10 +284,6 @@ defmodule Archethic.BeaconChain.SubsetTest do
                transaction_attestations: [^attestation],
                network_patches: ["F7A", "78A"]
              } = summary
-
-      Process.sleep(5)
-
-      assert [] = SummaryCache.stream_current_slots(subset) |> Enum.to_list()
     end
   end
 

--- a/test/archethic/beacon_chain/subset_test.exs
+++ b/test/archethic/beacon_chain/subset_test.exs
@@ -236,7 +236,7 @@ defmodule Archethic.BeaconChain.SubsetTest do
         _, %Ping{}, _ ->
           {:ok, %Ok{}}
 
-        _, %GetNetworkStats{subsets: _}, _ ->
+        _, %GetNetworkStats{}, _ ->
           {:ok,
            %NetworkStats{
              stats: %{

--- a/test/archethic/p2p/message/get_network_stats_test.exs
+++ b/test/archethic/p2p/message/get_network_stats_test.exs
@@ -4,4 +4,15 @@ defmodule Archethic.P2P.Message.GetNetworkStatsTest do
 
   alias Archethic.P2P.Message.GetNetworkStats
   doctest GetNetworkStats
+
+  describe "serialize/deserialize" do
+    summary_time = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    msg = %GetNetworkStats{summary_time: summary_time}
+
+    assert {^msg, <<>>} =
+             msg
+             |> GetNetworkStats.serialize()
+             |> GetNetworkStats.deserialize()
+  end
 end

--- a/test/archethic/utils/job_cache_test.exs
+++ b/test/archethic/utils/job_cache_test.exs
@@ -5,6 +5,11 @@ defmodule Archethic.Utils.JobCacheTest do
 
   doctest JobCache
 
+  test "should exit if no process" do
+    pid = spawn(fn -> :ok end)
+    assert {:normal, _} = catch_exit(JobCache.get!(pid))
+  end
+
   test "should not immediately start the job by default" do
     :persistent_term.put(:value, 1)
 
@@ -24,5 +29,17 @@ defmodule Archethic.Utils.JobCacheTest do
     :persistent_term.put(:value, 2)
 
     assert 1 = JobCache.get!(pid)
+  end
+
+  test "should be able to start when using get! if there is no process yet" do
+    :persistent_term.put(:value, 1)
+
+    assert 1 = JobCache.get!(:name, function: fn -> :persistent_term.get(:value) end)
+    assert 1 = JobCache.get!({:some, :key}, function: fn -> :persistent_term.get(:value) end)
+
+    :persistent_term.put(:value, 2)
+
+    assert 1 = JobCache.get!(:name)
+    assert 1 = JobCache.get!({:some, :key})
   end
 end

--- a/test/archethic/utils/job_cache_test.exs
+++ b/test/archethic/utils/job_cache_test.exs
@@ -4,4 +4,25 @@ defmodule Archethic.Utils.JobCacheTest do
   alias Archethic.Utils.JobCache
 
   doctest JobCache
+
+  test "should not immediately start the job by default" do
+    :persistent_term.put(:value, 1)
+
+    {:ok, pid} = JobCache.start_link(function: fn -> :persistent_term.get(:value) end)
+
+    :persistent_term.put(:value, 2)
+
+    assert 2 = JobCache.get!(pid)
+  end
+
+  test "should immediately start the job if :immediate flag is passed " do
+    :persistent_term.put(:value, 1)
+
+    {:ok, pid} =
+      JobCache.start_link(immediate: true, function: fn -> :persistent_term.get(:value) end)
+
+    :persistent_term.put(:value, 2)
+
+    assert 1 = JobCache.get!(pid)
+  end
 end


### PR DESCRIPTION
# Description

The GetNetworkStats message is called by many nodes at the same time, the computation it does is heavy. I added a JobCache so the computation is only done once (cache reset after 30s). 
I also added a 5s timer which is bigger than the 3s default.
Fixes #1325

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This can only be tested in stress condition. I'll setup some test environment tomorrow.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
