### PR TITLE
Utils.time_offset is more accurate

### DIFF
--- a/lib/archethic/beacon_chain/slot_timer.ex
+++ b/lib/archethic/beacon_chain/slot_timer.ex
@@ -33,9 +33,7 @@ defmodule Archethic.BeaconChain.SlotTimer do
   """
   @spec next_slot(DateTime.t()) :: DateTime.t()
   def next_slot(date_from = %DateTime{}) do
-    get_interval()
-    |> CronParser.parse!(true)
-    |> Utils.next_date(date_from)
+    get_interval() |> Utils.next_date(date_from)
   end
 
   @doc """
@@ -162,7 +160,7 @@ defmodule Archethic.BeaconChain.SlotTimer do
   end
 
   defp schedule_new_slot(interval) do
-    Process.send_after(self(), :new_slot, Utils.time_offset(interval) * 1000)
+    Process.send_after(self(), :new_slot, Utils.time_offset(interval))
   end
 
   def config_change(nil), do: :ok

--- a/lib/archethic/beacon_chain/summary_timer.ex
+++ b/lib/archethic/beacon_chain/summary_timer.ex
@@ -25,9 +25,7 @@ defmodule Archethic.BeaconChain.SummaryTimer do
   """
   @spec next_summary(DateTime.t()) :: DateTime.t()
   def next_summary(date_from = %DateTime{}) do
-    get_interval()
-    |> CronParser.parse!(true)
-    |> Utils.next_date(date_from)
+    get_interval() |> Utils.next_date(date_from)
   end
 
   @doc """
@@ -125,7 +123,7 @@ defmodule Archethic.BeaconChain.SummaryTimer do
   end
 
   defp schedule_next_summary_time(interval) do
-    Process.send_after(self(), :next_summary_time, Utils.time_offset(interval) * 1000)
+    Process.send_after(self(), :next_summary_time, Utils.time_offset(interval))
   end
 
   def config_change(nil), do: :ok

--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -17,7 +17,6 @@ defmodule Archethic.Contracts.Worker do
   alias Archethic.TransactionChain.TransactionData.Recipient
   alias Archethic.Utils
   alias Archethic.Utils.DetectNodeResponsiveness
-  alias Crontab.CronExpression.Parser, as: CronParser
 
   @extended_mode? Mix.env() != :prod
 
@@ -194,7 +193,7 @@ defmodule Archethic.Contracts.Worker do
   defp schedule_trigger(trigger = {:interval, interval}, triggers_type) do
     now = DateTime.utc_now()
 
-    next_tick = interval |> CronParser.parse!(@extended_mode?) |> Utils.next_date(now)
+    next_tick = Utils.next_date(interval, now, @extended_mode?)
 
     # do not allow an interval trigger if there is a datetime trigger at same time
     # because one of them would get a "transaction is already mining"
@@ -204,7 +203,7 @@ defmodule Archethic.Contracts.Worker do
           "Contract scheduler skips next tick for trigger=interval because there is a trigger=datetime at the same time that takes precedence"
         )
 
-        interval |> CronParser.parse!(@extended_mode?) |> Utils.next_date(next_tick)
+        Utils.next_date(interval, next_tick, @extended_mode?)
       else
         next_tick
       end

--- a/lib/archethic/networking/scheduler.ex
+++ b/lib/archethic/networking/scheduler.ex
@@ -89,7 +89,7 @@ defmodule Archethic.Networking.Scheduler do
   end
 
   defp schedule_update(interval) do
-    Process.send_after(self(), :update, Utils.time_offset(interval) * 1000)
+    Process.send_after(self(), :update, Utils.time_offset(interval))
   end
 
   defp do_update do

--- a/lib/archethic/oracle_chain.ex
+++ b/lib/archethic/oracle_chain.ex
@@ -148,7 +148,6 @@ defmodule Archethic.OracleChain do
   def next_summary_date(date_from = %DateTime{}) do
     Application.get_env(:archethic, Scheduler)
     |> Keyword.fetch!(:summary_interval)
-    |> CronParser.parse!(true)
     |> Utils.next_date(date_from)
   end
 

--- a/lib/archethic/oracle_chain/services/hydrating_cache.ex
+++ b/lib/archethic/oracle_chain/services/hydrating_cache.ex
@@ -154,7 +154,7 @@ defmodule Archethic.OracleChain.Services.HydratingCache do
 
   defp next_tick_in_seconds(refresh_interval) do
     if is_binary(refresh_interval) do
-      Utils.time_offset(refresh_interval) * 1000
+      Utils.time_offset(refresh_interval)
     else
       refresh_interval
     end

--- a/lib/archethic/reward/scheduler.ex
+++ b/lib/archethic/reward/scheduler.ex
@@ -409,7 +409,7 @@ defmodule Archethic.Reward.Scheduler do
   end
 
   defp schedule(interval) do
-    Process.send_after(self(), :mint_rewards, Utils.time_offset(interval) * 1000)
+    Process.send_after(self(), :mint_rewards, Utils.time_offset(interval))
   end
 
   defp trigger_node?(validation_nodes, count \\ 0) do

--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -117,14 +117,12 @@ defmodule Archethic.SelfRepair do
       :archethic
       |> Application.get_env(SummaryTimer, [])
       |> Keyword.fetch!(:interval)
-      |> CronParser.parse!(true)
       |> Utils.next_date(last_sync_date)
 
     next_repair_date =
       :archethic
       |> Application.get_env(Scheduler, [])
       |> Keyword.fetch!(:interval)
-      |> CronParser.parse!(true)
       |> Utils.next_date(next_summary_date)
 
     DateTime.compare(DateTime.utc_now(), next_repair_date) != :lt

--- a/lib/archethic/self_repair/scheduler.ex
+++ b/lib/archethic/self_repair/scheduler.ex
@@ -19,7 +19,6 @@ defmodule Archethic.SelfRepair.Scheduler do
   alias Archethic.Utils
 
   alias Archethic.Bootstrap.Sync, as: BootstrapSync
-  alias Crontab.CronExpression.Parser, as: CronParser
 
   require Logger
 
@@ -169,7 +168,7 @@ defmodule Archethic.SelfRepair.Scheduler do
   end
 
   defp schedule_sync(interval) do
-    Process.send_after(self(), :sync, Utils.time_offset(interval) * 1000)
+    Process.send_after(self(), :sync, Utils.time_offset(interval))
   end
 
   defp last_sync_date_to_string(last_sync_date) do
@@ -203,8 +202,6 @@ defmodule Archethic.SelfRepair.Scheduler do
   """
   @spec next_repair_time(DateTime.t()) :: DateTime.t()
   def next_repair_time(ref_time \\ DateTime.utc_now()) do
-    get_interval()
-    |> CronParser.parse!(true)
-    |> Utils.next_date(ref_time)
+    get_interval() |> Utils.next_date(ref_time)
   end
 end

--- a/lib/archethic/shared_secrets/node_renewal_scheduler.ex
+++ b/lib/archethic/shared_secrets/node_renewal_scheduler.ex
@@ -7,8 +7,6 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
   them as new authorized nodes and update the daily nonce seed.
   """
 
-  alias Crontab.CronExpression.Parser, as: CronParser
-
   alias Archethic
 
   alias Archethic.Election
@@ -320,7 +318,7 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
   end
 
   defp schedule_renewal_message(interval) do
-    Process.send_after(self(), :make_renewal, Utils.time_offset(interval) * 1000)
+    Process.send_after(self(), :make_renewal, Utils.time_offset(interval))
   end
 
   defp trigger_node?(validation_nodes, count \\ 0) do
@@ -339,14 +337,9 @@ defmodule Archethic.SharedSecrets.NodeRenewalScheduler do
   """
   @spec next_application_date(DateTime.t()) :: DateTime.t()
   def next_application_date(date_from = %DateTime{}) do
-    get_application_date_interval()
-    |> CronParser.parse!(true)
-    |> Utils.next_date(date_from)
-  end
-
-  defp get_application_date_interval do
     Application.get_env(:archethic, __MODULE__)
     |> Keyword.fetch!(:application_interval)
+    |> Utils.next_date(date_from)
   end
 
   def code_change(_old_vsn, state, data, _extra), do: {:ok, state, data}


### PR DESCRIPTION
# Description

Fixes an issue where the function `Utils.time_offset` returned the offset in second, but this was creating scheduler to be non really accurate because of milliseconds 

Alos refactored `Utils.next_date` to be more friendly to use

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
