### PR TITLE
MUCO to UCO in transaction movements

### DIFF
--- a/lib/archethic/account/mem_tables_loader.ex
+++ b/lib/archethic/account/mem_tables_loader.ex
@@ -233,6 +233,9 @@ defmodule Archethic.Account.MemTablesLoader do
         )
 
       %TransactionMovement{to: to, amount: amount, type: {:token, token_address, 0}} ->
+        # Since issue #1368 Reward token are converted to UCO directly in validation
+        # but to keep retrocompatibility with old transaction we need to keep this
+        # control when loading UTXO mainly for self repair
         if Reward.is_reward_token?(token_address) && tx_type != :node_rewards do
           new_utxo = %UnspentOutput{
             amount: amount,

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -28,7 +28,7 @@ defmodule Archethic.Mining do
 
   use Retry
 
-  @protocol_version 4
+  @protocol_version 5
 
   def protocol_version, do: @protocol_version
 

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -64,8 +64,6 @@ defmodule Archethic.Mining.ValidationContext do
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
 
-  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.TransactionMovement
-
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Recipient
@@ -800,7 +798,7 @@ defmodule Archethic.Mining.ValidationContext do
 
   defp get_ledger_operations(
          %__MODULE__{
-           transaction: tx,
+           transaction: tx = %Transaction{address: address, type: tx_type},
            unspent_outputs: unspent_outputs,
            resolved_addresses: resolved_addresses
          },
@@ -808,22 +806,23 @@ defmodule Archethic.Mining.ValidationContext do
          validation_time,
          encoded_state
        ) do
-    resolved_movements =
-      tx
-      |> Transaction.get_movements()
-      |> TransactionMovement.resolve_movements(resolved_addresses)
+    movements = Transaction.get_movements(tx)
 
-    %LedgerOperations{
-      fee: fee,
-      transaction_movements: resolved_movements,
-      tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, validation_time),
-      encoded_state: encoded_state
-    }
-    |> LedgerOperations.consume_inputs(
-      tx.address,
-      unspent_outputs,
-      validation_time |> DateTime.truncate(:millisecond)
-    )
+    {sufficient_funds?, ops} =
+      LedgerOperations.consume_inputs(
+        %LedgerOperations{fee: fee},
+        address,
+        unspent_outputs,
+        movements,
+        LedgerOperations.get_utxos_from_transaction(tx, validation_time),
+        encoded_state,
+        validation_time |> DateTime.truncate(:millisecond)
+      )
+
+    new_ops =
+      LedgerOperations.build_resolved_movements(ops, movements, resolved_addresses, tx_type)
+
+    {sufficient_funds?, new_ops}
   end
 
   @spec get_validation_error(
@@ -1229,12 +1228,16 @@ defmodule Archethic.Mining.ValidationContext do
                transaction_movements: transaction_movements
              }
          },
-         %__MODULE__{transaction: tx, resolved_addresses: resolved_addresses}
+         %__MODULE__{
+           transaction: tx = %Transaction{type: tx_type},
+           resolved_addresses: resolved_addresses
+         }
        ) do
-    resolved_movements =
-      tx
-      |> Transaction.get_movements()
-      |> TransactionMovement.resolve_movements(resolved_addresses)
+    movements = Transaction.get_movements(tx)
+
+    %LedgerOperations{transaction_movements: resolved_movements} =
+      %LedgerOperations{}
+      |> LedgerOperations.build_resolved_movements(movements, resolved_addresses, tx_type)
 
     length(resolved_movements) == length(transaction_movements) and
       Enum.all?(resolved_movements, &(&1 in transaction_movements))

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -248,7 +248,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
           {:ok, map} ->
             properties = %{
               decimals: Map.get(map, "decimals", 8),
-              symbol: Map.get(map, "symbol")
+              symbol: Map.get(map, "symbol", Map.get(map, "name"))
             }
 
             Map.put(acc, token_address, properties)

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -186,7 +186,7 @@
                 Movements (<%= movements_count %>)
               </div>
               <ul class="column">
-                <%= for {movement, transfer_address} <- @movements_zipped do %>
+                <%= for {movement, transfer_address, reward_token_address} <- @movements_zipped do %>
                   <%= case movement.type do %>
                     <% :UCO -> %>
                       <li class="columns">
@@ -216,14 +216,28 @@
                           ) %>
                         </div>
 
-                        <div class="column is-narrow">
-                          <span class="ae-label">Amount</span>
-                          <Amount.uco
-                            amount={movement.amount}
-                            uco_price_at_time={@uco_price_at_time}
-                            uco_price_now={@uco_price_now}
-                          />
-                        </div>
+                        <%= if reward_token_address != nil do %>
+                          <div class="column is-narrow">
+                            <span class="ae-label">Amount</span>
+                            <Amount.reward
+                              amount={movement.amount}
+                              token_address={reward_token_address}
+                              token_properties={@token_properties}
+                              socket={@socket}
+                              uco_price_at_time={@uco_price_at_time}
+                              uco_price_now={@uco_price_now}
+                            />
+                          </div>
+                        <% else %>
+                          <div class="column is-narrow">
+                            <span class="ae-label">Amount</span>
+                            <Amount.uco
+                              amount={movement.amount}
+                              uco_price_at_time={@uco_price_at_time}
+                              uco_price_now={@uco_price_now}
+                            />
+                          </div>
+                        <% end %>
                       </li>
                     <% {:token, token_address, token_id} -> %>
                       <li class="columns">

--- a/test/archethic/contracts/constants_test.exs
+++ b/test/archethic/contracts/constants_test.exs
@@ -5,6 +5,8 @@ defmodule Archethic.Contracts.ConstantsTest do
 
   alias Archethic.Contracts.Constants
 
+  alias Archethic.Reward.MemTables.RewardTokens
+
   alias Archethic.TransactionChain.TransactionData.Ledger
   alias Archethic.TransactionChain.TransactionData.Ownership
   alias Archethic.TransactionChain.TransactionData.UCOLedger
@@ -19,6 +21,11 @@ defmodule Archethic.Contracts.ConstantsTest do
 
   alias Archethic.ContractFactory
   alias Archethic.TransactionFactory
+
+  setup do
+    start_supervised!(RewardTokens)
+    :ok
+  end
 
   describe "from_transaction/1" do
     test "should return a map" do

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -9,6 +9,8 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
   alias Archethic.Contracts.Interpreter.ActionInterpreter
   alias Archethic.Contracts.Interpreter.FunctionKeys
 
+  alias Archethic.Reward.MemTables.RewardTokens
+
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Ledger
@@ -20,6 +22,11 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
   alias Archethic.TransactionFactory
 
   doctest ActionInterpreter
+
+  setup do
+    start_supervised!(RewardTokens)
+    :ok
+  end
 
   # ----------------------------------------------
   # parse/1

--- a/test/archethic/contracts/interpreter/condition_validator_test.exs
+++ b/test/archethic/contracts/interpreter/condition_validator_test.exs
@@ -6,12 +6,18 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidatorTest do
   alias Archethic.Contracts.Interpreter
   alias Archethic.Contracts.Interpreter.ConditionInterpreter
   alias Archethic.Contracts.Interpreter.ConditionValidator
+  alias Archethic.Reward.MemTables.RewardTokens
   alias Archethic.TransactionChain.TransactionData.Ledger
   alias Archethic.TransactionChain.TransactionData.TokenLedger
   alias Archethic.TransactionChain.TransactionData.TokenLedger.Transfer, as: TokenTransfer
   alias Archethic.TransactionChain.TransactionData.UCOLedger
   alias Archethic.TransactionChain.TransactionData.UCOLedger.Transfer, as: UCOTransfer
   alias Archethic.TransactionFactory
+
+  setup do
+    start_supervised!(RewardTokens)
+    :ok
+  end
 
   describe "execute_condition/2" do
     test "should return ok if the transaction's conditions are valid" do

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -375,19 +375,30 @@ defmodule Archethic.Mining.ValidationContextTest do
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
        }) do
+    fee = Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version())
+
+    movements = Transaction.get_movements(tx)
+    resolved_addresses = Enum.map(movements, &{&1.to, &1.to}) |> Map.new()
+
+    ledger_operations =
+      %LedgerOperations{fee: fee}
+      |> LedgerOperations.consume_inputs(
+        tx.address,
+        unspent_outputs,
+        movements,
+        LedgerOperations.get_utxos_from_transaction(tx, timestamp),
+        nil,
+        timestamp
+      )
+      |> elem(1)
+      |> LedgerOperations.build_resolved_movements(movements, resolved_addresses, tx.type)
+
     %ValidationStamp{
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-      ledger_operations:
-        %LedgerOperations{
-          fee: Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version()),
-          transaction_movements: Transaction.get_movements(tx),
-          tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
-        }
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
-        |> elem(1),
+      ledger_operations: ledger_operations,
       signature: :crypto.strong_rand_bytes(32),
       protocol_version: current_protocol_version()
     }
@@ -398,19 +409,30 @@ defmodule Archethic.Mining.ValidationContextTest do
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
        }) do
+    fee = Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version())
+
+    movements = Transaction.get_movements(tx)
+    resolved_addresses = Enum.map(movements, &{&1.to, &1.to}) |> Map.new()
+
+    ledger_operations =
+      %LedgerOperations{fee: fee}
+      |> LedgerOperations.consume_inputs(
+        tx.address,
+        unspent_outputs,
+        movements,
+        LedgerOperations.get_utxos_from_transaction(tx, timestamp),
+        nil,
+        timestamp
+      )
+      |> elem(1)
+      |> LedgerOperations.build_resolved_movements(movements, resolved_addresses, tx.type)
+
     %ValidationStamp{
       timestamp: timestamp,
       proof_of_work: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-      ledger_operations:
-        %LedgerOperations{
-          fee: Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version()),
-          transaction_movements: Transaction.get_movements(tx),
-          tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
-        }
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
-        |> elem(1),
+      ledger_operations: ledger_operations,
       protocol_version: current_protocol_version()
     }
     |> ValidationStamp.sign()
@@ -421,19 +443,30 @@ defmodule Archethic.Mining.ValidationContextTest do
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
        }) do
+    fee = Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version())
+
+    movements = Transaction.get_movements(tx)
+    resolved_addresses = Enum.map(movements, &{&1.to, &1.to}) |> Map.new()
+
+    ledger_operations =
+      %LedgerOperations{fee: fee}
+      |> LedgerOperations.consume_inputs(
+        tx.address,
+        unspent_outputs,
+        movements,
+        LedgerOperations.get_utxos_from_transaction(tx, timestamp),
+        nil,
+        timestamp
+      )
+      |> elem(1)
+      |> LedgerOperations.build_resolved_movements(movements, resolved_addresses, tx.type)
+
     %ValidationStamp{
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-      ledger_operations:
-        %LedgerOperations{
-          fee: Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version()),
-          transaction_movements: Transaction.get_movements(tx),
-          tokens_to_mint: LedgerOperations.get_utxos_from_transaction(tx, timestamp)
-        }
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
-        |> elem(1),
+      ledger_operations: ledger_operations,
       protocol_version: current_protocol_version()
     }
     |> ValidationStamp.sign()
@@ -444,18 +477,28 @@ defmodule Archethic.Mining.ValidationContextTest do
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
        }) do
+    movements = Transaction.get_movements(tx)
+    resolved_addresses = Enum.map(movements, &{&1.to, &1.to}) |> Map.new()
+
+    ledger_operations =
+      %LedgerOperations{fee: 1}
+      |> LedgerOperations.consume_inputs(
+        tx.address,
+        unspent_outputs,
+        movements,
+        LedgerOperations.get_utxos_from_transaction(tx, timestamp),
+        nil,
+        timestamp
+      )
+      |> elem(1)
+      |> LedgerOperations.build_resolved_movements(movements, resolved_addresses, tx.type)
+
     %ValidationStamp{
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-      ledger_operations:
-        %LedgerOperations{
-          fee: 1,
-          transaction_movements: Transaction.get_movements(tx)
-        }
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
-        |> elem(1),
+      ledger_operations: ledger_operations,
       protocol_version: current_protocol_version()
     }
     |> ValidationStamp.sign()
@@ -468,28 +511,27 @@ defmodule Archethic.Mining.ValidationContextTest do
        }) do
     fee = Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version())
 
+    ledger_operations = %LedgerOperations{
+      fee: fee,
+      transaction_movements: [
+        %TransactionMovement{to: "@Bob3", amount: 200_000_000_000, type: :UCO}
+      ],
+      unspent_outputs: [
+        %UnspentOutput{
+          amount: Enum.reduce(unspent_outputs, 0, &(&1.amount + &2)) - fee,
+          from: tx.address,
+          type: :UCO,
+          timestamp: timestamp
+        }
+      ]
+    }
+
     %ValidationStamp{
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-      ledger_operations:
-        %LedgerOperations{
-          fee: fee,
-          transaction_movements: [
-            %TransactionMovement{to: "@Bob3", amount: 200_000_000_000, type: :UCO}
-          ],
-          unspent_outputs: [
-            %UnspentOutput{
-              amount: Enum.reduce(unspent_outputs, 0, &(&1.amount + &2)) - fee,
-              from: tx.address,
-              type: :UCO,
-              timestamp: timestamp
-            }
-          ]
-        }
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
-        |> elem(1),
+      ledger_operations: ledger_operations,
       protocol_version: current_protocol_version()
     }
     |> ValidationStamp.sign()
@@ -527,18 +569,29 @@ defmodule Archethic.Mining.ValidationContextTest do
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
        }) do
+    fee = Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version())
+    movements = Transaction.get_movements(tx)
+    resolved_addresses = Enum.map(movements, &{&1.to, &1.to}) |> Map.new()
+
+    ledger_operations =
+      %LedgerOperations{fee: fee}
+      |> LedgerOperations.consume_inputs(
+        tx.address,
+        unspent_outputs,
+        movements,
+        LedgerOperations.get_utxos_from_transaction(tx, timestamp),
+        nil,
+        timestamp
+      )
+      |> elem(1)
+      |> LedgerOperations.build_resolved_movements(movements, resolved_addresses, tx.type)
+
     %ValidationStamp{
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
       proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-      ledger_operations:
-        %LedgerOperations{
-          fee: Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version()),
-          transaction_movements: Transaction.get_movements(tx)
-        }
-        |> LedgerOperations.consume_inputs(tx.address, unspent_outputs, timestamp)
-        |> elem(1),
+      ledger_operations: ledger_operations,
       error: :invalid_pending_transaction,
       protocol_version: current_protocol_version()
     }

--- a/test/archethic/transaction_chain/transaction_test.exs
+++ b/test/archethic/transaction_chain/transaction_test.exs
@@ -5,6 +5,7 @@ defmodule Archethic.TransactionChain.TransactionTest do
   import ArchethicCase
 
   alias Archethic.Crypto
+  alias Archethic.Reward.MemTables.RewardTokens
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
 
@@ -18,6 +19,11 @@ defmodule Archethic.TransactionChain.TransactionTest do
   alias Archethic.TransactionFactory
 
   doctest Archethic.TransactionChain.Transaction
+
+  setup do
+    start_supervised!(RewardTokens)
+    :ok
+  end
 
   describe "new/2" do
     test "with type ':node' create a new transaction using the node keys" do


### PR DESCRIPTION
# Description

This PR update the behavior of converting MUCO to UCO. The conversion is now done during the validation in the movements.
Updated the explorer view to display the conversion

Fixes #1368

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Unit tests
- Update the reward address of a node (localhost:4000/settings)
Using the chain of the new reward address, send the MUCO to another address, in the validation stamp the movement is UCO.
- Also created a transfer of MUCO before applying this PR, then applied the PR with new explorer behavior, it works as it was previously (just display MUCO)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
