### PR TITLE
Add consumed input explorer

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -28,6 +28,7 @@ defmodule Archethic do
   alias Archethic.TaskSupervisor
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
   alias Archethic.TransactionChain.TransactionInput
 
   require Logger
@@ -348,6 +349,16 @@ defmodule Archethic do
     address
     |> TransactionChain.fetch_inputs(nodes, DateTime.utc_now(), paging_offset, limit)
     |> Enum.to_list()
+  end
+
+  @doc """
+  Request to fetch the unspent outputs for a transaction address from the closest nodes
+  """
+  @spec get_unspent_outputs(address :: Crypto.prepended_hash(), genesis? :: boolean()) ::
+          list(UnspentOutput.t())
+  def get_unspent_outputs(address, genesis? \\ false) do
+    nodes = Election.storage_nodes(address, P2P.authorized_and_available_nodes())
+    TransactionChain.fetch_unspent_outputs(address, nodes, genesis?) |> Enum.to_list()
   end
 
   @doc """

--- a/lib/archethic/p2p/message/get_unspent_outputs.ex
+++ b/lib/archethic/p2p/message/get_unspent_outputs.ex
@@ -3,18 +3,19 @@ defmodule Archethic.P2P.Message.GetUnspentOutputs do
   Represents a message to request the list of unspent outputs from a transaction
   """
   @enforce_keys [:address]
-  defstruct [:address, offset: 0, limit: 0]
+  defstruct [:address, offset: 0, limit: 0, genesis?: false]
 
-  alias Archethic.Crypto
   alias Archethic.Account
   alias Archethic.Contracts
+  alias Archethic.Crypto
   alias Archethic.P2P.Message.UnspentOutputList
 
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
+
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
   alias Archethic.Utils
   alias Archethic.Utils.VarInt
-
-  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
-  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
+  alias Archethic.UTXO
 
   @threshold Keyword.get(
                Application.compile_env(:archethic, __MODULE__, []),
@@ -25,11 +26,12 @@ defmodule Archethic.P2P.Message.GetUnspentOutputs do
   @type t :: %__MODULE__{
           address: Crypto.versioned_hash(),
           offset: non_neg_integer(),
-          limit: non_neg_integer()
+          limit: non_neg_integer(),
+          genesis?: boolean()
         }
 
   @spec process(__MODULE__.t(), Crypto.key()) :: UnspentOutputList.t()
-  def process(%__MODULE__{address: tx_address, offset: offset}, _) do
+  def process(%__MODULE__{address: tx_address, offset: offset, genesis?: false}, _) do
     contract_utxos =
       tx_address
       |> Contracts.list_contract_transactions()
@@ -47,38 +49,8 @@ defmodule Archethic.P2P.Message.GetUnspentOutputs do
     ledger_utxos = Account.get_unspent_outputs(tx_address)
 
     utxos = ledger_utxos ++ contract_utxos
-    utxos_length = length(utxos)
 
-    %{utxos: utxos, offset: offset, more?: more?} =
-      utxos
-      |> Enum.with_index()
-      |> Enum.drop(offset)
-      |> Enum.reduce_while(
-        %{utxos: [], offset: 0, more?: false, acc_size: 0},
-        fn {versioned_utxo, index}, acc ->
-          acc_size = Map.get(acc, :acc_size)
-
-          utxo_size =
-            versioned_utxo
-            |> VersionedUnspentOutput.serialize()
-            |> byte_size
-
-          new_acc_size = acc_size + utxo_size
-
-          if new_acc_size < @threshold do
-            new_acc =
-              acc
-              |> Map.update!(:utxos, &[versioned_utxo | &1])
-              |> Map.put(:acc_size, new_acc_size)
-              |> Map.put(:offset, index + 1)
-              |> Map.put(:more?, index + 1 < utxos_length)
-
-            {:cont, new_acc}
-          else
-            {:halt, acc}
-          end
-        end
-      )
+    %{utxos: utxos, offset: offset, more?: more?} = reduce_utxos(utxos, offset)
 
     %UnspentOutputList{
       unspent_outputs: utxos,
@@ -87,16 +59,63 @@ defmodule Archethic.P2P.Message.GetUnspentOutputs do
     }
   end
 
+  def process(%__MODULE__{address: genesis_address, offset: offset, genesis?: true}, _) do
+    %{utxos: utxos, offset: offset, more?: more?} =
+      genesis_address |> UTXO.stream_unspent_outputs() |> reduce_utxos(offset)
+
+    %UnspentOutputList{
+      unspent_outputs: utxos,
+      offset: offset,
+      more?: more?
+    }
+  end
+
+  defp reduce_utxos(utxos, offset) do
+    utxos_length = Enum.count(utxos)
+
+    utxos
+    |> Enum.sort_by(& &1.unspent_output.timestamp, {:desc, DateTime})
+    |> Enum.with_index()
+    |> Enum.drop(offset)
+    |> Enum.reduce_while(
+      %{utxos: [], offset: 0, more?: false, acc_size: 0},
+      fn {versioned_utxo, index}, acc ->
+        acc_size = Map.get(acc, :acc_size)
+
+        utxo_size =
+          versioned_utxo
+          |> VersionedUnspentOutput.serialize()
+          |> byte_size
+
+        new_acc_size = acc_size + utxo_size
+
+        if new_acc_size < @threshold do
+          new_acc =
+            acc
+            |> Map.update!(:utxos, &[versioned_utxo | &1])
+            |> Map.put(:acc_size, new_acc_size)
+            |> Map.put(:offset, index + 1)
+            |> Map.put(:more?, index + 1 < utxos_length)
+
+          {:cont, new_acc}
+        else
+          {:halt, acc}
+        end
+      end
+    )
+  end
+
   @spec serialize(t()) :: bitstring()
-  def serialize(%__MODULE__{address: tx_address, offset: offset}) do
-    <<tx_address::binary, VarInt.from_value(offset)::binary>>
+  def serialize(%__MODULE__{address: tx_address, offset: offset, genesis?: genesis?}) do
+    genesis_bit = if genesis?, do: 1, else: 0
+    <<tx_address::binary, VarInt.from_value(offset)::binary, genesis_bit::1>>
   end
 
   @spec deserialize(bitstring()) :: {t(), bitstring}
   def deserialize(<<rest::bitstring>>) do
     {address, rest} = Utils.deserialize_address(rest)
 
-    {offset, rest} = VarInt.get_value(rest)
-    {%__MODULE__{address: address, offset: offset}, rest}
+    {offset, <<genesis_bit::1, rest::binary>>} = VarInt.get_value(rest)
+    {%__MODULE__{address: address, offset: offset, genesis?: genesis_bit == 1}, rest}
   end
 end

--- a/lib/archethic_web/explorer/components/unspent_outputs_list.ex
+++ b/lib/archethic_web/explorer/components/unspent_outputs_list.ex
@@ -1,0 +1,78 @@
+defmodule ArchethicWeb.Explorer.Components.UnspentOutputList do
+  @moduledoc false
+
+  alias ArchethicWeb.ExplorerRouter.Helpers, as: Routes
+
+  use Phoenix.Component
+  use Phoenix.HTML
+
+  alias ArchethicWeb.Explorer.Components.Amount
+
+  import ArchethicWeb.WebUtils
+
+  def display_all(assigns) do
+    # uco_price_at_time is optional because sometimes we do not have the time context
+    # example: on a genesis page, there is no time
+    assigns = assign(assigns, :uco_price_at_time, Map.get(assigns, :uco_price_at_time))
+
+    ~H"""
+    <ul>
+      <%= for utxo <- @utxos do %>
+        <li class="columns">
+          <div class="column is-narrow">
+            <span class="ae-label">From</span>
+            <%= link(short_address(utxo.from),
+              to:
+                Routes.live_path(
+                  @socket,
+                  ArchethicWeb.Explorer.TransactionDetailsLive,
+                  Base.encode16(utxo.from)
+                )
+            ) %>
+          </div>
+
+          <div class="column is-narrow">
+            <span class="ae-label">At</span>
+            <%= format_date(utxo.timestamp) %>
+          </div>
+
+          <div class="column is-narrow">
+            <%= case utxo.type do %>
+              <% :UCO -> %>
+                <span class="ae-label">Amount</span>
+                <Amount.uco
+                  amount={utxo.amount}
+                  uco_price_at_time={@uco_price_at_time}
+                  uco_price_now={@uco_price_now}
+                />
+              <% {:token, token_address, token_id} -> %>
+                <span class="ae-label">Amount</span>
+                <Amount.token
+                  amount={utxo.amount}
+                  token_address={token_address}
+                  token_id={token_id}
+                  token_properties={@token_properties}
+                  socket={@socket}
+                />
+              <% :call -> %>
+                <span class="ae-label">Smart contract call</span>
+              <% :state -> %>
+                <span class="ae-label">Smart contract state</span>
+            <% end %>
+          </div>
+
+          <%= if @display_status? do %>
+            <div class="column is-narrow">
+              <%= if ArchethicWeb.Explorer.TransactionDetailsLive.utxo_spent?(utxo, @inputs) do %>
+                <span class="tag is-danger mono">Spent&nbsp;&nbsp;</span>
+              <% else %>
+                <span class="tag is-success mono">Unspent</span>
+              <% end %>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+    """
+  end
+end

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -24,6 +24,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
   alias Archethic.TransactionChain.TransactionInput
   alias ArchethicWeb.WebUtils
   alias ArchethicWeb.Explorer.Components.InputsList
+  alias ArchethicWeb.Explorer.Components.UnspentOutputList
   alias ArchethicWeb.Explorer.Components.Amount
   import ArchethicWeb.Explorer.ExplorerView
 

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -349,7 +349,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
   # loop through the inputs to detect if a UTXO is spent or not
   def utxo_spent?(utxo, inputs) do
     case Enum.find(inputs, &similar?(&1, utxo)) do
-      nil -> false
+      nil -> true
       input -> input.spent?
     end
   end

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -42,10 +42,10 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
      })}
   end
 
-  def handle_params(opts = %{"address" => address}, _uri, socket) do
+  def handle_params(%{"address" => address}, _uri, socket) do
     with {:ok, addr} <- Base.decode16(address, case: :mixed),
          true <- Crypto.valid_address?(addr) do
-      case get_transaction(addr, opts) do
+      case Archethic.search_transaction(addr) do
         {:ok, tx} ->
           {:noreply, handle_transaction(socket, tx)}
 
@@ -63,7 +63,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
   end
 
   def handle_info({:new_transaction, address}, socket) do
-    {:ok, tx} = get_transaction(address, %{})
+    {:ok, tx} = Archethic.search_transaction(address)
 
     new_socket =
       socket
@@ -79,14 +79,6 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
 
   def handle_info(_, socket) do
     {:noreply, socket}
-  end
-
-  defp get_transaction(address, %{"address" => "true"}) do
-    Archethic.get_last_transaction(address)
-  end
-
-  defp get_transaction(address, _opts = %{}) do
-    Archethic.search_transaction(address)
   end
 
   defp handle_transaction(

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -51,12 +51,23 @@
 
         <%= if inputs_count > 0 do %>
           <div class="my-4 is-size-4">Inputs (<%= inputs_count %>)</div>
-          <InputsList.display_all
-            inputs={@inputs}
-            socket={@socket}
-            uco_price_now={@uco_price_now}
-            token_properties={@token_properties}
-          />
+          <%= if @debug? do %>
+            <UnspentOutputList.display_all
+              inputs={@inputs}
+              utxos={@inputs}
+              socket={@socket}
+              uco_price_now={@uco_price_now}
+              token_properties={@token_properties}
+              display_status?={false}
+            />
+          <% else %>
+            <InputsList.display_all
+              inputs={@inputs}
+              socket={@socket}
+              uco_price_now={@uco_price_now}
+              token_properties={@token_properties}
+            />
+          <% end %>
         <% end %>
       <% assigns[:error] != nil and @error == :invalid_address -> %>
         <p>The given transaction address is invalid.</p>
@@ -478,27 +489,29 @@
               </ul>
             </div>
 
-            <%!----------------------------- CONSUMED INPUTS --------------------------------%>
-            <div class="columns">
-              <% utxos_count =
-                Enum.count(@transaction.validation_stamp.ledger_operations.consumed_inputs) %>
+            <%= if @debug? do %>
+              <%!----------------------------- CONSUMED INPUTS --------------------------------%>
+              <div class="columns">
+                <% utxos_count =
+                  Enum.count(@transaction.validation_stamp.ledger_operations.consumed_inputs) %>
 
-              <div class="column ae-left-heading is-2">
-                <p>Consumed inputs (<%= utxos_count %>)</p>
-              </div>
+                <div class="column ae-left-heading is-2">
+                  <p>Consumed inputs (<%= utxos_count %>)</p>
+                </div>
 
-              <div class="column">
-                <UnspentOutputList.display_all
-                  inputs={@inputs}
-                  utxos={@transaction.validation_stamp.ledger_operations.consumed_inputs}
-                  socket={@socket}
-                  uco_price_at_time={@uco_price_at_time}
-                  uco_price_now={@uco_price_now}
-                  token_properties={@token_properties}
-                  display_status?={false}
-                />
+                <div class="column">
+                  <UnspentOutputList.display_all
+                    inputs={@inputs}
+                    utxos={@transaction.validation_stamp.ledger_operations.consumed_inputs}
+                    socket={@socket}
+                    uco_price_at_time={@uco_price_at_time}
+                    uco_price_now={@uco_price_now}
+                    token_properties={@token_properties}
+                    display_status?={false}
+                  />
+                </div>
               </div>
-            </div>
+            <% end %>
 
             <%!----------------------------- OUTPUTS --------------------------------%>
             <div class="columns">
@@ -523,62 +536,82 @@
               </div>
             </div>
 
-            <%!----------------------------- INPUTS --------------------------------%>
-            <div class="columns">
-              <% filtered_inputs =
-                filter_inputs(
-                  @inputs,
-                  @transaction.validation_stamp.ledger_operations.unspent_outputs
-                ) %>
-              <% inputs_count = Enum.count(filtered_inputs) %>
-              <div class="column ae-left-heading is-2">
-                <p>Inputs (<%= inputs_count %>)</p>
-              </div>
+            <%= if @debug? do %>
+              <%!----------------------------- GENESIS INPUTS --------------------------------%>
+              <div class="columns">
+                <div class="column ae-left-heading is-2">
+                  <p>Genesis inputs (<%= Enum.count(@inputs) %>)</p>
+                </div>
 
-              <div class="column">
-                <%= if inputs_count == 0 do %>
-                  <div></div>
-                <% else %>
-                  <InputsList.display_all
-                    inputs={filtered_inputs}
+                <div class="column">
+                  <UnspentOutputList.display_all
+                    inputs={@inputs}
+                    utxos={@inputs}
                     socket={@socket}
                     uco_price_at_time={@uco_price_at_time}
                     uco_price_now={@uco_price_now}
                     token_properties={@token_properties}
+                    display_status?={false}
                   />
-                <% end %>
+                </div>
               </div>
-            </div>
+            <% else %>
+              <%!----------------------------- INPUTS --------------------------------%>
+              <div class="columns">
+                <% filtered_inputs =
+                  filter_inputs(
+                    @inputs,
+                    @transaction.validation_stamp.ledger_operations.unspent_outputs
+                  ) %>
+                <div class="column ae-left-heading is-2">
+                  <p>Inputs (<%= Enum.count(filtered_inputs) %>)</p>
+                </div>
 
-            <%!----------------------------- CALLS --------------------------------%>
-            <div class="columns">
-              <% calls_count = Enum.count(@calls) %>
-
-              <div class="column ae-left-heading is-2">
-                <p>Contract inputs (<%= calls_count %>)</p>
+                <div class="column">
+                  <%= if inputs_count == 0 do %>
+                    <div></div>
+                  <% else %>
+                    <InputsList.display_all
+                      inputs={filtered_inputs}
+                      socket={@socket}
+                      uco_price_at_time={@uco_price_at_time}
+                      uco_price_now={@uco_price_now}
+                      token_properties={@token_properties}
+                    />
+                  <% end %>
+                </div>
               </div>
 
-              <div class="column">
-                <%= if calls_count > 0 do %>
-                  <ul>
-                    <%= for call <- @calls do %>
-                      <li>
-                        <%= link(WebUtils.short_address(call.from),
-                          to:
-                            Routes.live_path(
-                              @socket,
-                              ArchethicWeb.Explorer.TransactionDetailsLive,
-                              Base.encode16(call.from)
-                            )
-                        ) %>
-                      </li>
-                    <% end %>
-                  </ul>
-                <% else %>
-                  <div></div>
-                <% end %>
+              <%!----------------------------- CALLS --------------------------------%>
+              <div class="columns">
+                <% calls_count = Enum.count(@calls) %>
+
+                <div class="column ae-left-heading is-2">
+                  <p>Contract inputs (<%= calls_count %>)</p>
+                </div>
+
+                <div class="column">
+                  <%= if calls_count > 0 do %>
+                    <ul>
+                      <%= for call <- @calls do %>
+                        <li>
+                          <%= link(WebUtils.short_address(call.from),
+                            to:
+                              Routes.live_path(
+                                @socket,
+                                ArchethicWeb.Explorer.TransactionDetailsLive,
+                                Base.encode16(call.from)
+                              )
+                          ) %>
+                        </li>
+                      <% end %>
+                    </ul>
+                  <% else %>
+                    <div></div>
+                  <% end %>
+                </div>
               </div>
-            </div>
+            <% end %>
 
             <%!----------------------------- CRYPTO --------------------------------%>
             <div class="columns" x-data="{show: false}">

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -508,65 +508,49 @@
               </div>
             </div>
 
-            <%!----------------------------- OUTPUTS --------------------------------%>
+            <%!----------------------------- CONSUMED INPUTS --------------------------------%>
             <div class="columns">
               <% utxos_count =
-                Enum.count(@transaction.validation_stamp.ledger_operations.unspent_outputs) %>
+                Enum.count(@transaction.validation_stamp.ledger_operations.consumed_inputs) %>
 
               <div class="column ae-left-heading is-2">
-                <p>Unspent outputs (<%= utxos_count %>)</p>
+                <p>Consumed inputs (<%= utxos_count %>)</p>
               </div>
 
-              <ul class="column">
-                <%= for utxo <- @transaction.validation_stamp.ledger_operations.unspent_outputs, utxo.type != :state do %>
-                  <li class="columns">
-                    <div class="column is-narrow">
-                      <span class="ae-label">From</span>
-                      <%= link(WebUtils.short_address(utxo.from),
-                        to:
-                          Routes.live_path(
-                            @socket,
-                            ArchethicWeb.Explorer.TransactionDetailsLive,
-                            Base.encode16(utxo.from)
-                          )
-                      ) %>
-                    </div>
+              <div class="column">
+                <UnspentOutputList.display_all
+                  inputs={@inputs}
+                  utxos={@transaction.validation_stamp.ledger_operations.consumed_inputs}
+                  socket={@socket}
+                  uco_price_at_time={@uco_price_at_time}
+                  uco_price_now={@uco_price_now}
+                  token_properties={@token_properties}
+                  display_status?={false}
+                />
+              </div>
+            </div>
 
-                    <div class="column is-narrow">
-                      <span class="ae-label">At</span>
-                      <%= format_date(utxo.timestamp) %>
-                    </div>
+            <%!----------------------------- OUTPUTS --------------------------------%>
+            <div class="columns">
+              <% utxos =
+                @transaction.validation_stamp.ledger_operations.unspent_outputs
+                |> Enum.reject(&(&1.type == :state)) %>
 
-                    <div class="column is-narrow">
-                      <span class="ae-label">Amount</span>
-                      <%= case utxo.type do %>
-                        <% :UCO -> %>
-                          <Amount.uco
-                            amount={utxo.amount}
-                            uco_price_at_time={@uco_price_at_time}
-                            uco_price_now={@uco_price_now}
-                          />
-                        <% {:token, token_address, token_id} -> %>
-                          <Amount.token
-                            amount={utxo.amount}
-                            token_address={token_address}
-                            token_id={token_id}
-                            token_properties={@token_properties}
-                            socket={@socket}
-                          />
-                      <% end %>
-                    </div>
+              <div class="column ae-left-heading is-2">
+                <p>Unspent outputs (<%= Enum.count(utxos) %>)</p>
+              </div>
 
-                    <div class="column is-narrow">
-                      <%= if ArchethicWeb.Explorer.TransactionDetailsLive.utxo_spent?(utxo, @inputs) do %>
-                        <span class="tag is-danger mono">Spent&nbsp;&nbsp;</span>
-                      <% else %>
-                        <span class="tag is-success mono">Unspent</span>
-                      <% end %>
-                    </div>
-                  </li>
-                <% end %>
-              </ul>
+              <div class="column">
+                <UnspentOutputList.display_all
+                  inputs={@inputs}
+                  utxos={utxos}
+                  socket={@socket}
+                  uco_price_at_time={@uco_price_at_time}
+                  uco_price_now={@uco_price_now}
+                  token_properties={@token_properties}
+                  display_status?={true}
+                />
+              </div>
             </div>
 
             <%!----------------------------- INPUTS --------------------------------%>

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -478,36 +478,6 @@
               </ul>
             </div>
 
-            <%!----------------------------- CALLS --------------------------------%>
-            <div class="columns">
-              <% calls_count = Enum.count(@calls) %>
-
-              <div class="column ae-left-heading is-2">
-                <p>Contract inputs (<%= calls_count %>)</p>
-              </div>
-
-              <div class="column">
-                <%= if calls_count > 0 do %>
-                  <ul>
-                    <%= for call <- @calls do %>
-                      <li>
-                        <%= link(WebUtils.short_address(call.from),
-                          to:
-                            Routes.live_path(
-                              @socket,
-                              ArchethicWeb.Explorer.TransactionDetailsLive,
-                              Base.encode16(call.from)
-                            )
-                        ) %>
-                      </li>
-                    <% end %>
-                  </ul>
-                <% else %>
-                  <div></div>
-                <% end %>
-              </div>
-            </div>
-
             <%!----------------------------- CONSUMED INPUTS --------------------------------%>
             <div class="columns">
               <% utxos_count =
@@ -576,6 +546,36 @@
                     uco_price_now={@uco_price_now}
                     token_properties={@token_properties}
                   />
+                <% end %>
+              </div>
+            </div>
+
+            <%!----------------------------- CALLS --------------------------------%>
+            <div class="columns">
+              <% calls_count = Enum.count(@calls) %>
+
+              <div class="column ae-left-heading is-2">
+                <p>Contract inputs (<%= calls_count %>)</p>
+              </div>
+
+              <div class="column">
+                <%= if calls_count > 0 do %>
+                  <ul>
+                    <%= for call <- @calls do %>
+                      <li>
+                        <%= link(WebUtils.short_address(call.from),
+                          to:
+                            Routes.live_path(
+                              @socket,
+                              ArchethicWeb.Explorer.TransactionDetailsLive,
+                              Base.encode16(call.from)
+                            )
+                        ) %>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% else %>
+                  <div></div>
                 <% end %>
               </div>
             </div>


### PR DESCRIPTION
# Description

Update the explorer transaction details page with the new consumed inputs field.
Also display the genesis inputs of the chain.

Those fields are currently not visible by default until phase 2 of AEIP 21 is deployed. To access those field you have to put an argument `?debug` at the end of the url.

To display the genesis input of the chain, the message `GetUnspentOutput` is modified with a new `genesis?` flag. Once phase 2 deployed this flag could be removed if not used anymore

Fixes part of #1245 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with mutiple kinf of transaction

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
