### PR TITLE
fix 🐛 (explorer): Use memory values for Oracle's explorer page

### DIFF
--- a/lib/archethic_web/explorer/live/chains/oracle_chain_live.html.heex
+++ b/lib/archethic_web/explorer/live/chains/oracle_chain_live.html.heex
@@ -9,7 +9,7 @@
     <%= if Enum.empty?(@last_oracle_data) do %>
       N/A
     <% else %>
-      <%= get_in(@last_oracle_data, ["uco", "usd"]) %> $
+      <%= get_in(@last_oracle_data, [:uco, :usd]) %> $
     <% end %>
   </h2>
 </div>
@@ -26,4 +26,3 @@
   socket={@socket}
   uco_price_now={@uco_price_now}
 />
-<div>Last changes from <%= format_date(@update_time) %></div>


### PR DESCRIPTION
Before the page loads Oracle's data from transaction itself and decoded it, while it could be retrieved directly from the memory tables.

## Type of change

Please delete options that are not relevant.

- Enhancement

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
