### PR TITLE
Smart Contracts: Add the `do..end` syntax for condition blocks

### DIFF
--- a/lib/archethic/contracts/interpreter/condition_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/condition_interpreter.ex
@@ -18,7 +18,8 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
   Parse the given node and return the trigger and the actions block.
   """
   @spec parse(any(), FunctionKeys.t()) ::
-          {:ok, Contract.condition_type(), ConditionsSubjects.t()} | {:error, any(), String.t()}
+          {:ok, Contract.condition_type(), ConditionsSubjects.t() | Macro.t()}
+          | {:error, any(), String.t()}
   def parse(
         # legacy syntax: condition transaction: []
         node = {{:atom, "condition"}, _, [[{{:atom, condition_name}, keyword}]]},
@@ -26,13 +27,13 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
       ) do
     case condition_name do
       "transaction" ->
-        do_parse({:transaction, nil, nil}, keyword, functions_keys, node)
+        do_parse_keyword({:transaction, nil, nil}, keyword, functions_keys, node)
 
       "inherit" ->
-        do_parse(:inherit, keyword, functions_keys, node)
+        do_parse_keyword(:inherit, keyword, functions_keys, node)
 
       "oracle" ->
-        do_parse(:oracle, keyword, functions_keys, node)
+        do_parse_keyword(:oracle, keyword, functions_keys, node)
 
       _ ->
         {:error, node, "invalid condition type"}
@@ -52,10 +53,10 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
       ) do
     case triggered_by do
       "oracle" ->
-        do_parse(:oracle, keyword, functions_keys, node)
+        do_parse_keyword(:oracle, keyword, functions_keys, node)
 
       "transaction" ->
-        do_parse({:transaction, nil, nil}, keyword, functions_keys, node)
+        do_parse_keyword({:transaction, nil, nil}, keyword, functions_keys, node)
 
       _ ->
         {:error, node, "unknown condition type"}
@@ -80,7 +81,49 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
         _ -> Enum.map(args, fn {{:atom, arg_name}, _, nil} -> arg_name end)
       end
 
-    do_parse({:transaction, action_name, args}, keyword, functions_keys, node)
+    do_parse_keyword({:transaction, action_name, args}, keyword, functions_keys, node)
+  end
+
+  def parse(
+        node =
+          {{:atom, "condition"}, _,
+           [[{{:atom, "triggered_by"}, {{:atom, triggered_by}, _, nil}}], [do: block]]},
+        functions_keys
+      ) do
+    case triggered_by do
+      "oracle" -> do_parse_block(:oracle, block, functions_keys)
+      "transaction" -> do_parse_block({:transaction, nil, nil}, block, functions_keys)
+      _ -> {:error, node, "unknown condition type"}
+    end
+
+    do_parse_block({:transaction, nil, nil}, block, functions_keys)
+  end
+
+  def parse(
+        {{:atom, "condition"}, _, [{{:atom, "inherit"}, _, nil}, [do: block]]},
+        functions_keys
+      ) do
+    do_parse_block(:inherit, block, functions_keys)
+  end
+
+  def parse(
+        {{:atom, "condition"}, _,
+         [
+           [
+             {{:atom, "triggered_by"}, {{:atom, "transaction"}, _, nil}},
+             {{:atom, "on"}, {{:atom, action_name}, _, args}}
+           ],
+           [do: block]
+         ]},
+        functions_keys
+      ) do
+    args =
+      case args do
+        nil -> []
+        _ -> Enum.map(args, fn {{:atom, arg_name}, _, nil} -> arg_name end)
+      end
+
+    do_parse_block({:transaction, action_name, args}, block, functions_keys)
   end
 
   def parse(node, _) do
@@ -95,7 +138,25 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreter do
   #  | .__/|_|  |_| \_/ \__,_|\__\___|
   #  |_|
   # ----------------------------------------------------------------------
-  defp do_parse(condition_type, keyword, functions_keys, node) do
+  defp do_parse_block(condition_type, block, functions_keys) do
+    {new_ast, _} =
+      Macro.traverse(
+        AST.wrap_in_block(block),
+        %{
+          functions: functions_keys
+        },
+        fn node, acc ->
+          CommonInterpreter.prewalk(node, acc)
+        end,
+        fn node, acc ->
+          CommonInterpreter.postwalk(node, acc)
+        end
+      )
+
+    {:ok, condition_type, new_ast}
+  end
+
+  defp do_parse_keyword(condition_type, keyword, functions_keys, node) do
     global_variable =
       case condition_type do
         {:transaction, _, _} -> "transaction"

--- a/lib/archethic/contracts/interpreter/condition_validator.ex
+++ b/lib/archethic/contracts/interpreter/condition_validator.ex
@@ -13,9 +13,33 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
   @doc """
   Determines if the conditions of a contract are valid from the given constants
   """
-  @spec execute_condition(ConditionsSubjects.t(), map()) ::
+  @spec execute_condition(Macro.t() | ConditionsSubjects.t(), map()) ::
           {:ok, list(String.t())} | {:error, String.t(), list(String.t())}
-  def execute_condition(conditions, constants = %{}) do
+  def execute_condition(condition_or_ast, constants = %{}) do
+    case condition_or_ast do
+      %ConditionsSubjects{} ->
+        # condition triggered_by: <trigger>, as: [ <field>: <expr> ]
+        execute_condition_keyword(condition_or_ast, constants)
+
+      _ ->
+        # condition triggered_by: <trigger> do <expr> end
+        execute_condition_block(condition_or_ast, constants)
+    end
+  end
+
+  defp execute_condition_block(ast, constants = %{}) do
+    if evaluate_condition(ast, constants) do
+      # TODO: logs
+      logs = []
+      {:ok, logs}
+    else
+      # TODO: logs
+      logs = []
+      {:error, "N/A", logs}
+    end
+  end
+
+  defp execute_condition_keyword(conditions, constants = %{}) do
     conditions
     |> Map.from_struct()
     |> Enum.reduce_while(

--- a/lib/archethic/contracts/interpreter/condition_validator.ex
+++ b/lib/archethic/contracts/interpreter/condition_validator.ex
@@ -15,16 +15,14 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
   """
   @spec execute_condition(Macro.t() | ConditionsSubjects.t(), map()) ::
           {:ok, list(String.t())} | {:error, String.t(), list(String.t())}
-  def execute_condition(condition_or_ast, constants = %{}) do
-    case condition_or_ast do
-      %ConditionsSubjects{} ->
-        # condition triggered_by: <trigger>, as: [ <field>: <expr> ]
-        execute_condition_keyword(condition_or_ast, constants)
+  def execute_condition(subjects = %ConditionsSubjects{}, constants = %{}) do
+    # condition triggered_by: <trigger>, as: [ <field>: <expr> ]
+    execute_condition_subjects(subjects, constants)
+  end
 
-      _ ->
-        # condition triggered_by: <trigger> do <expr> end
-        execute_condition_block(condition_or_ast, constants)
-    end
+  def execute_condition(ast, constants = %{}) do
+    # condition triggered_by: <trigger> do <expr> end
+    execute_condition_block(ast, constants)
   end
 
   defp execute_condition_block(ast, constants = %{}) do
@@ -39,7 +37,7 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
     end
   end
 
-  defp execute_condition_keyword(conditions, constants = %{}) do
+  defp execute_condition_subjects(conditions, constants = %{}) do
     conditions
     |> Map.from_struct()
     |> Enum.reduce_while(

--- a/test/archethic/contracts/interpreter/condition_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/condition_interpreter_test.exs
@@ -269,4 +269,34 @@ defmodule Archethic.Contracts.Interpreter.ConditionInterpreterTest do
                |> Interpreter.sanitize_code()
     end
   end
+
+  describe "do-end syntax" do
+    test "should parse a unnamed action" do
+      code = ~s"""
+      condition triggered_by: transaction do
+        true
+      end
+      """
+
+      assert {:ok, {:transaction, nil, nil}, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ConditionInterpreter.parse([])
+    end
+
+    test "should parse a named action" do
+      code = ~s"""
+      condition triggered_by: transaction, on: count(x, y) do
+        true
+      end
+      """
+
+      assert {:ok, {:transaction, "count", ["x", "y"]}, _} =
+               code
+               |> Interpreter.sanitize_code()
+               |> elem(1)
+               |> ConditionInterpreter.parse([])
+    end
+  end
 end


### PR DESCRIPTION
# Description

Add the new `do..end` syntax for conditions:

```
condition inherit do 
   ...
end

condition triggered_by: oracle do 
   ...
end

condition triggered_by: transaction do 
   ...
end

condition triggered_by: transaction, on: vote(x) do 
   ...
end
```

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
