### PR TITLE
Reconnection backoff & heartbeat mechanism

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -128,7 +128,11 @@ config :archethic, Archethic.P2P.Client, MockClient
 config :archethic, Archethic.P2P.GeoPatch.GeoIP, MockGeoIP
 
 config :archethic, Archethic.P2P.BootstrappingSeeds, enabled: false
-config :archethic, Archethic.P2P.Client.Connection, backoff_strategy: :static
+
+config :archethic, Archethic.P2P.Client.Connection,
+  backoff_strategy: :static,
+  heartbeat_interval: 200,
+  reconnect_delay: 50
 
 config :archethic, Archethic.Mining.PendingTransactionValidation, validate_node_ip: true
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -128,6 +128,7 @@ config :archethic, Archethic.P2P.Client, MockClient
 config :archethic, Archethic.P2P.GeoPatch.GeoIP, MockGeoIP
 
 config :archethic, Archethic.P2P.BootstrappingSeeds, enabled: false
+config :archethic, Archethic.P2P.Client.Connection, backoff_strategy: :static
 
 config :archethic, Archethic.Mining.PendingTransactionValidation, validate_node_ip: true
 

--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -23,6 +23,7 @@ defmodule Archethic.P2P.Client.Connection do
   use GenStateMachine, callback_mode: [:handle_event_function, :state_enter], restart: :temporary
   @vsn Mix.Project.config()[:version]
   @table_name :connection_status
+  @max_reconnect_attempts 5
 
   @doc """
   Starts a new connection
@@ -57,6 +58,18 @@ defmodule Archethic.P2P.Client.Connection do
       timeout ->
         {:error, :timeout}
     end
+  end
+
+  @doc """
+  When called, if disconnect, it will try to connect to socket
+  Noop if it's already connected
+
+  It's used when some node has been offline for a long time
+  It has connected to us so we know we can connect to it as well
+  """
+  @spec wake_up(Crypto.key()) :: :ok
+  def wake_up(public_key) do
+    GenStateMachine.cast(via_tuple(public_key), :wake_up)
   end
 
   @doc """
@@ -102,7 +115,8 @@ defmodule Archethic.P2P.Client.Connection do
       request_id: 0,
       messages: %{},
       send_tasks: %{},
-      availability_timer: {nil, 0}
+      availability_timer: {nil, 0},
+      reconnect_attempts: 0
     }
 
     {:ok, :initializing, data, [{:next_event, :internal, {:connect, from}}]}
@@ -190,7 +204,7 @@ defmodule Archethic.P2P.Client.Connection do
       end)
 
     # Reconnect with backoff
-    actions = [{{:timeout, :reconnect}, 500, nil} | actions]
+    actions = [{{:timeout, :reconnect}, backoff(data.reconnect_attempts), nil} | actions]
     {:keep_state, new_data, actions}
   end
 
@@ -204,7 +218,9 @@ defmodule Archethic.P2P.Client.Connection do
 
     # Start availability timer
     new_data =
-      Map.update!(data, :availability_timer, fn
+      data
+      |> Map.put(:reconnect_attempts, 0)
+      |> Map.update!(:availability_timer, fn
         {nil, time} ->
           {System.monotonic_time(:second), time}
 
@@ -217,7 +233,6 @@ defmodule Archethic.P2P.Client.Connection do
 
   def handle_event(:enter, _old_state, :initializing, _data), do: :keep_state_and_data
   def handle_event(:enter, _old_state, :disconnected, _data), do: :keep_state_and_data
-  def handle_event(:enter, _old_state, {:connected, _socket}, _data), do: :keep_state_and_data
 
   # called from the :disconnected or :initializing state
   def handle_event(
@@ -258,9 +273,15 @@ defmodule Archethic.P2P.Client.Connection do
   end
 
   # this message is used to delay next connection attempt
-  def handle_event({:timeout, :reconnect}, _event_data, _state, _data) do
-    actions = [{:next_event, :internal, {:connect, nil}}]
-    {:keep_state_and_data, actions}
+  def handle_event({:timeout, :reconnect}, _event_data, _state, data) do
+    if data.reconnect_attempts > @max_reconnect_attempts do
+      :keep_state_and_data
+    else
+      actions = [{:next_event, :internal, {:connect, nil}}]
+
+      new_data = Map.update!(data, :reconnect_attempts, &(&1 + 1))
+      {:keep_state, new_data, actions}
+    end
   end
 
   def handle_event(
@@ -270,6 +291,25 @@ defmodule Archethic.P2P.Client.Connection do
         _data
       ) do
     send(from, {ref, {:error, :closed}})
+    :keep_state_and_data
+  end
+
+  def handle_event(
+        :cast,
+        :wake_up,
+        :disconnected,
+        data
+      ) do
+    actions = [{:next_event, :internal, {:connect, nil}}]
+    {:keep_state, %{data | reconnect_attempts: 0}, actions}
+  end
+
+  def handle_event(
+        :cast,
+        :wake_up,
+        _,
+        _data
+      ) do
     :keep_state_and_data
   end
 
@@ -440,13 +480,13 @@ defmodule Archethic.P2P.Client.Connection do
 
   # Task.async sending us the result of the handle_connect
   def handle_event(:info, {_ref, {:error, _reason, nil}}, _, data) do
-    actions = [{{:timeout, :reconnect}, 500, nil}]
+    actions = [{{:timeout, :reconnect}, backoff(data.reconnect_attempts), nil}]
     {:next_state, :disconnected, data, actions}
   end
 
   def handle_event(:info, {_ref, {:error, reason, from}}, _, data) do
     send(from, {:error, reason})
-    actions = [{{:timeout, :reconnect}, 500, nil}]
+    actions = [{{:timeout, :reconnect}, backoff(data.reconnect_attempts), nil}]
     {:next_state, :disconnected, data, actions}
   end
 
@@ -540,4 +580,16 @@ defmodule Archethic.P2P.Client.Connection do
   end
 
   def code_change(_old_vsn, state, data, _extra), do: {:ok, state, data}
+
+  defp backoff(attempts) do
+    config = Application.get_env(:archethic, __MODULE__, [])
+
+    case Keyword.get(config, :backoff_strategy, :exponential) do
+      :static ->
+        500
+
+      :exponential ->
+        2 ** attempts * 500
+    end
+  end
 end

--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -24,7 +24,16 @@ defmodule Archethic.P2P.Client.Connection do
   @vsn Mix.Project.config()[:version]
   @table_name :connection_status
   @max_reconnect_attempts 5
-  @heartbeat_interval 10_000
+  @heartbeat_interval Keyword.get(
+                        Application.compile_env(:archethic, __MODULE__, []),
+                        :heartbeat_interval,
+                        10_000
+                      )
+  @reconnect_delay Keyword.get(
+                     Application.compile_env(:archethic, __MODULE__, []),
+                     :reconnect_delay,
+                     500
+                   )
 
   @doc """
   Starts a new connection
@@ -281,7 +290,7 @@ defmodule Archethic.P2P.Client.Connection do
 
   # this message is used to delay next connection attempt
   def handle_event({:timeout, :reconnect}, _event_data, _state, data) do
-    if data.reconnect_attempts > @max_reconnect_attempts do
+    if data.reconnect_attempts >= @max_reconnect_attempts do
       :keep_state_and_data
     else
       actions = [{:next_event, :internal, {:connect, nil}}]
@@ -626,10 +635,10 @@ defmodule Archethic.P2P.Client.Connection do
 
     case Keyword.get(config, :backoff_strategy, :exponential) do
       :static ->
-        500
+        @reconnect_delay
 
       :exponential ->
-        2 ** attempts * 500
+        2 ** attempts * @reconnect_delay
     end
   end
 end

--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -24,6 +24,7 @@ defmodule Archethic.P2P.Client.Connection do
   @vsn Mix.Project.config()[:version]
   @table_name :connection_status
   @max_reconnect_attempts 5
+  @heartbeat_interval 10_000
 
   @doc """
   Starts a new connection
@@ -116,7 +117,9 @@ defmodule Archethic.P2P.Client.Connection do
       messages: %{},
       send_tasks: %{},
       availability_timer: {nil, 0},
-      reconnect_attempts: 0
+      reconnect_attempts: 0,
+      heartbeats_sent: 0,
+      heartbeats_received: 0
     }
 
     {:ok, :initializing, data, [{:next_event, :internal, {:connect, from}}]}
@@ -220,6 +223,8 @@ defmodule Archethic.P2P.Client.Connection do
     new_data =
       data
       |> Map.put(:reconnect_attempts, 0)
+      |> Map.put(:heartbeats_sent, 0)
+      |> Map.put(:heartbeats_received, 0)
       |> Map.update!(:availability_timer, fn
         {nil, time} ->
           {System.monotonic_time(:second), time}
@@ -227,6 +232,8 @@ defmodule Archethic.P2P.Client.Connection do
         timer ->
           timer
       end)
+
+    Process.send_after(self(), :heartbeat, @heartbeat_interval)
 
     {:keep_state, new_data}
   end
@@ -421,6 +428,35 @@ defmodule Archethic.P2P.Client.Connection do
     end
   end
 
+  def handle_event(
+        :info,
+        :heartbeat,
+        {:connected, socket},
+        data = %{
+          transport: transport,
+          heartbeats_sent: heartbeats_sent,
+          heartbeats_received: heartbeats_received
+        }
+      ) do
+    # disconnect if missed more than 2 heartbeats
+    if heartbeats_sent - heartbeats_received >= 2 do
+      {:next_state, :disconnected, data}
+    else
+      transport.handle_send(socket, "hb")
+      Process.send_after(self(), :heartbeat, @heartbeat_interval)
+      {:keep_state, %{data | heartbeats_sent: heartbeats_sent + 1}}
+    end
+  end
+
+  def handle_event(
+        :info,
+        :heartbeat,
+        _state,
+        _data
+      ) do
+    :keep_state_and_data
+  end
+
   def handle_event(:info, {ref, :ok}, {:connected, _socket}, data = %{send_tasks: send_tasks}) do
     case Map.pop(send_tasks, ref) do
       {nil, _} ->
@@ -496,7 +532,8 @@ defmodule Archethic.P2P.Client.Connection do
         {:connected, _socket},
         data = %{
           transport: transport,
-          node_public_key: node_public_key
+          node_public_key: node_public_key,
+          heartbeats_received: heartbeats_received
         }
       ) do
     case transport.handle_message(event) do
@@ -506,6 +543,9 @@ defmodule Archethic.P2P.Client.Connection do
         )
 
         {:next_state, :disconnected, data}
+
+      {:ok, "hb"} ->
+        {:keep_state, %{data | heartbeats_received: heartbeats_received + 1}}
 
       {:ok, msg} ->
         set_node_connected(node_public_key)

--- a/lib/archethic/p2p/listener_protocol.ex
+++ b/lib/archethic/p2p/listener_protocol.ex
@@ -39,6 +39,19 @@ defmodule Archethic.P2P.ListenerProtocol do
   end
 
   def handle_info(
+        {_transport, socket, "hb"},
+        state = %{transport: transport}
+      ) do
+    :inet.setopts(socket, active: :once)
+
+    Task.Supervisor.start_child(TaskSupervisor, fn ->
+      transport.send(socket, "hb")
+    end)
+
+    {:noreply, state}
+  end
+
+  def handle_info(
         {_transport, socket, msg},
         state = %{transport: transport}
       ) do

--- a/lib/archethic/p2p/listener_protocol.ex
+++ b/lib/archethic/p2p/listener_protocol.ex
@@ -9,6 +9,7 @@ defmodule Archethic.P2P.ListenerProtocol do
 
   alias Archethic.Crypto
 
+  alias Archethic.P2P.Client.Connection
   alias Archethic.P2P.Message
   alias Archethic.P2P.MessageEnvelop
 
@@ -69,6 +70,9 @@ defmodule Archethic.P2P.ListenerProtocol do
 
         start_processing_time = System.monotonic_time()
         response = Message.process(message, sender_public_key)
+
+        # we may attempt to wakeup a connection that offline
+        Connection.wake_up(sender_public_key)
 
         :telemetry.execute(
           [:archethic, :p2p, :handle_message],

--- a/test/archethic/p2p/client/connection_test.exs
+++ b/test/archethic/p2p/client/connection_test.exs
@@ -12,6 +12,17 @@ defmodule Archethic.P2P.Client.ConnectionTest do
 
   alias Archethic.Utils
 
+  @heartbeat_interval Keyword.get(
+                        Application.compile_env(:archethic, Connection, []),
+                        :heartbeat_interval,
+                        10_000
+                      )
+  @reconnect_delay Keyword.get(
+                     Application.compile_env(:archethic, Connection, []),
+                     :reconnect_delay,
+                     500
+                   )
+
   test "start_link/1 should open a socket and a connection worker and initialize the backlog and lookup tables" do
     {:ok, pid} =
       Connection.start_link(
@@ -164,7 +175,7 @@ defmodule Archethic.P2P.Client.ConnectionTest do
           {:ok, make_ref()}
         end
 
-        def handle_send(_socket, <<0::32, _rest::bitstring>>), do: :ok
+        def handle_send(_socket, _), do: :ok
 
         def handle_message({_, _, _}), do: {:error, :closed}
       end
@@ -185,6 +196,36 @@ defmodule Archethic.P2P.Client.ConnectionTest do
       Process.sleep(550)
 
       assert {{:connected, _socket}, _} = :sys.get_state(pid)
+    end
+
+    test "should stop trying to reconnect after some time" do
+      defmodule MockTransportOffline do
+        alias Archethic.P2P.Client.Transport
+
+        @behaviour Transport
+
+        def handle_connect({127, 0, 0, 1}, _port) do
+          {:error, :timeout}
+        end
+
+        def handle_send(_socket, _), do: :ok
+
+        def handle_message({_, _, _}), do: {:error, :closed}
+      end
+
+      {:ok, pid} =
+        Connection.start_link(
+          transport: MockTransportOffline,
+          ip: {127, 0, 0, 1},
+          port: 3000,
+          node_public_key: Crypto.first_node_public_key()
+        )
+
+      Process.sleep(@reconnect_delay * 6)
+      assert {:disconnected, %{reconnect_attempts: 5}} = :sys.get_state(pid)
+
+      Process.sleep(@reconnect_delay * 2)
+      assert {:disconnected, %{reconnect_attempts: 5}} = :sys.get_state(pid)
     end
 
     test "should get an error when the timeout is reached" do
@@ -545,6 +586,57 @@ defmodule Archethic.P2P.Client.ConnectionTest do
     end
   end
 
+  describe "Stale detection" do
+    test "should change state to disconnected once a few heartbeats are missed" do
+      defmodule MockTransportStale do
+        alias Archethic.P2P.Client.Transport
+
+        @behaviour Transport
+
+        def handle_connect({127, 0, 0, 1}, _port) do
+          conn_count = :persistent_term.get(:conn_count, 0)
+          :persistent_term.put(:conn_count, conn_count + 1)
+
+          if conn_count == 0 do
+            {:ok, make_ref()}
+          else
+            {:error, :timeout}
+          end
+        end
+
+        def handle_send(_socket, "hb") do
+          hb_count = :persistent_term.get(:hb_count, 0)
+          :persistent_term.put(:hb_count, hb_count + 1)
+
+          # become stale after 5 hbs
+          if hb_count <= 5 do
+            send(self(), {:tcp, make_ref(), "hb"})
+          end
+
+          :ok
+        end
+
+        def handle_send(_socket, _), do: :ok
+
+        def handle_message({_, _, data}), do: {:ok, data}
+      end
+
+      {:ok, pid} =
+        Connection.start_link(
+          transport: MockTransportStale,
+          ip: {127, 0, 0, 1},
+          port: 3000,
+          node_public_key: Crypto.first_node_public_key()
+        )
+
+      Process.sleep(@heartbeat_interval * 5)
+      assert {{:connected, _}, _} = :sys.get_state(pid)
+
+      Process.sleep(@heartbeat_interval * 5)
+      assert {:disconnected, _} = :sys.get_state(pid)
+    end
+  end
+
   defmodule MockTransport do
     alias Archethic.P2P.Client.Transport
 
@@ -552,6 +644,11 @@ defmodule Archethic.P2P.Client.ConnectionTest do
 
     def handle_connect(_ip, _port) do
       {:ok, make_ref()}
+    end
+
+    def handle_send(_socket, "hb") do
+      send(self(), {:tcp, make_ref(), "hb"})
+      :ok
     end
 
     def handle_send(_socket, _data), do: :ok
@@ -568,7 +665,7 @@ defmodule Archethic.P2P.Client.ConnectionTest do
       {:ok, make_ref()}
     end
 
-    def handle_send(_socket, <<0::32, _rest::bitstring>>), do: :ok
+    def handle_send(_socket, _), do: :ok
 
     def handle_message({_, _, _}), do: {:error, :closed}
   end


### PR DESCRIPTION
# Description

- Exponential backoff on reconnect
- Stop trying to reconnect after X times
- Wakeup when the other node connect to us
- Heartbeat to automatically close "stale" connections

- [ ] There is one scenario that is still to be resolved. In case of a "split", both nodes consider the other as "stale". In that scenario, there is no attempt of reconnection ever.

Fixes #1323

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally with multiple nodes and turning them on and off.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
