### PR TITLE
Lock chain before start mining

### DIFF
--- a/lib/archethic/mining/chain_lock.ex
+++ b/lib/archethic/mining/chain_lock.ex
@@ -1,0 +1,100 @@
+defmodule Archethic.Mining.ChainLock do
+  @moduledoc false
+
+  alias Archethic.Crypto
+  alias Archethic.PubSub
+
+  use GenServer
+  require Logger
+
+  @vsn 1
+
+  def start_link(args \\ [], opts \\ []) do
+    GenServer.start_link(__MODULE__, args, opts)
+  end
+
+  @spec lock(address :: Crypto.prepended_hash(), tx_hash :: binary()) ::
+          :ok | {:error, :already_locked}
+  def lock(address, tx_hash) do
+    address |> via_tuple() |> GenServer.call({:lock, address, tx_hash})
+  end
+
+  @spec unlock(address :: Crypto.prepended_hash()) :: :ok
+  def unlock(address) do
+    address |> via_tuple() |> GenServer.cast({:unlock, address})
+  end
+
+  defp via_tuple(address) do
+    {:via, PartitionSupervisor, {ChainLockSupervisor, address}}
+  end
+
+  def init(args) do
+    timeout = Keyword.fetch!(args, :mining_timeout)
+    {:ok, %{timeout: timeout, addresses_locked: Map.new()}}
+  end
+
+  def handle_call(
+        {:lock, address, tx_hash},
+        _from,
+        state = %{timeout: timeout, addresses_locked: addresses_locked}
+      ) do
+    case Map.get(addresses_locked, address) do
+      nil ->
+        Logger.info("Lock transaction chain", transaction_address: Base.encode16(address))
+        PubSub.register_to_new_transaction_by_address(address)
+        timer = Process.send_after(self(), {:unlock, address}, timeout)
+
+        new_state = Map.update!(state, :addresses_locked, &Map.put(&1, address, {tx_hash, timer}))
+
+        {:reply, :ok, new_state}
+
+      {hash, _timer} when hash == tx_hash ->
+        {:reply, :ok, state}
+
+      _ ->
+        Logger.debug("Received lock with different transaction hash",
+          transaction_address: Base.encode16(address)
+        )
+
+        {:reply, {:error, :already_locked}, state}
+    end
+  end
+
+  # Unlock from message UnlockChain
+  def handle_cast({:unlock, address}, state) do
+    new_state = Map.update!(state, :addresses_locked, &unlock_address(&1, address))
+    {:noreply, new_state}
+  end
+
+  # Unlock from self unlock after timeout
+  def handle_info({:unlock, address}, state) do
+    new_state = Map.update!(state, :addresses_locked, &unlock_address(&1, address))
+    {:noreply, new_state}
+  end
+
+  # Unlock from transaction being replicated
+  def handle_info({:new_transaction, address}, state) do
+    new_state = Map.update!(state, :addresses_locked, &unlock_address(&1, address))
+    {:noreply, new_state}
+  end
+
+  # Unlock from transaction being replicated
+  def handle_info({:new_transaction, address, _type, _timestamp}, state) do
+    new_state = Map.update!(state, :addresses_locked, &unlock_address(&1, address))
+    {:noreply, new_state}
+  end
+
+  defp unlock_address(addresses_locked, address) do
+    PubSub.unregister_to_new_transaction_by_address(address)
+
+    case Map.pop(addresses_locked, address) do
+      {nil, _} ->
+        addresses_locked
+
+      {{_hash, timer}, new_addresses_locked} ->
+        Process.cancel_timer(timer)
+        Logger.debug("Unlock transaction chain", transaction_address: Base.encode16(address))
+        new_addresses_locked
+    end
+  end
+end

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -39,6 +39,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
   alias Archethic.P2P.Message.ReplicationError
   alias Archethic.P2P.Message.ValidateTransaction
   alias Archethic.P2P.Message.ValidationError
+  alias Archethic.P2P.Message.UnlockChain
   alias Archethic.P2P.Node
 
   alias Archethic.TransactionChain
@@ -1158,11 +1159,12 @@ defmodule Archethic.Mining.DistributedWorkflow do
   end
 
   defp notify_error(reason, %{
-         context: %ValidationContext{
-           welcome_node: welcome_node = %Node{},
-           transaction: %Transaction{address: tx_address},
-           pending_transaction_error_detail: pending_error_detail
-         }
+         context:
+           context = %ValidationContext{
+             welcome_node: welcome_node = %Node{},
+             transaction: %Transaction{address: tx_address},
+             pending_transaction_error_detail: pending_error_detail
+           }
        }) do
     {error_context, error_reason} =
       case reason do
@@ -1201,5 +1203,10 @@ defmodule Archethic.Mining.DistributedWorkflow do
 
       :ok
     end)
+
+    # Notify storage nodes to unlock chain
+    message = %UnlockChain{address: tx_address}
+
+    context |> ValidationContext.get_chain_replication_nodes() |> P2P.broadcast_message(message)
   end
 end

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -80,7 +80,8 @@ defmodule Archethic.P2P.Message do
     ValidateSmartContractCall,
     SmartContractCallValidation,
     GetDashboardData,
-    DashboardData
+    DashboardData,
+    UnlockChain
   }
 
   require Logger
@@ -133,6 +134,7 @@ defmodule Archethic.P2P.Message do
           | ValidateSmartContractCall.t()
           | GetDashboardData.t()
           | RequestChainLock.t()
+          | UnlockChain.t()
 
   @type response ::
           Ok.t()

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -58,6 +58,7 @@ defmodule Archethic.P2P.Message do
     RegisterBeaconUpdates,
     ReplicateTransaction,
     ReplicationError,
+    RequestChainLock,
     ShardRepair,
     StartMining,
     TransactionChainLength,
@@ -131,6 +132,7 @@ defmodule Archethic.P2P.Message do
           | GetNetworkStats.t()
           | ValidateSmartContractCall.t()
           | GetDashboardData.t()
+          | RequestChainLock.t()
 
   @type response ::
           Ok.t()

--- a/lib/archethic/p2p/message/error.ex
+++ b/lib/archethic/p2p/message/error.ex
@@ -13,6 +13,7 @@ defmodule Archethic.P2P.Message.Error do
           | :network_chains_sync
           | :p2p_sync
           | :both_sync
+          | :already_locked
 
   @type t :: %__MODULE__{
           reason: reason()
@@ -39,6 +40,7 @@ defmodule Archethic.P2P.Message.Error do
   def serialize_reason(:network_chains_sync), do: 4
   def serialize_reason(:p2p_sync), do: 5
   def serialize_reason(:both_sync), do: 6
+  def serialize_reason(:already_locked), do: 7
 
   @doc """
   Deserialize an error reason
@@ -51,4 +53,5 @@ defmodule Archethic.P2P.Message.Error do
   def deserialize_reason(4), do: :network_chains_sync
   def deserialize_reason(5), do: :p2p_sync
   def deserialize_reason(6), do: :both_sync
+  def deserialize_reason(7), do: :already_locked
 end

--- a/lib/archethic/p2p/message/message_id.ex
+++ b/lib/archethic/p2p/message/message_id.ex
@@ -69,7 +69,8 @@ defmodule Archethic.P2P.MessageId do
     ValidateSmartContractCall,
     SmartContractCallValidation,
     GetDashboardData,
-    DashboardData
+    DashboardData,
+    RequestChainLock
   }
 
   alias Archethic.TransactionChain.{
@@ -102,7 +103,7 @@ defmodule Archethic.P2P.MessageId do
     GetBalance => 16,
     GetTransactionInputs => 17,
     GetTransactionChainLength => 18,
-    # Message number 19 is available
+    RequestChainLock => 19,
     GetFirstPublicKey => 20,
     GetLastTransactionAddress => 21,
     NotifyLastTransactionAddress => 22,

--- a/lib/archethic/p2p/message/message_id.ex
+++ b/lib/archethic/p2p/message/message_id.ex
@@ -70,7 +70,8 @@ defmodule Archethic.P2P.MessageId do
     SmartContractCallValidation,
     GetDashboardData,
     DashboardData,
-    RequestChainLock
+    RequestChainLock,
+    UnlockChain
   }
 
   alias Archethic.TransactionChain.{
@@ -125,6 +126,7 @@ defmodule Archethic.P2P.MessageId do
     NotifyReplicationValidation => 38,
     GetNetworkStats => 39,
     GetDashboardData => 40,
+    UnlockChain => 41,
 
     # Responses
     DashboardData => 225,

--- a/lib/archethic/p2p/message/request_chain_lock.ex
+++ b/lib/archethic/p2p/message/request_chain_lock.ex
@@ -1,0 +1,36 @@
+defmodule Archethic.P2P.Message.RequestChainLock do
+  @moduledoc """
+  Request to a storage pool to lock the validation of a transaction in a chain
+  """
+
+  @enforce_keys [:address, :hash]
+  defstruct [:address, :hash]
+
+  alias Archethic.Crypto
+  alias Archethic.Mining.ChainLock
+  alias Archethic.P2P.Message.Ok
+  alias Archethic.P2P.Message.Error
+  alias Archethic.Utils
+
+  @type t :: %__MODULE__{address: Crypto.prepended_hash(), hash: Crypto.versioned_hash()}
+
+  @spec process(__MODULE__.t(), Crypto.key()) :: Ok.t() | Error.t()
+  def process(%__MODULE__{address: address, hash: hash}, _) do
+    case ChainLock.lock(address, hash) do
+      :ok -> %Ok{}
+      {:error, :already_locked} -> %Error{reason: :already_locked}
+    end
+  end
+
+  @spec serialize(t()) :: bitstring()
+  def serialize(%__MODULE__{address: address, hash: hash}) do
+    <<address::binary, hash::binary-size(33)>>
+  end
+
+  @spec deserialize(bitstring()) :: {t(), bitstring()}
+  def deserialize(bin) do
+    {address, <<hash::binary-size(33), rest::bitstring>>} = Utils.deserialize_address(bin)
+
+    {%__MODULE__{address: address, hash: hash}, rest}
+  end
+end

--- a/lib/archethic/p2p/message/unlock_chain.ex
+++ b/lib/archethic/p2p/message/unlock_chain.ex
@@ -1,0 +1,29 @@
+defmodule Archethic.P2P.Message.UnlockChain do
+  @moduledoc """
+  Request a storage node to unlock the chain for an address
+  """
+  alias Archethic.Crypto
+  alias Archethic.Mining.ChainLock
+  alias Archethic.P2P.Message.Ok
+  alias Archethic.Utils
+
+  @enforce_keys [:address]
+  defstruct [:address]
+
+  @type t :: %__MODULE__{address: Crypto.prepended_hash()}
+
+  @spec process(__MODULE__.t(), Crypto.key()) :: Ok.t()
+  def process(%__MODULE__{address: address}, _) do
+    ChainLock.unlock(address)
+    %Ok{}
+  end
+
+  @spec serialize(t()) :: bitstring()
+  def serialize(%__MODULE__{address: address}), do: <<address::binary>>
+
+  @spec deserialize(bitstring()) :: {t(), bitstring}
+  def deserialize(bin) do
+    {address, rest} = Utils.deserialize_address(bin)
+    {%__MODULE__{address: address}, rest}
+  end
+end

--- a/test/archethic/mining/chain_lock_test.exs
+++ b/test/archethic/mining/chain_lock_test.exs
@@ -1,0 +1,88 @@
+defmodule Archethic.Mining.ChainLockTest do
+  @moduledoc false
+
+  alias Archethic.Crypto
+  alias Archethic.Mining.ChainLock
+  alias Archethic.PubSub
+
+  use ArchethicCase
+  import ArchethicCase
+
+  describe "lock" do
+    test "should allow same address and hash to be locked multiple times" do
+      address = random_address()
+      hash = Crypto.hash(address)
+
+      assert :ok == ChainLock.lock(address, hash)
+      assert :ok == ChainLock.lock(address, hash)
+      assert :ok == ChainLock.lock(address, hash)
+    end
+
+    test "should refuse same address to be locked with different hash" do
+      address = random_address()
+      hash1 = Crypto.hash(address)
+      hash2 = Crypto.hash(hash1)
+
+      assert :ok == ChainLock.lock(address, hash1)
+      assert {:error, :already_locked} == ChainLock.lock(address, hash2)
+    end
+
+    test "should subscribe to PubSub new transaction" do
+      address = random_address()
+      hash = Crypto.hash(address)
+
+      pid = GenServer.whereis({:via, PartitionSupervisor, {ChainLockSupervisor, address}})
+
+      assert [] == Registry.keys(Archethic.PubSubRegistry, pid)
+
+      ChainLock.lock(address, hash)
+
+      assert [{:new_transaction, address}] == Registry.keys(Archethic.PubSubRegistry, pid)
+    end
+  end
+
+  describe "unlock" do
+    test "should return ok if there is no lock" do
+      assert :ok == random_address() |> ChainLock.unlock()
+    end
+
+    test "should unlock address" do
+      address = random_address()
+      hash1 = Crypto.hash(address)
+      hash2 = Crypto.hash(hash1)
+
+      assert :ok == ChainLock.lock(address, hash1)
+      assert {:error, :already_locked} == ChainLock.lock(address, hash2)
+      assert :ok == ChainLock.unlock(address)
+      assert :ok == ChainLock.lock(address, hash2)
+    end
+
+    test "should remove lock when transaction is replicated" do
+      address = random_address()
+      hash1 = Crypto.hash(address)
+      hash2 = Crypto.hash(hash1)
+
+      assert :ok == ChainLock.lock(address, hash1)
+      assert {:error, :already_locked} == ChainLock.lock(address, hash2)
+      PubSub.notify_new_transaction(address)
+      assert :ok == ChainLock.lock(address, hash2)
+
+      assert {:error, :already_locked} == ChainLock.lock(address, hash1)
+      PubSub.notify_new_transaction(address, :transfer, DateTime.utc_now())
+      assert :ok == ChainLock.lock(address, hash1)
+    end
+
+    test "should remove lock after mining timeout" do
+      pid = start_supervised!({ChainLock, mining_timeout: 200})
+
+      address = random_address()
+      hash1 = Crypto.hash(address)
+      hash2 = Crypto.hash(hash1)
+
+      assert :ok == GenServer.call(pid, {:lock, address, hash1})
+      assert {:error, :already_locked} == GenServer.call(pid, {:lock, address, hash2})
+      Process.sleep(205)
+      assert :ok == GenServer.call(pid, {:lock, address, hash2})
+    end
+  end
+end

--- a/test/archethic/mining_test.exs
+++ b/test/archethic/mining_test.exs
@@ -1,0 +1,117 @@
+defmodule Archethic.MiningTest do
+  @moduledoc false
+
+  alias Archethic.Crypto
+  alias Archethic.Election
+  alias Archethic.Mining
+  alias Archethic.P2P
+  alias Archethic.P2P.Message.Error
+  alias Archethic.P2P.Message.Ok
+  alias Archethic.P2P.Message.RequestChainLock
+  alias Archethic.P2P.Node
+  alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionFactory
+
+  use ArchethicCase
+  import Mox
+
+  setup do
+    Enum.each(1..10, fn i ->
+      P2P.add_and_connect_node(%Node{
+        ip: {122, 12, 0, i},
+        port: 300 + i,
+        first_public_key: "node#{i}",
+        last_public_key: "node#{i}",
+        network_patch: "AAA",
+        geo_patch: "AAA",
+        available?: true,
+        authorized?: true,
+        authorization_date: DateTime.utc_now() |> DateTime.add(-1)
+      })
+    end)
+  end
+
+  describe "request_chain_lock" do
+    setup do
+      tx =
+        TransactionFactory.create_non_valided_transaction(
+          type: :data,
+          content: "something random"
+        )
+
+      hash =
+        tx
+        |> Transaction.to_pending()
+        |> Transaction.serialize()
+        |> Crypto.hash()
+
+      %{tx: tx, hash: hash}
+    end
+
+    test "should request chain lock to all storage nodes", %{
+      tx: tx = %Transaction{address: address},
+      hash: hash
+    } do
+      message = %RequestChainLock{address: address, hash: hash}
+
+      address
+      |> Election.storage_nodes(P2P.authorized_and_available_nodes())
+      |> Enum.each(fn node ->
+        MockClient
+        |> expect(:send_message, fn ^node, ^message, _ -> {:ok, %Ok{}} end)
+      end)
+
+      assert :ok == Mining.request_chain_lock(tx)
+    end
+
+    test "should return ok if at least 75% of storage nodes returned Ok", %{
+      tx: tx = %Transaction{address: address},
+      hash: hash
+    } do
+      message = %RequestChainLock{address: address, hash: hash}
+      storage_nodes = Election.storage_nodes(address, P2P.authorized_and_available_nodes())
+      nb_ok_nodes = ceil(length(storage_nodes) * 0.75)
+
+      {ok_nodes, error_nodes} = Enum.split(storage_nodes, nb_ok_nodes)
+
+      Enum.each(ok_nodes, fn node ->
+        MockClient
+        |> expect(:send_message, fn ^node, ^message, _ -> {:ok, %Ok{}} end)
+      end)
+
+      Enum.each(error_nodes, fn node ->
+        MockClient
+        |> expect(:send_message, fn ^node, ^message, _ ->
+          {:ok, %Error{reason: :already_locked}}
+        end)
+      end)
+
+      assert :ok == Mining.request_chain_lock(tx)
+    end
+
+    test "should return error if less than 75% of storage nodes returned Ok", %{
+      tx: tx = %Transaction{address: address},
+      hash: hash
+    } do
+      message = %RequestChainLock{address: address, hash: hash}
+      storage_nodes = Election.storage_nodes(address, P2P.authorized_and_available_nodes())
+      nb_ok_nodes = floor(length(storage_nodes) * 0.75)
+
+      {ok_nodes, error_nodes} = Enum.split(storage_nodes, nb_ok_nodes)
+
+      Enum.each(ok_nodes, fn node ->
+        MockClient
+        |> expect(:send_message, fn ^node, ^message, _ -> {:ok, %Ok{}} end)
+      end)
+
+      Enum.each(error_nodes, fn node ->
+        MockClient
+        |> expect(:send_message, fn ^node, ^message, _ ->
+          {:ok, %Error{reason: :already_locked}}
+        end)
+      end)
+
+      assert {:error, :already_locked} == Mining.request_chain_lock(tx)
+    end
+  end
+end

--- a/test/archethic/p2p/message/request_chain_lock_test.exs
+++ b/test/archethic/p2p/message/request_chain_lock_test.exs
@@ -1,0 +1,49 @@
+defmodule Archethic.P2P.Message.RequestChainLockTest do
+  @moduledoc false
+
+  alias Archethic.Crypto
+  alias Archethic.Mining.ChainLock
+  alias Archethic.P2P.Message
+  alias Archethic.P2P.Message.Error
+  alias Archethic.P2P.Message.Ok
+  alias Archethic.P2P.Message.RequestChainLock
+
+  use ArchethicCase
+  import ArchethicCase
+
+  describe "serialization" do
+    test "should serialize and deserialize message" do
+      address = random_address()
+      hash = Crypto.hash(address)
+
+      message = %RequestChainLock{address: address, hash: hash}
+
+      assert message == message |> Message.encode() |> Message.decode() |> elem(0)
+    end
+  end
+
+  describe "process" do
+    test "should lock an address and return Ok" do
+      address = random_address()
+      hash1 = Crypto.hash(address)
+      hash2 = Crypto.hash(hash1)
+
+      message = %RequestChainLock{address: address, hash: hash1}
+
+      assert %Ok{} == Message.process(message, random_public_key())
+      assert {:error, :already_locked} == ChainLock.lock(address, hash2)
+    end
+
+    test "should return Error if address is already locked" do
+      address = random_address()
+      hash1 = Crypto.hash(address)
+      hash2 = Crypto.hash(hash1)
+
+      assert :ok == ChainLock.lock(address, hash1)
+
+      message = %RequestChainLock{address: address, hash: hash2}
+
+      assert %Error{reason: :already_locked} == Message.process(message, random_public_key())
+    end
+  end
+end

--- a/test/archethic/p2p/message/unlock_chain_test.exs
+++ b/test/archethic/p2p/message/unlock_chain_test.exs
@@ -1,0 +1,35 @@
+defmodule Archethic.P2P.Message.UnlockChainTest do
+  @moduledoc false
+
+  alias Archethic.Crypto
+  alias Archethic.Mining.ChainLock
+  alias Archethic.P2P.Message
+  alias Archethic.P2P.Message.Ok
+  alias Archethic.P2P.Message.UnlockChain
+
+  use ArchethicCase
+  import ArchethicCase
+
+  describe "serialization" do
+    test "should serialize and deserialize message" do
+      message = %UnlockChain{address: random_address()}
+
+      assert message == message |> Message.encode() |> Message.decode() |> elem(0)
+    end
+  end
+
+  describe "process" do
+    test "should unlock an address and return Ok" do
+      address = random_address()
+      hash1 = Crypto.hash(address)
+      hash2 = Crypto.hash(hash1)
+
+      ChainLock.lock(address, hash1)
+
+      message = %UnlockChain{address: address}
+
+      assert %Ok{} == Message.process(message, random_public_key())
+      assert :ok == ChainLock.lock(address, hash2)
+    end
+  end
+end


### PR DESCRIPTION
# Description

This PR adds a new security layer before to start mining a transaction.
When receiving the StartMining message for a transaction, validation nodes request the storage nodes of this transaction to lock the address. If the address is already locked for the same address but with a different transaction data, the lock is refused and the validation node does not start the mining.

This PR does not handle malicious node which could still start the transaction mining even with no lock. And so ask the replication to storage nodes.
To handle this, the storage nodes could sign the lock request, and so the storage nodes will replication the transaction only if they have the proof of the request lock being signed by all storage nodes.

Fixes #1373 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Unit test
- Create multiple transaction in the same chain => no problem
- Create an invalid transaction send it and retry to validate it again after receiving the error => no problem, transaction still in error with the expected error
- Create an invalid transaction send it, update it and retry to validate it again after receiving the error => no problem, transaction still in error with the expected error
- Update the code so the node never unlock an address, and run the previous test => validation nodes return the error that the transaction is already locked with another data
- Tested with high usage with benchmark => no problem


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
