### PR TITLE
do not check for reward conversion on token transaction

### DIFF
--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/transaction_movement.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/transaction_movement.ex
@@ -250,7 +250,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
         movement = %__MODULE__{type: {:token, token_address, _token_id}},
         tx_type
       )
-      when tx_type != :node_rewards do
+      when tx_type not in [:node_rewards, :token] do
     if Reward.is_reward_token?(token_address),
       do: %__MODULE__{movement | type: :UCO},
       else: movement

--- a/test/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/transaction_movement_test.exs
+++ b/test/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/transaction_movement_test.exs
@@ -2,7 +2,8 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
   use ArchethicCase
 
   import ArchethicCase
-
+  import Mock
+  alias Archethic.Reward
   alias Archethic.Reward.MemTables.RewardTokens
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.TransactionMovement
@@ -317,6 +318,23 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       movement = %TransactionMovement{to: address, amount: 30, type: :UCO}
 
       assert movement == TransactionMovement.maybe_convert_reward(movement, :transfer)
+    end
+
+    test "should not even check if tx type is token" do
+      address = random_address()
+      token_address = random_address()
+
+      movement = %TransactionMovement{
+        to: address,
+        amount: 30,
+        type: {:token, token_address, 0}
+      }
+
+      with_mock(Reward, is_reward_token?: fn _ -> false end) do
+        assert movement == TransactionMovement.maybe_convert_reward(movement, :token)
+
+        assert_not_called(Reward.is_reward_token?(:_))
+      end
     end
   end
 end


### PR DESCRIPTION
Wondered why I need to mock Reward module when I was working with tokens. 
No need to check if a token is a reward if the transaction type is token. 
