### PR TITLE
Add new flag resolve_last to rpc call function

### DIFF
--- a/lib/archethic_web/api/ecto_schemas/function_call_payload.ex
+++ b/lib/archethic_web/api/ecto_schemas/function_call_payload.ex
@@ -9,11 +9,12 @@ defmodule ArchethicWeb.API.FunctionCallPayload do
     field(:contract, Address)
     field(:function, :string)
     field(:args, {:array, :any})
+    field(:resolve_last, :boolean)
   end
 
   def changeset(params = %{}) do
     %__MODULE__{}
-    |> cast(params, [:contract, :function, :args])
+    |> cast(params, [:contract, :function, :args, :resolve_last])
     |> validate_required([:contract, :function])
   end
 end


### PR DESCRIPTION
# Description

Add a new flag `resolve_last` to the json rpc function `call_function` allowing user to execute the contract to it's last version/time or to the version/time of the requested address.
`request_last` is a boolean, default to true

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Created a contract with a public function returning a State and an action updating the state. I was able to retrieve state of the selected address.
```elixir
@version 1

actions triggered_by: interval, at: "*/5 * * * * *" do
  counter = State.get("counter", 0)
  State.set("counter", counter + 1)
end

export fun get_counter() do
  State.get("counter", 0)
end
```

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
