### PR TITLE
Use the same timeout on all tasks related to network patches

### DIFF
--- a/lib/archethic/p2p/message/get_network_stats.ex
+++ b/lib/archethic/p2p/message/get_network_stats.ex
@@ -6,6 +6,7 @@ defmodule Archethic.P2P.Message.GetNetworkStats do
   @enforce_keys [:summary_time]
   defstruct [:summary_time]
 
+  alias Archethic.BeaconChain.NetworkCoordinates
   alias Archethic.BeaconChain.Subset.StatsCollector
   alias Archethic.Crypto
   alias Archethic.P2P.Message.NetworkStats
@@ -40,6 +41,6 @@ defmodule Archethic.P2P.Message.GetNetworkStats do
   """
   @spec process(t(), Crypto.key()) :: NetworkStats.t()
   def process(%__MODULE__{summary_time: summary_time}, _node_public_key) do
-    %NetworkStats{stats: StatsCollector.get(summary_time)}
+    %NetworkStats{stats: StatsCollector.get(summary_time, NetworkCoordinates.timeout())}
   end
 end

--- a/test/archethic/beacon_chain/network_coordinates_test.exs
+++ b/test/archethic/beacon_chain/network_coordinates_test.exs
@@ -9,6 +9,7 @@ defmodule Archethic.BeaconChain.NetworkCoordinatesTest do
   alias Archethic.P2P.Node
 
   doctest NetworkCoordinates
+  @timeout 1_000
 
   import Mox
 
@@ -77,7 +78,9 @@ defmodule Archethic.BeaconChain.NetworkCoordinatesTest do
                [100, 110, 90, 0, 0, 0],
                [100, 105, 90, 0, 0, 0],
                [90, 105, 90, 0, 0, 0]
-             ] == NetworkCoordinates.fetch_network_stats(DateTime.utc_now()) |> Nx.to_list()
+             ] ==
+               NetworkCoordinates.fetch_network_stats(DateTime.utc_now(), @timeout)
+               |> Nx.to_list()
     end
 
     test "should filter stats that are different from expected nodes for a subset" do
@@ -134,7 +137,9 @@ defmodule Archethic.BeaconChain.NetworkCoordinatesTest do
                [150, 150, 150, 0, 0, 0],
                [150, 150, 150, 0, 0, 0],
                [150, 150, 150, 0, 0, 0]
-             ] == NetworkCoordinates.fetch_network_stats(DateTime.utc_now()) |> Nx.to_list()
+             ] ==
+               NetworkCoordinates.fetch_network_stats(DateTime.utc_now(), @timeout)
+               |> Nx.to_list()
     end
   end
 end


### PR DESCRIPTION
# Description

The network patch calculation takes up to 15seconds in testnet. The timeout values were too low. 
This PR calculate the timeout based on the next SelfRepair tick. 

In practice, we're setting the timeout to 4m30s instead of 5s.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

locally with 3 nodes

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
