### PR TITLE
Scope assignation returns assigned value

### DIFF
--- a/lib/archethic/contracts/interpreter/scope.ex
+++ b/lib/archethic/contracts/interpreter/scope.ex
@@ -137,7 +137,7 @@ defmodule Archethic.Contracts.Interpreter.Scope do
       )
     )
 
-    :ok
+    value
   end
 
   @doc """
@@ -157,7 +157,7 @@ defmodule Archethic.Contracts.Interpreter.Scope do
       )
     )
 
-    :ok
+    value
   end
 
   @doc """

--- a/test/archethic/contracts/interpreter/scope_test.exs
+++ b/test/archethic/contracts/interpreter/scope_test.exs
@@ -225,6 +225,21 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
   end
 
   describe "write_at/2" do
+    test "should return assigned value" do
+      # Setup with a single context and a single scope
+      scope = %{
+        "current_context" => %{
+          "only_scope" => %{},
+          scope_hierarchy: ["only_scope"]
+        },
+        context_list: ["current_context"]
+      }
+
+      Process.put(:scope, scope)
+
+      assert 42 == Scope.write_at("my_var", 42)
+    end
+
     test "should write a variable in the current scope of the current context" do
       # Setup with a single context and a single scope
       scope = %{
@@ -312,6 +327,20 @@ defmodule Archethic.Contracts.Interpreter.ScopeTest do
   end
 
   describe "write_cascade/2" do
+    test "should return assigned value" do
+      scope = %{
+        "current_context" => %{
+          "only_scope" => %{},
+          scope_hierarchy: ["only_scope"]
+        },
+        context_list: ["current_context"]
+      }
+
+      Process.put(:scope, scope)
+
+      assert 42 == Scope.write_cascade("my_var", 42)
+    end
+
     test "should write the variable in the current scope if it doesn't exist anywhere" do
       scope = %{
         "current_context" => %{


### PR DESCRIPTION
# Description

Fixes an issue in smart contract language where it could be possible for a user to have an atom in a variable.
When assigning a value to a variable, we call `Scope.write_cascade`, this function was returning `:ok`. The problem was that we could create a function where the last statement is a assignation, and so the function returns `:ok`
```elixir
action ... do
  my_var = bad_return()
  log(my_var) 
  # :ok
end

fun bad_return() do
  # Assignation returns :ok
  var = "toto"
end
```

The fix is to have the same behavior than elixir, the assignation return the assigned value

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a simple contract with a function that assign a value in it's last statement

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
