### PR TITLE
Smart Contracts: `Http.request/5` and `Http.request_many/2`

### DIFF
--- a/lib/archethic/contracts/interpreter/ast_helper.ex
+++ b/lib/archethic/contracts/interpreter/ast_helper.ex
@@ -33,6 +33,24 @@ defmodule Archethic.Contracts.Interpreter.ASTHelper do
   def is_keyword_list?(_), do: false
 
   @doc """
+  Return wether the given ast is a bool
+
+    iex> ast = quote do: true
+    iex> ASTHelper.is_boolean?(ast)
+    true
+
+    iex> ast = quote do: false
+    iex> ASTHelper.is_boolean?(ast)
+    true
+
+    iex> ast = quote do: %{"sum" => 1, "product" => 10}
+    iex> ASTHelper.is_boolean?(ast)
+    false
+  """
+  @spec is_boolean?(Macro.t()) :: boolean()
+  def is_boolean?(arg), do: is_boolean(arg)
+
+  @doc """
   Return wether the given ast is a map
 
     iex> ast = quote do: %{"sum" => 1, "product" => 10}

--- a/lib/archethic/contracts/interpreter/library/common/http.ex
+++ b/lib/archethic/contracts/interpreter/library/common/http.ex
@@ -12,7 +12,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Http do
   @callback request(String.t(), String.t()) :: map()
   @callback request(String.t(), String.t(), map()) :: map()
   @callback request(String.t(), String.t(), map(), String.t() | nil) :: map()
+  @callback request(String.t(), String.t(), map(), String.t() | nil, boolean()) :: map()
   @callback request_many(list(map())) :: list(map())
+  @callback request_many(list(map()), boolean()) :: list(map())
 
   def check_types(:request, [first]) do
     binary_or_variable_or_function?(first)
@@ -30,8 +32,17 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Http do
     check_types(:request, [first, second, third]) && binary_or_variable_or_function?(fourth)
   end
 
+  def check_types(:request, [first, second, third, fourth, fifth]) do
+    check_types(:request, [first, second, third, fourth]) &&
+      boolean_or_variable_or_function?(fifth)
+  end
+
   def check_types(:request_many, [first]) do
     list_or_variable_or_function?(first)
+  end
+
+  def check_types(:request_many, [first, second]) do
+    check_types(:request_many, [first]) && boolean_or_variable_or_function?(second)
   end
 
   def check_types(_, _), do: false
@@ -46,5 +57,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Http do
 
   defp map_or_variable_or_function?(arg) do
     AST.is_map?(arg) || AST.is_variable_or_function_call?(arg)
+  end
+
+  defp boolean_or_variable_or_function?(arg) do
+    AST.is_boolean?(arg) || AST.is_variable_or_function_call?(arg)
   end
 end

--- a/lib/archethic/contracts/interpreter/library/common/http_impl.ex
+++ b/lib/archethic/contracts/interpreter/library/common/http_impl.ex
@@ -93,23 +93,11 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImpl do
       {:error, :timeout, _} ->
         %{"status" => -4001}
 
-      {:error, :request_failure, _} ->
-        %{"status" => -4000}
-
-      {:error, :invalid_url, _} ->
-        %{"status" => -4000}
-
-      {:error, :invalid_method, _} ->
-        %{"status" => -4000}
-
-      {:error, :invalid_headers, _} ->
-        %{"status" => -4000}
-
-      {:error, :invalid_body, _} ->
-        %{"status" => -4000}
-
       {:error, :not_supported_scheme, _} ->
         %{"status" => -4004}
+
+      {:error, _, _} ->
+        %{"status" => -4000}
     end)
   end
 

--- a/lib/archethic/mining/smart_contract_validation.ex
+++ b/lib/archethic/mining/smart_contract_validation.ex
@@ -138,6 +138,12 @@ defmodule Archethic.Mining.SmartContractValidation do
     {:error, Error.new(:invalid_recipients_execution, data)}
   end
 
+  defp format_error_status({:error, :timeout}, data) do
+    data = data |> Map.put("message", "Failed to validate call due to timeout")
+
+    {:error, Error.new(:invalid_recipients_execution, data)}
+  end
+
   defp format_error_status(
          {:error, :invalid_execution, %Failure{user_friendly_error: message, data: failure_data}},
          data

--- a/test/archethic/contracts/interpreter/library/common/http_impl_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/http_impl_test.exs
@@ -36,7 +36,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImplTest do
   # ----------------------------------------
   describe "request/4 common behavior" do
     test "should raise if domain does not exist" do
-      assert_raise Library.Error, fn -> HttpImpl.request("https://localhost.local", "GET") end
+      assert_raise Library.Error, fn -> HttpImpl.request("https://non-existing.domain", "GET") end
     end
 
     test "should return a 404 if page does not exist" do
@@ -131,9 +131,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImplTest do
                HttpImpl.request("https://127.0.0.1:8081", "GET", %{}, nil, false)
     end
 
-    test "should return a -4001 if the domain is inexistant" do
-      assert %{"status" => -4001} =
-               HttpImpl.request("https://localhost.local", "GET", %{}, nil, false)
+    test "should return a -4000 if the domain is inexistant" do
+      assert %{"status" => -4000} =
+               HttpImpl.request("https://non-existing.domain", "GET", %{}, nil, false)
     end
   end
 
@@ -177,7 +177,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImplTest do
       assert_raise Library.Error, fn ->
         HttpImpl.request_many([
           %{"url" => "https://127.0.0.1:8081", "method" => "GET"},
-          %{"url" => "https://localhost.local", "method" => "GET"}
+          %{"url" => "https://non-existing.domain", "method" => "GET"}
         ])
       end
 
@@ -304,12 +304,12 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.HttpImplTest do
                )
     end
 
-    test "should return a -4001 if the domain is inexistant" do
-      assert [%{"status" => 200}, %{"status" => -4001}] =
+    test "should return a -4000 if the domain is inexistant" do
+      assert [%{"status" => 200}, %{"status" => -4000}] =
                HttpImpl.request_many(
                  [
                    %{"url" => "https://127.0.0.1:8081", "method" => "GET"},
-                   %{"url" => "https://localhost.local", "method" => "GET"}
+                   %{"url" => "https://non-existing.domain", "method" => "GET"}
                  ],
                  false
                )


### PR DESCRIPTION
# Description

Add a new `throw_on_error` flag that can be specified to handle the HTTP errors in the contracts.
Fixes #1381 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests & local test with contract such as: 

```
  @version 1

  actions triggered_by: interval, at: "* * * * *" do
    responses = Http.request_many([
      [url: "https://fakerapi.it/api/v1/users?_quantity=1&_gender=male&_seed=cucumber", method: "GET"],
      [url: "https://fakerapi.it/api/v1/users?_quantity=1&_gender=male&_seed=cucumber", method: "GET"],
      [url: "https://fakerapi.it/api/v1/users?_quantity=1&_gender=female&_seed=tomato", method: "GET"],
      [url: "https://fakerapi.it/api/v1/users?_quantity=1&_gender=female&_seed=tomato", method: "GET"],
# should fail (non https)
      [url: "http://fakerapi.it/api/v1/users?_quantity=1&_gender=female&_seed=tomato", method: "GET"],
# should fail (too many urls)
      [url: "https://fakerapi.it/api/v1/users?_quantity=1&_gender=female&_seed=tomato", method: "GET"],
    ], false)

    log(responses)
  end
```

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
