### PR TITLE
Fix issue in Notify workflow

### DIFF
--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -100,8 +100,7 @@ defmodule Archethic.Mining.ValidationContext do
           chain_storage_nodes_view: bitstring(),
           beacon_storage_nodes_view: bitstring(),
           valid_pending_transaction?: boolean(),
-          storage_nodes_confirmations:
-            list({node_public_key :: Crypto.key(), signature :: binary()}),
+          storage_nodes_confirmations: list({index :: non_neg_integer(), signature :: binary()}),
           pending_transaction_error_detail: binary(),
           sub_replication_tree_validations: list(Crypto.key()),
           contract_context: nil | Contract.Context.t()
@@ -1328,14 +1327,18 @@ defmodule Archethic.Mining.ValidationContext do
 
   @doc """
   Return the list of nodes which confirmed the transaction replication
+
+  We use the authorized_and_available_nodes as a common reference between the nodes
   """
   @spec get_confirmed_replication_nodes(t()) :: list(Node.t())
   def get_confirmed_replication_nodes(%__MODULE__{
-        chain_storage_nodes: chain_storage_nodes,
+        validation_time: validation_time,
         storage_nodes_confirmations: storage_nodes_confirmations
       }) do
+    nodes = P2P.authorized_and_available_nodes(validation_time)
+
     Enum.map(storage_nodes_confirmations, fn {index, _} ->
-      Enum.at(chain_storage_nodes, index)
+      Enum.at(nodes, index)
     end)
   end
 

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1335,7 +1335,9 @@ defmodule Archethic.Mining.ValidationContext do
         validation_time: validation_time,
         storage_nodes_confirmations: storage_nodes_confirmations
       }) do
-    nodes = P2P.authorized_and_available_nodes(validation_time)
+    nodes =
+      P2P.authorized_and_available_nodes(validation_time)
+      |> Enum.sort_by(& &1.first_public_key)
 
     Enum.map(storage_nodes_confirmations, fn {index, _} ->
       Enum.at(nodes, index)


### PR DESCRIPTION
# Description

The message for `NotifyPreviousChain` uses an index to specify the node. The index was based on `authorized_and_available_nodes` on sender and on the `chain_storage_nodes` on the receiver end.

Fixes #1331 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
