### PR TITLE
Better conflict/acceptance resolver

### DIFF
--- a/test/archethic/self_repair/sync/transaction_handler_test.exs
+++ b/test/archethic/self_repair/sync/transaction_handler_test.exs
@@ -17,6 +17,7 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
 
   alias Archethic.TransactionFactory
 
+  alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionInput
   alias Archethic.TransactionChain.TransactionSummary
 
@@ -158,13 +159,11 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
 
       %Node{first_public_key: ^coordinator_node_pkey}, %GetTransaction{}, _ ->
         # split
-        {:ok,
-         put_in(tx, [Access.key!(:validation_stamp), Access.key!(:timestamp)], DateTime.utc_now())}
+        {:ok, %Transaction{tx | type: :data}}
 
       %Node{first_public_key: ^storage_node_pkey}, %GetTransaction{}, _ ->
         # split
-        {:ok,
-         put_in(tx, [Access.key!(:validation_stamp), Access.key!(:timestamp)], DateTime.utc_now())}
+        {:ok, %Transaction{tx | type: :data}}
     end)
 
     assert ^tx =
@@ -201,18 +200,15 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
     |> stub(:send_message, fn
       %Node{first_public_key: ^welcome_node_pkey}, %GetTransaction{}, _ ->
         # split
-        {:ok,
-         put_in(tx, [Access.key!(:validation_stamp), Access.key!(:timestamp)], DateTime.utc_now())}
+        {:ok, %Transaction{tx | type: :data}}
 
       %Node{first_public_key: ^coordinator_node_pkey}, %GetTransaction{}, _ ->
         # split
-        {:ok,
-         put_in(tx, [Access.key!(:validation_stamp), Access.key!(:timestamp)], DateTime.utc_now())}
+        {:ok, %Transaction{tx | type: :data}}
 
       %Node{first_public_key: ^storage_node_pkey}, %GetTransaction{}, _ ->
         # split
-        {:ok,
-         put_in(tx, [Access.key!(:validation_stamp), Access.key!(:timestamp)], DateTime.utc_now())}
+        {:ok, %Transaction{tx | type: :data}}
     end)
 
     attestation = %ReplicationAttestation{

--- a/test/archethic/transaction_chain_test.exs
+++ b/test/archethic/transaction_chain_test.exs
@@ -316,28 +316,18 @@ defmodule Archethic.TransactionChainTest do
 
         %Node{port: 3001}, %GetTransaction{address: _}, _ ->
           # split
-          {:ok,
-           put_in(
-             tx,
-             [Access.key!(:validation_stamp), Access.key!(:timestamp)],
-             DateTime.utc_now()
-           )}
+          {:ok, %Transaction{tx | type: :data}}
 
         %Node{port: 3002}, %GetTransaction{address: _}, _ ->
           # split
-          {:ok,
-           put_in(
-             tx,
-             [Access.key!(:validation_stamp), Access.key!(:timestamp)],
-             DateTime.utc_now()
-           )}
+          {:ok, %Transaction{tx | type: :data}}
       end)
 
       assert {:ok, ^tx} =
                TransactionChain.fetch_transaction(tx.address, nodes,
                  search_mode: :remote,
                  acceptance_resolver: fn tx1 ->
-                   tx1.validation_stamp.timestamp == tx.validation_stamp.timestamp
+                   tx1.type == tx.type
                  end
                )
     end


### PR DESCRIPTION
# Description

- `download_transaction` check for the tx's integrity directly in the acceptance_resolver
- `fetch_transaction`'s conflict_resolver was naive and accepted the first non-error result

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
