### PR TITLE
Consensus error due to wrong timestamp used

### DIFF
--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1087,11 +1087,10 @@ defmodule Archethic.Mining.ValidationContext do
            transaction: tx = %Transaction{data: %TransactionData{recipients: recipients}},
            previous_transaction: prev_tx,
            resolved_addresses: resolved_addresses,
-           validation_time: validation_time,
            contract_context: contract_context,
            validation_stamp:
              stamp = %ValidationStamp{
-               timestamp: timestamp,
+               timestamp: validation_time,
                ledger_operations: %LedgerOperations{fee: stamp_fee}
              }
          }
@@ -1114,7 +1113,7 @@ defmodule Archethic.Mining.ValidationContext do
       )
 
     {sufficient_funds?, ledger_operations} =
-      get_ledger_operations(context, stamp_fee, timestamp, next_state)
+      get_ledger_operations(context, stamp_fee, validation_time, next_state)
 
     subsets_verifications = [
       timestamp: fn -> valid_timestamp(stamp, context) end,
@@ -1193,12 +1192,11 @@ defmodule Archethic.Mining.ValidationContext do
   end
 
   defp valid_stamp_error?(
-         %ValidationStamp{error: error},
+         %ValidationStamp{error: error, timestamp: validation_time},
          %__MODULE__{
            transaction: tx,
            previous_transaction: prev_tx,
-           valid_pending_transaction?: valid_pending_transaction?,
-           validation_time: validation_time
+           valid_pending_transaction?: valid_pending_transaction?
          },
          valid_contract_execution?,
          valid_contract_recipients?,


### PR DESCRIPTION
# Description

Fix concensus error but using the `validation_time` instead of the `cross_validation_time` for the fees calculations
Fixes #1344

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
