### PR TITLE
Fix regression introduced with rebranding explorer

### DIFF
--- a/lib/archethic_web/explorer/components/transactions_list.ex
+++ b/lib/archethic_web/explorer/components/transactions_list.ex
@@ -36,9 +36,16 @@ defmodule ArchethicWeb.Explorer.Components.TransactionsList do
       )
 
     ~H"""
+    <% tx_count = length(@transactions) %>
     <div
       class="ae-box ae-purple shadow"
-      phx-hook="InfiniteScroll"
+      phx-hook={
+        if tx_count < assigns.total do
+          "InfiniteScroll"
+        else
+          ""
+        end
+      }
       data-page={@page}
       id="infinite_scroll"
     >
@@ -73,7 +80,7 @@ defmodule ArchethicWeb.Explorer.Components.TransactionsList do
         <% end %>
       </ul>
 
-      <%= if length(@transactions) < @total do %>
+      <%= if tx_count < @total do %>
         <div phx-click="load-more">Click to load more transactions</div>
       <% end %>
     </div>


### PR DESCRIPTION
# Description

Fix a regression introduced on the explorer rebranding. It tries to load transaction for the infinite scrolling on some page that does not support this.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

locally

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
