### PR TITLE
Fix bug when there are 10 txs in last page

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -344,7 +344,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
             all_addresses_asc
             |> Enum.find_index(&(&1 == paging_state))
 
-          if paging_state_idx < @page_size do
+          if paging_state_idx <= @page_size do
             {paging_state_idx, nil, false, nil}
           else
             idx = paging_state_idx - 1 - @page_size


### PR DESCRIPTION
# Description

When exploring a chain that have a multiple of ten transactions, the last page could not load and crashed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit-tests and manual testing

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
