### PR TITLE
Fix regression on the explorer with invalid transactions

### DIFF
--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -31,6 +31,8 @@
 
   <div class="ae-box ae-purple shadow">
     <%= cond do %>
+      <% @ko? -> %>
+        <p>The transaction is invalid.</p>
       <% @address == burning_address() -> %>
         <p>This address is not owned by any user being the burn address.</p>
         <%= if inputs_count > 0 do %>


### PR DESCRIPTION
Fix a regression I introduced with rebranding.
Liveview was crashing when trying to display a "KO" transaction

<img width="721" alt="Capture d’écran 2024-01-15 à 15 01 20" src="https://github.com/archethic-foundation/archethic-node/assets/74045243/7fa668a6-0578-46b7-9bd8-8fe4743bf696">
