### PR TITLE
Default RPC Timeout to 30s

### DIFF
--- a/lib/archethic_web/api/jsonrpc/controllers/jsonrpc_controller.ex
+++ b/lib/archethic_web/api/jsonrpc/controllers/jsonrpc_controller.ex
@@ -57,7 +57,8 @@ defmodule ArchethicWeb.API.JsonRPCController do
 
   defp execute_request_concurently(requests) do
     Task.Supervisor.async_stream(TaskSupervisor, requests, &execute_request/1,
-      on_timeout: :kill_task
+      on_timeout: :kill_task,
+      timeout: 30_000
     )
     |> Enum.zip(requests)
     |> Enum.map(fn


### PR DESCRIPTION
# Description

Default timeout set to 30s instead of 5s
Fixes #1336

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

not tested 👼 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
