### PR TITLE
Compress the transaction code on serialization

### DIFF
--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -206,7 +206,7 @@ defmodule Archethic.Bootstrap.NetworkInit do
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_election:
           Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-        proof_of_integrity: tx |> Transaction.serialize() |> Crypto.hash(),
+        proof_of_integrity: tx |> Transaction.serialize(:extended) |> Crypto.hash(),
         ledger_operations: operations
       }
       |> ValidationStamp.sign()

--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -206,7 +206,7 @@ defmodule Archethic.Bootstrap.NetworkInit do
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_election:
           Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
-        proof_of_integrity: tx |> Transaction.serialize(:extended) |> Crypto.hash(),
+        proof_of_integrity: tx |> Transaction.serialize() |> Crypto.hash(),
         ledger_operations: operations
       }
       |> ValidationStamp.sign()

--- a/lib/archethic/db/embedded_impl/encoding.ex
+++ b/lib/archethic/db/embedded_impl/encoding.ex
@@ -103,7 +103,7 @@ defmodule Archethic.DB.EmbeddedImpl.Encoding do
         {"address", address},
         {"type", <<Transaction.serialize_type(type)::8>>},
         {"data.content", content},
-        {"data.code", code},
+        {"data.code", TransactionData.compress_code(code)},
         {"data.ledger.uco", UCOLedger.serialize(uco_ledger, tx_version)},
         {"data.ledger.token", TokenLedger.serialize(token_ledger, tx_version)},
         {"data.ownerships", <<encoded_ownerships_len::binary, ownerships_encoding::binary>>},

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -27,7 +27,7 @@ defmodule Archethic.Mining do
 
   use Retry
 
-  # protocol version 5->6 the POI changed and is now done with tx.data.code compressed
+  # protocol version 5->6 the POI changed and is now done with tx.data.recipients.args serialized with :extended mode
   @protocol_version 6
 
   def protocol_version, do: @protocol_version

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -27,7 +27,8 @@ defmodule Archethic.Mining do
 
   use Retry
 
-  @protocol_version 5
+  # protocol version 5->6 the POI changed and is now done with tx.data.code compressed
+  @protocol_version 6
 
   def protocol_version, do: @protocol_version
 

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -1068,7 +1068,7 @@ defmodule Archethic.TransactionChain do
   def proof_of_integrity([tx = %Transaction{} | _]) do
     tx
     |> Transaction.to_pending()
-    |> Transaction.serialize(:extended)
+    |> Transaction.serialize()
     |> Crypto.hash()
   end
 

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -1068,7 +1068,7 @@ defmodule Archethic.TransactionChain do
   def proof_of_integrity([tx = %Transaction{} | _]) do
     tx
     |> Transaction.to_pending()
-    |> Transaction.serialize()
+    |> Transaction.serialize(:extended)
     |> Crypto.hash()
   end
 

--- a/lib/archethic/transaction_chain/transaction/data.ex
+++ b/lib/archethic/transaction_chain/transaction/data.ex
@@ -29,18 +29,25 @@ defmodule Archethic.TransactionChain.TransactionData do
           content: binary()
         }
 
+  @code_max_size Application.compile_env!(:archethic, :transaction_data_code_max_size)
+
   @spec compress_code(String.t()) :: binary()
   def compress_code(""), do: ""
 
   def compress_code(code) do
-    :zlib.gzip(code)
+    :zlib.zip(code)
   end
 
   @spec decompress_code(binary()) :: String.t()
   def decompress_code(""), do: ""
 
   def decompress_code(code) do
-    :zlib.gunzip(code)
+    :zlib.unzip(code)
+  end
+
+  @spec code_size_valid?(String.t()) :: bool()
+  def code_size_valid?(code) do
+    compress_code(code) |> byte_size() < @code_max_size
   end
 
   @doc """

--- a/lib/archethic/transaction_chain/transaction/data.ex
+++ b/lib/archethic/transaction_chain/transaction/data.ex
@@ -171,8 +171,6 @@ defmodule Archethic.TransactionChain.TransactionData do
   def cast(data = %{}) do
     code = Map.get(data, :code, "")
 
-    # our database contains both compressed and not compressed code
-    # this can be removed after a migration
     code =
       if String.printable?(code) do
         code

--- a/lib/archethic/utils/regression/api.ex
+++ b/lib/archethic/utils/regression/api.ex
@@ -137,7 +137,7 @@ defmodule Archethic.Utils.Regression.Api do
     true =
       Crypto.verify?(
         tx.previous_signature,
-        Transaction.extract_for_previous_signature(tx) |> Transaction.serialize(),
+        Transaction.extract_for_previous_signature(tx) |> Transaction.serialize(:extended),
         tx.previous_public_key
       )
 
@@ -195,7 +195,7 @@ defmodule Archethic.Utils.Regression.Api do
     true =
       Crypto.verify?(
         tx.previous_signature,
-        Transaction.extract_for_previous_signature(tx) |> Transaction.serialize(),
+        Transaction.extract_for_previous_signature(tx) |> Transaction.serialize(:extended),
         tx.previous_public_key
       )
 
@@ -462,7 +462,7 @@ defmodule Archethic.Utils.Regression.Api do
     true =
       Crypto.verify?(
         tx.previous_signature,
-        Transaction.extract_for_previous_signature(tx) |> Transaction.serialize(),
+        Transaction.extract_for_previous_signature(tx) |> Transaction.serialize(:extended),
         tx.previous_public_key
       )
 

--- a/lib/archethic_web/api/ecto_schemas/schema/transaction_data.ex
+++ b/lib/archethic_web/api/ecto_schemas/schema/transaction_data.ex
@@ -1,11 +1,11 @@
 defmodule ArchethicWeb.API.Schema.TransactionData do
   @moduledoc false
   @content_max_size Application.compile_env!(:archethic, :transaction_data_content_max_size)
-  @code_max_size Application.compile_env!(:archethic, :transaction_data_code_max_size)
 
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Archethic.TransactionChain.TransactionData
   alias ArchethicWeb.API.Schema.Ledger
   alias ArchethicWeb.API.Schema.Ownership
   alias ArchethicWeb.API.Types.Hex
@@ -29,15 +29,21 @@ defmodule ArchethicWeb.API.Schema.TransactionData do
       message: "content size must be less than content_max_size",
       count: :bytes
     )
-    |> validate_length(:code,
-      max: @code_max_size,
-      message: "code size can't be more than #{Integer.to_string(@code_max_size)} bytes",
-      count: :bytes
-    )
+    |> validate_code_size()
     |> validate_length(:ownerships, max: 255, message: "ownerships can not be more that 255")
     |> validate_length(:recipients,
       max: 255,
       message: "maximum number of recipients can be 255"
     )
+  end
+
+  def validate_code_size(changeset) do
+    validate_change(changeset, :code, fn field, value ->
+      if TransactionData.code_size_valid?(value) do
+        []
+      else
+        [{field, "Invalid transaction, code exceed max size"}]
+      end
+    end)
   end
 end

--- a/lib/archethic_web/api/jsonrpc/schemas/transaction.ex
+++ b/lib/archethic_web/api/jsonrpc/schemas/transaction.ex
@@ -8,7 +8,6 @@ defmodule ArchethicWeb.API.JsonRPC.TransactionSchema do
 
   alias Archethic.Utils
 
-  @max_code_bytes Application.compile_env(:archethic, :transaction_data_code_max_size, 24 * 1024)
   @transaction_schema :archethic
                       |> Application.app_dir("priv/json-schemas/transaction.json")
                       |> File.read!()
@@ -52,13 +51,13 @@ defmodule ArchethicWeb.API.JsonRPC.TransactionSchema do
         :ok
 
       code ->
-        size = TransactionData.compress_code(code) |> byte_size()
-
-        if size <= @max_code_bytes do
+        if TransactionData.code_size_valid?(code) do
           :ok
         else
           {:error,
-           [{"Expected value to have a maximum length of 24576 but was #{size}.", "#/data/code"}]}
+           [
+             {"Invalid transaction, code exceed max size.", "#/data/code"}
+           ]}
         end
     end
   end

--- a/lib/archethic_web/api/jsonrpc/schemas/transaction.ex
+++ b/lib/archethic_web/api/jsonrpc/schemas/transaction.ex
@@ -8,7 +8,7 @@ defmodule ArchethicWeb.API.JsonRPC.TransactionSchema do
 
   alias Archethic.Utils
 
-  @max_code_bytes 24 * 1024
+  @max_code_bytes Application.compile_env(:archethic, :transaction_data_code_max_size, 24 * 1024)
   @transaction_schema :archethic
                       |> Application.app_dir("priv/json-schemas/transaction.json")
                       |> File.read!()

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -94,7 +94,7 @@
 
             <%!-------------------------------- CODE --------------------------------%>
             <div class="columns" x-data="{show: true}">
-              <% code_bytes = byte_size(@transaction.data.code) %>
+              <% code_bytes = byte_size(TransactionData.compress_code(@transaction.data.code)) %>
               <div class="column ae-left-heading is-2">
                 <p>Code (<%= format_bytes(code_bytes) %>)</p>
                 <%= if code_bytes > 0 do %>

--- a/priv/json-schemas/schemas/object/transaction_data.json
+++ b/priv/json-schemas/schemas/object/transaction_data.json
@@ -4,8 +4,7 @@
   "properties": {
     "code": {
       "type": "string",
-      "description": "Transaction's smart contract code",
-      "maxLength": 24576
+      "description": "Transaction's smart contract code"
     },
     "content": {
       "type": "string",

--- a/test/archethic/contracts/contract_test.exs
+++ b/test/archethic/contracts/contract_test.exs
@@ -104,7 +104,7 @@ defmodule Archethic.Contracts.ContractTest do
                Contract.sign_next_transaction(contract, next_tx, 1)
 
       tx_payload =
-        Transaction.extract_for_previous_signature(signed_tx) |> Transaction.serialize()
+        Transaction.extract_for_previous_signature(signed_tx) |> Transaction.serialize(:extended)
 
       assert Crypto.verify?(signature, tx_payload, pub)
     end

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -158,16 +158,9 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
     end
 
     test "exceeds max code size" do
-      size = Application.get_env(:archethic, :transaction_data_code_max_size)
-      data = :crypto.strong_rand_bytes(size + 1)
+      code = generate_code_that_exceed_limit_when_compressed()
 
-      code = ~s"""
-        condition transaction: [
-         content: hash(#{data}})
-      ]
-      """
-
-      assert {:error, "Invalid contract type transaction , code exceed max size"} =
+      assert {:error, "Invalid transaction, code exceed max size"} =
                ContractFactory.create_valid_contract_tx(code)
                |> PendingTransactionValidation.validate()
     end

--- a/test/archethic/transaction_chain/transaction_test.exs
+++ b/test/archethic/transaction_chain/transaction_test.exs
@@ -34,7 +34,9 @@ defmodule Archethic.TransactionChain.TransactionTest do
 
       assert Crypto.verify?(
                tx.origin_signature,
-               tx |> Transaction.extract_for_origin_signature() |> Transaction.serialize(),
+               tx
+               |> Transaction.extract_for_origin_signature()
+               |> Transaction.serialize(:extended),
                Crypto.origin_node_public_key()
              )
     end
@@ -54,7 +56,9 @@ defmodule Archethic.TransactionChain.TransactionTest do
 
       assert Crypto.verify?(
                tx.origin_signature,
-               tx |> Transaction.extract_for_origin_signature() |> Transaction.serialize(),
+               tx
+               |> Transaction.extract_for_origin_signature()
+               |> Transaction.serialize(:extended),
                Crypto.origin_node_public_key()
              )
     end

--- a/test/archethic_web/api/ecto_schemas/transaction_payload_test.exs
+++ b/test/archethic_web/api/ecto_schemas/transaction_payload_test.exs
@@ -133,14 +133,13 @@ defmodule ArchethicWeb.API.TransactionPayloadTest do
         "previousPublicKey" => Base.encode16(random_address()),
         "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
         "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
-        "data" => %{"code" => Base.encode16(:crypto.strong_rand_bytes(24 * 1024 + 1))}
+        "data" => %{"code" => generate_code_that_exceed_limit_when_compressed()}
       }
 
       assert {:ok, %Ecto.Changeset{valid?: false, changes: %{data: %{errors: errors}}}} =
                TransactionPayload.changeset(map)
 
-      {error_message, _} = Keyword.get(errors, :code)
-      assert String.starts_with?(error_message, "code size can't be more than ")
+      assert {"Invalid transaction, code exceed max size", _} = Keyword.get(errors, :code)
     end
 
     test "should return an error if the uco ledger transfer address is invalid" do

--- a/test/archethic_web/api/jsonrpc/schemas/transaction_test.exs
+++ b/test/archethic_web/api/jsonrpc/schemas/transaction_test.exs
@@ -131,7 +131,7 @@ defmodule ArchethicWeb.API.JsonRPC.TransactionSchemaTest do
 
       assert {:error,
               %{
-                "#/data/code" => "Expected value to have a maximum length of 24576 but was 49154."
+                "#/data/code" => "Expected value to have a maximum length of 24576 but was " <> _
               }} = TransactionSchema.validate(map)
     end
 

--- a/test/archethic_web/api/jsonrpc/schemas/transaction_test.exs
+++ b/test/archethic_web/api/jsonrpc/schemas/transaction_test.exs
@@ -118,7 +118,7 @@ defmodule ArchethicWeb.API.JsonRPC.TransactionSchemaTest do
                TransactionSchema.validate(map)
     end
 
-    test "should return an error if the code length is more than 24KB" do
+    test "should return an error if the code length is more than limit" do
       map = %{
         "version" => current_transaction_version(),
         "address" => Base.encode16(random_address()),
@@ -126,12 +126,12 @@ defmodule ArchethicWeb.API.JsonRPC.TransactionSchemaTest do
         "previousPublicKey" => Base.encode16(random_address()),
         "previousSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
         "originSignature" => Base.encode16(:crypto.strong_rand_bytes(64)),
-        "data" => %{"code" => Base.encode16(:crypto.strong_rand_bytes(24 * 1024 + 1))}
+        "data" => %{"code" => generate_code_that_exceed_limit_when_compressed()}
       }
 
       assert {:error,
               %{
-                "#/data/code" => "Expected value to have a maximum length of 24576 but was " <> _
+                "#/data/code" => "Invalid transaction, code exceed max size."
               }} = TransactionSchema.validate(map)
     end
 

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -9,7 +9,13 @@ defmodule ArchethicCase do
 
   alias Account.MemTables.{TokenLedger, UCOLedger}
   alias SharedSecrets.MemTables.{NetworkLookup, OriginKeyLookup}
-  alias TransactionChain.{Transaction, MemTables.KOLedger, MemTables.PendingLedger}
+
+  alias TransactionChain.{
+    Transaction,
+    TransactionData,
+    MemTables.KOLedger,
+    MemTables.PendingLedger
+  }
 
   alias Archethic.Governance.Pools.MemTable, as: PoolsMemTable
   alias Archethic.OracleChain.MemTable, as: OracleMemTable
@@ -281,6 +287,19 @@ defmodule ArchethicCase do
         action_ast,
         constants |> ContractFactory.append_contract_constant(contract_tx),
         contract_tx
+      )
+    end
+  end
+
+  def generate_code_that_exceed_limit_when_compressed(code \\ "") do
+    max_bytes = Application.get_env(:archethic, :transaction_data_code_max_size)
+
+    if code |> TransactionData.compress_code() |> byte_size() > max_bytes do
+      code
+    else
+      # generate 10k*2 bytes on every loop until limit is reached
+      generate_code_that_exceed_limit_when_compressed(
+        code <> Base.encode16(:crypto.strong_rand_bytes(10_000))
       )
     end
   end


### PR DESCRIPTION
# Description

- Compress code when serializing it (network & db)
- Check code size on compressed code 

Fixes #1299 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with following scenarios: 

- an existing contract is triggered in the newer version
- a new contract is triggered
- explorer can read transactions with zipped or unzipped code

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
