### PR TITLE
Add state unspent outputs in graphql

### DIFF
--- a/lib/archethic_web/api/graphql/schema/transaction_type.ex
+++ b/lib/archethic_web/api/graphql/schema/transaction_type.ex
@@ -170,6 +170,7 @@ defmodule ArchethicWeb.API.GraphQL.Schema.TransactionType do
   - token id: It is the id for a token which is allocated when the token is minted.
   - Timestamp: Date time when the UTXO created/manipulated
   - Version: Version of the UTXO data structure
+  - State: It is the state of a smart contract
   """
   object :unspent_output do
     field(:from, :address)
@@ -179,6 +180,14 @@ defmodule ArchethicWeb.API.GraphQL.Schema.TransactionType do
     field(:token_id, :integer)
     field(:timestamp, :timestamp)
     field(:version, :integer)
+    field(:state, :state)
+  end
+
+  @desc """
+    [State] represents the smart contract state
+  """
+  scalar :state do
+    serialize(& &1)
   end
 
   @desc """


### PR DESCRIPTION
# Description

Since AEIP-14 smart contracts have the possibility to create a state stored in a new UTXO.
However this new UTXO content was not accessible through graphql API.

This PR update the unspent_outputs graphql schemas to add the state.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Created a smart contract using state and request it's state using graphql

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
