### PR TITLE
Graphql transaction_chain from filter

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -354,9 +354,13 @@ defmodule Archethic do
   Retrieve a transaction chain based on an address from the closest nodes
   by setting `paging_address as an offset address.
   """
-  @spec get_transaction_chain_by_paging_address(binary(), binary() | nil, :asc | :desc) ::
+  @spec get_pagined_transaction_chain(
+          address :: Crypto.prepended_hash(),
+          paging_state :: Crypto.prepended_hash() | DateTime.t() | nil,
+          order :: :asc | :desc
+        ) ::
           {:ok, list(Transaction.t())} | {:error, :network_issue}
-  def get_transaction_chain_by_paging_address(address, paging_address, order) do
+  def get_pagined_transaction_chain(address, paging_state, order) do
     case get_last_transaction_address(address) do
       {:ok, last_address} ->
         storage_nodes =
@@ -364,7 +368,7 @@ defmodule Archethic do
 
         transactions =
           TransactionChain.fetch(last_address, storage_nodes,
-            paging_address: paging_address,
+            paging_state: paging_state,
             order: order
           )
           |> Enum.take(10)

--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -352,7 +352,7 @@ defmodule Archethic do
 
   @doc """
   Retrieve a transaction chain based on an address from the closest nodes
-  by setting `paging_address as an offset address.
+  by setting paging_state as an offset address or a date.
   """
   @spec get_pagined_transaction_chain(
           address :: Crypto.prepended_hash(),

--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -30,7 +30,7 @@ defmodule Archethic.DB do
               binary(),
               fields :: list(),
               opts :: [
-                paging_state: nil | binary(),
+                paging_address: nil | binary(),
                 after: DateTime.t(),
                 order: :asc | :desc
               ]

--- a/lib/archethic/db/embedded_impl.ex
+++ b/lib/archethic/db/embedded_impl.ex
@@ -167,7 +167,7 @@ defmodule Archethic.DB.EmbeddedImpl do
   """
   @spec get_transaction_chain(address :: binary(), fields :: list(), opts :: list()) ::
           {transactions_by_page :: list(Transaction.t()), more? :: boolean(),
-           paging_state :: nil | binary()}
+           paging_address :: nil | binary()}
   def get_transaction_chain(address, fields \\ [], opts \\ [])
       when is_binary(address) and is_list(fields) and is_list(opts) do
     ChainReader.get_transaction_chain(address, fields, opts, db_path())

--- a/lib/archethic/p2p/message/get_transaction_chain.ex
+++ b/lib/archethic/p2p/message/get_transaction_chain.ex
@@ -3,32 +3,31 @@ defmodule Archethic.P2P.Message.GetTransactionChain do
   Represents a message to request an entire transaction chain
   """
   @enforce_keys [:address]
-  defstruct [:address, :paging_state, order: :asc]
+  defstruct [:address, paging_state: nil, order: :asc]
 
   alias Archethic.Crypto
   alias Archethic.DB
   alias Archethic.P2P.Message.TransactionList
+  alias Archethic.TransactionChain
   alias Archethic.Utils
 
   @type t :: %__MODULE__{
-          address: Crypto.versioned_hash(),
-          paging_state: nil | binary(),
+          address: Crypto.prepended_hash(),
+          paging_state: Crypto.prepended_hash() | DateTime.t() | nil,
           order: :desc | :asc
         }
 
   # paging_state received contains binary offset for next page, to be used for query
   @spec process(__MODULE__.t(), Crypto.key()) :: TransactionList.t()
-  def process(
-        %__MODULE__{
-          address: tx_address,
-          paging_state: paging_state,
-          order: order
-        },
-        _
-      ) do
+  def process(%__MODULE__{address: tx_address, paging_state: paging_state, order: order}, _) do
     {chain, more?, paging_state} =
-      tx_address
-      |> DB.get_transaction_chain([], paging_state: paging_state, order: order)
+      case TransactionChain.resolve_paging_state(tx_address, paging_state, order) do
+        {:ok, paging_address} ->
+          DB.get_transaction_chain(tx_address, [], paging_state: paging_address, order: order)
+
+        {:error, _} ->
+          {[], false, nil}
+      end
 
     # empty list for fields/cols to be processed
     # new_page_state contains binary offset for the next page
@@ -36,16 +35,6 @@ defmodule Archethic.P2P.Message.GetTransactionChain do
   end
 
   @spec serialize(t()) :: bitstring()
-  def serialize(%__MODULE__{address: tx_address, paging_state: nil, order: order}) do
-    order_bit =
-      case order do
-        :asc -> 0
-        :desc -> 1
-      end
-
-    <<tx_address::binary, order_bit::1, 0::8>>
-  end
-
   def serialize(%__MODULE__{address: tx_address, paging_state: paging_state, order: order}) do
     order_bit =
       case order do
@@ -53,22 +42,25 @@ defmodule Archethic.P2P.Message.GetTransactionChain do
         :desc -> 1
       end
 
-    <<tx_address::binary, order_bit::1, byte_size(paging_state)::8, paging_state::binary>>
+    paging_state_bin =
+      case paging_state do
+        nil -> <<0::2>>
+        %DateTime{} -> <<1::2, DateTime.to_unix(paging_state)::32>>
+        paging_address -> <<2::2, paging_address::binary>>
+      end
+
+    <<tx_address::binary, order_bit::1, paging_state_bin::bitstring>>
   end
 
-  @spec deserialize(bitstring()) :: {t(), bitstring}
+  @spec deserialize(bitstring()) :: {t(), bitstring()}
   def deserialize(<<rest::bitstring>>) do
-    {address,
-     <<order_bit::1, paging_state_size::8, paging_state::binary-size(paging_state_size),
-       rest::bitstring>>} = Utils.deserialize_address(rest)
+    {address, <<order_bit::1, rest::bitstring>>} = Utils.deserialize_address(rest)
 
-    paging_state =
-      case paging_state do
-        "" ->
-          nil
-
-        _ ->
-          paging_state
+    {paging_state, rest} =
+      case rest do
+        <<0::2, rest::bitstring>> -> {nil, rest}
+        <<1::2, timestamp::32, rest::bitstring>> -> {DateTime.from_unix!(timestamp), rest}
+        <<2::2, rest::bitstring>> -> Utils.deserialize_address(rest)
       end
 
     order =
@@ -77,9 +69,6 @@ defmodule Archethic.P2P.Message.GetTransactionChain do
         1 -> :desc
       end
 
-    {
-      %__MODULE__{address: address, paging_state: paging_state, order: order},
-      rest
-    }
+    {%__MODULE__{address: address, paging_state: paging_state, order: order}, rest}
   end
 end

--- a/lib/archethic/p2p/message/get_transaction_chain.ex
+++ b/lib/archethic/p2p/message/get_transaction_chain.ex
@@ -20,10 +20,10 @@ defmodule Archethic.P2P.Message.GetTransactionChain do
   # paging_state received contains binary offset for next page, to be used for query
   @spec process(__MODULE__.t(), Crypto.key()) :: TransactionList.t()
   def process(%__MODULE__{address: tx_address, paging_state: paging_state, order: order}, _) do
-    {chain, more?, paging_state} =
+    {chain, more?, paging_address} =
       case TransactionChain.resolve_paging_state(tx_address, paging_state, order) do
         {:ok, paging_address} ->
-          DB.get_transaction_chain(tx_address, [], paging_state: paging_address, order: order)
+          DB.get_transaction_chain(tx_address, [], paging_address: paging_address, order: order)
 
         {:error, _} ->
           {[], false, nil}
@@ -31,7 +31,7 @@ defmodule Archethic.P2P.Message.GetTransactionChain do
 
     # empty list for fields/cols to be processed
     # new_page_state contains binary offset for the next page
-    %TransactionList{transactions: chain, paging_state: paging_state, more?: more?}
+    %TransactionList{transactions: chain, paging_address: paging_address, more?: more?}
   end
 
   @spec serialize(t()) :: bitstring()

--- a/lib/archethic/replication/transaction_context.ex
+++ b/lib/archethic/replication/transaction_context.ex
@@ -41,7 +41,7 @@ defmodule Archethic.Replication.TransactionContext do
            TransactionChain.fetch_genesis_address(address, storage_nodes),
          paging_address when paging_address != address <-
            TransactionChain.get_last_stored_address(genesis_address) do
-      TransactionChain.fetch(address, storage_nodes, paging_address: paging_address)
+      TransactionChain.fetch(address, storage_nodes, paging_state: paging_address)
       |> Stream.take_while(&(Transaction.previous_address(&1) != address))
     else
       _ -> []

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -365,7 +365,7 @@ defmodule Archethic.TransactionChain do
   end
 
   @doc """
-  Stream a transaction chain from the paging address
+  Stream a transaction chain from the paging state
   """
   @spec fetch(Crypto.prepended_hash(), list(Node.t()), list()) ::
           Enumerable.t() | list(Transaction.t())

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -427,7 +427,7 @@ defmodule Archethic.TransactionChain do
           # More to fetch from DB using paging address
           {transactions, more?, next_paging_address} =
             DB.get_transaction_chain(paging_address, [],
-              paging_state: paging_address,
+              paging_address: paging_address,
               order: order
             )
 
@@ -475,7 +475,7 @@ defmodule Archethic.TransactionChain do
           # More to fetch from DB using paging address
           {transactions, more?, next_paging_address} =
             DB.get_transaction_chain(paging_address, [],
-              paging_state: paging_address,
+              paging_address: paging_address,
               order: order
             )
 
@@ -538,7 +538,7 @@ defmodule Archethic.TransactionChain do
        %TransactionList{
          transactions: transactions,
          more?: more?,
-         paging_state: next_paging_address
+         paging_address: next_paging_address
        }} ->
         {transactions, more?, next_paging_address}
 

--- a/lib/archethic_web/api/graphql/schema.ex
+++ b/lib/archethic_web/api/graphql/schema.ex
@@ -90,13 +90,15 @@ defmodule ArchethicWeb.API.GraphQL.Schema do
     field :transaction_chain, list_of(:transaction) do
       arg(:address, non_null(:address))
       arg(:paging_address, :address)
+      arg(:from, :timestamp)
       arg(:order, :sort_order)
 
       resolve(fn args = %{address: address}, _ ->
         paging_address = Map.get(args, :paging_address)
+        from = Map.get(args, :from)
         order = Map.get(args, :order, :asc)
 
-        Resolver.transaction_chain_by_paging_address(address, paging_address, order)
+        Resolver.transaction_chain_by_paging_address(address, paging_address, from, order)
       end)
     end
 

--- a/lib/archethic_web/api/graphql/schema/datetime_type.ex
+++ b/lib/archethic_web/api/graphql/schema/datetime_type.ex
@@ -22,7 +22,10 @@ defmodule ArchethicWeb.API.GraphQL.Schema.DateTimeType do
   end
 
   defp parse_datetime(%Absinthe.Blueprint.Input.Integer{value: value}) do
-    DateTime.from_unix(value)
+    case DateTime.from_unix(value) do
+      {:ok, datetime} -> {:ok, datetime}
+      _ -> :error
+    end
   end
 
   defp parse_datetime(_), do: :error

--- a/lib/archethic_web/api/graphql/schema/resolver.ex
+++ b/lib/archethic_web/api/graphql/schema/resolver.ex
@@ -107,8 +107,15 @@ defmodule ArchethicWeb.API.GraphQL.Schema.Resolver do
     }
   end
 
-  def transaction_chain_by_paging_address(address, paging_address, order) do
-    case Archethic.get_transaction_chain_by_paging_address(address, paging_address, order) do
+  def transaction_chain_by_paging_address(_, paging_address, from, _)
+      when paging_address != nil and from != nil do
+    {:error, "Cannot use from and paging address in same request"}
+  end
+
+  def transaction_chain_by_paging_address(address, paging_address, from, order) do
+    paging_state = paging_address || from
+
+    case Archethic.get_pagined_transaction_chain(address, paging_state, order) do
       {:ok, chain} ->
         chain = Enum.map(chain, &Transaction.to_map(&1))
         {:ok, chain}

--- a/lib/archethic_web/explorer/live/chains/transaction_chain_live.ex
+++ b/lib/archethic_web/explorer/live/chains/transaction_chain_live.ex
@@ -131,6 +131,6 @@ defmodule ArchethicWeb.Explorer.TransactionChainLive do
 
   # DESC pagination
   defp paginate_chain(address, paging_address) do
-    Archethic.get_transaction_chain_by_paging_address(address, paging_address, :desc)
+    Archethic.get_pagined_transaction_chain(address, paging_address, :desc)
   end
 end

--- a/test/archethic/bootstrap/network_init_test.exs
+++ b/test/archethic/bootstrap/network_init_test.exs
@@ -264,7 +264,7 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
         {:ok, %NotFound{}}
 
       _, %GetTransactionChain{}, _ ->
-        {:ok, %TransactionList{transactions: [], more?: false, paging_state: nil}}
+        {:ok, %TransactionList{transactions: [], more?: false, paging_address: nil}}
 
       _, %GetTransactionInputs{}, _ ->
         {:ok, %TransactionInputList{inputs: []}}
@@ -319,7 +319,7 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
         {:ok, %NotFound{}}
 
       _, %GetTransactionChain{}, _ ->
-        {:ok, %TransactionList{transactions: [], more?: false, paging_state: nil}}
+        {:ok, %TransactionList{transactions: [], more?: false, paging_address: nil}}
 
       _, %GetTransactionInputs{}, _ ->
         {:ok, %TransactionInputList{inputs: []}}
@@ -367,7 +367,7 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
         {:ok, %NotFound{}}
 
       _, %GetTransactionChain{}, _ ->
-        {:ok, %TransactionList{transactions: [], more?: false, paging_state: nil}}
+        {:ok, %TransactionList{transactions: [], more?: false, paging_address: nil}}
 
       _, %GetTransactionInputs{}, _ ->
         {:ok, %TransactionInputList{inputs: []}}
@@ -414,7 +414,7 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
         {:ok, %NotFound{}}
 
       _, %GetTransactionChain{}, _ ->
-        {:ok, %TransactionList{transactions: [], more?: false, paging_state: nil}}
+        {:ok, %TransactionList{transactions: [], more?: false, paging_address: nil}}
 
       _, %GetTransactionInputs{}, _ ->
         {:ok, %TransactionInputList{inputs: []}}

--- a/test/archethic/db/embedded_impl_test.exs
+++ b/test/archethic/db/embedded_impl_test.exs
@@ -305,16 +305,16 @@ defmodule Archethic.DB.EmbeddedTest do
           tx
         end)
 
-      {page, true, paging_state} =
+      {page, true, paging_address} =
         EmbeddedImpl.get_transaction_chain(List.last(transactions).address)
 
       assert length(page) == 10
       assert page == Enum.take(transactions, 10)
-      assert paging_state == List.last(page).address
+      assert paging_address == List.last(page).address
 
       {page2, false, nil} =
         EmbeddedImpl.get_transaction_chain(List.last(transactions).address, [],
-          paging_state: paging_state
+          paging_address: paging_address
         )
 
       assert length(page2) == 10
@@ -335,16 +335,16 @@ defmodule Archethic.DB.EmbeddedTest do
           tx
         end)
 
-      {page, true, paging_state} =
+      {page, true, paging_address} =
         EmbeddedImpl.get_transaction_chain(List.last(transactions).address)
 
       assert length(page) == 10
       assert page == Enum.take(transactions, 10)
-      assert paging_state == List.last(page).address
+      assert paging_address == List.last(page).address
 
       assert {[], false, nil} =
                EmbeddedImpl.get_transaction_chain(List.last(transactions).address, [],
-                 paging_state: :crypto.strong_rand_bytes(32)
+                 paging_address: :crypto.strong_rand_bytes(32)
                )
     end
   end
@@ -392,24 +392,24 @@ defmodule Archethic.DB.EmbeddedTest do
           tx
         end)
 
-      {page1, true, paging_state1} =
+      {page1, true, paging_address1} =
         EmbeddedImpl.get_transaction_chain(List.last(transactions).address, [], order: :desc)
 
       assert length(page1) == 10
-      assert paging_state1 == List.last(page1).address
+      assert paging_address1 == List.last(page1).address
 
-      {page2, true, paging_state2} =
+      {page2, true, paging_address2} =
         EmbeddedImpl.get_transaction_chain(List.last(transactions).address, [],
-          paging_state: paging_state1,
+          paging_address: paging_address1,
           order: :desc
         )
 
       assert length(page2) == 10
-      assert paging_state2 == List.last(page2).address
+      assert paging_address2 == List.last(page2).address
 
       {page3, false, nil} =
         EmbeddedImpl.get_transaction_chain(List.last(transactions).address, [],
-          paging_state: paging_state2,
+          paging_address: paging_address2,
           order: :desc
         )
 
@@ -431,24 +431,24 @@ defmodule Archethic.DB.EmbeddedTest do
           tx
         end)
 
-      {page1, true, paging_state1} =
+      {page1, true, paging_address1} =
         EmbeddedImpl.get_transaction_chain(List.last(transactions).address, [], order: :desc)
 
       assert length(page1) == 10
-      assert paging_state1 == List.last(page1).address
+      assert paging_address1 == List.last(page1).address
 
-      {page2, true, paging_state2} =
+      {page2, true, paging_address2} =
         EmbeddedImpl.get_transaction_chain(List.last(transactions).address, [],
-          paging_state: paging_state1,
+          paging_address: paging_address1,
           order: :desc
         )
 
       assert length(page2) == 10
-      assert paging_state2 == List.last(page2).address
+      assert paging_address2 == List.last(page2).address
 
       {page3, false, nil} =
         EmbeddedImpl.get_transaction_chain(List.last(transactions).address, [],
-          paging_state: paging_state2,
+          paging_address: paging_address2,
           order: :desc
         )
 

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -110,8 +110,9 @@ defmodule Archethic.P2P.MessageTest do
     end
 
     test "GetTransactionChain message" do
-      address = <<0::8>> <> <<0::8>> <> :crypto.strong_rand_bytes(32)
-      paging_state = <<0::8>> <> <<0::8>> <> :crypto.strong_rand_bytes(32)
+      address = random_address()
+      paging_address = random_address()
+      from = DateTime.utc_now() |> DateTime.truncate(:second)
 
       assert %GetTransactionChain{address: address} ==
                %GetTransactionChain{address: address}
@@ -119,8 +120,8 @@ defmodule Archethic.P2P.MessageTest do
                |> Message.decode()
                |> elem(0)
 
-      assert %GetTransactionChain{address: address, paging_state: paging_state} ==
-               %GetTransactionChain{address: address, paging_state: paging_state}
+      assert %GetTransactionChain{address: address, paging_state: paging_address} ==
+               %GetTransactionChain{address: address, paging_state: paging_address}
                |> Message.encode()
                |> Message.decode()
                |> elem(0)
@@ -131,8 +132,8 @@ defmodule Archethic.P2P.MessageTest do
                |> Message.decode()
                |> elem(0)
 
-      assert %GetTransactionChain{address: address, order: :asc} ==
-               %GetTransactionChain{address: address, order: :asc}
+      assert %GetTransactionChain{address: address, order: :asc, paging_state: from} ==
+               %GetTransactionChain{address: address, order: :asc, paging_state: from}
                |> Message.encode()
                |> Message.decode()
                |> elem(0)

--- a/test/archethic/transaction_chain_test.exs
+++ b/test/archethic/transaction_chain_test.exs
@@ -402,9 +402,12 @@ defmodule Archethic.TransactionChainTest do
       |> expect(:get_genesis_address, fn ^address3 -> genesis_address end)
       |> expect(:list_chain_addresses, fn ^genesis_address -> chain_addresses end)
       |> expect(:transaction_exists?, fn ^address1, _ -> true end)
-      |> expect(:get_transaction_chain, fn ^address1, _, [paging_state: ^address1, order: :asc] ->
-        {[%Transaction{address: address2}, %Transaction{address: address3}], false, nil}
-      end)
+      |> expect(
+        :get_transaction_chain,
+        fn ^address1, _, [paging_address: ^address1, order: :asc] ->
+          {[%Transaction{address: address2}, %Transaction{address: address3}], false, nil}
+        end
+      )
 
       assert [^address2, ^address3] =
                TransactionChain.fetch(address3, nodes, paging_state: date2)


### PR DESCRIPTION
# Description

This PR adds a new filter "from" in `transaction_chain` graphql request. This filter is a timestamp allow user to request the transaction from a specific date.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests + playing with graphiql interface to request multiple date and order on a chain

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
