### PR TITLE
AEIP21-P2: Resolve genesis addresses

### DIFF
--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -31,7 +31,8 @@ defmodule Archethic.Mining do
 
   # version 5->6 the POI changed and is now done with tx.data.recipients.args serialized with :extended mode
   # version 6->7 add Add consumed inputs in tx.validation_stamp.ledger_operations
-  @protocol_version 7
+  # version 7->8 movement resolved address are now the genesis address of the destination
+  @protocol_version 8
 
   @lock_threshold 0.75
 

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -214,7 +214,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
         authorized_nodes
       )
 
-    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx, validation_time)
+    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx)
 
     io_storage_nodes =
       if Transaction.network_type?(tx.type) do

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -214,7 +214,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
         authorized_nodes
       )
 
-    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx)
+    resolved_addresses = TransactionChain.resolve_transaction_addresses!(tx)
 
     io_storage_nodes =
       if Transaction.network_type?(tx.type) do

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -220,19 +220,8 @@ defmodule Archethic.Mining.DistributedWorkflow do
       if Transaction.network_type?(tx.type) do
         P2P.list_nodes()
       else
-        targets_resolved_addresses = resolved_addresses |> Enum.into(%{}) |> Map.values()
-
-        Task.Supervisor.async_stream_nolink(
-          Archethic.TaskSupervisor,
-          targets_resolved_addresses,
-          fn address ->
-            {:ok, genesis_address} =
-              TransactionChain.fetch_genesis_address(address, previous_storage_nodes)
-
-            [genesis_address, address]
-          end
-        )
-        |> Enum.flat_map(fn {:ok, res} -> res end)
+        resolved_addresses
+        |> Map.values()
         |> Election.io_storage_nodes(authorized_nodes)
       end
 

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -79,7 +79,7 @@ defmodule Archethic.Mining.StandaloneWorkflow do
         authorized_nodes
       )
 
-    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx, validation_time)
+    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx)
 
     previous_address = Transaction.previous_address(tx)
     previous_storage_nodes = Election.chain_storage_nodes(previous_address, authorized_nodes)

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -93,19 +93,8 @@ defmodule Archethic.Mining.StandaloneWorkflow do
       if Transaction.network_type?(tx.type) do
         P2P.list_nodes()
       else
-        targets_resolved_addresses = resolved_addresses |> Enum.into(%{}) |> Map.values()
-
-        Task.Supervisor.async_stream_nolink(
-          Archethic.TaskSupervisor,
-          targets_resolved_addresses,
-          fn address ->
-            {:ok, genesis_address} =
-              TransactionChain.fetch_genesis_address(address, previous_storage_nodes)
-
-            [genesis_address, address]
-          end
-        )
-        |> Enum.flat_map(fn {:ok, res} -> res end)
+        resolved_addresses
+        |> Map.values()
         |> Election.io_storage_nodes(authorized_nodes)
       end
 

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -79,7 +79,7 @@ defmodule Archethic.Mining.StandaloneWorkflow do
         authorized_nodes
       )
 
-    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx)
+    resolved_addresses = TransactionChain.resolve_transaction_addresses!(tx)
 
     previous_address = Transaction.previous_address(tx)
     previous_storage_nodes = Election.chain_storage_nodes(previous_address, authorized_nodes)

--- a/lib/archethic/replication/transaction_validator.ex
+++ b/lib/archethic/replication/transaction_validator.ex
@@ -317,7 +317,7 @@ defmodule Archethic.Replication.TransactionValidator do
            }
          }
        ) do
-    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx)
+    resolved_addresses = TransactionChain.resolve_transaction_addresses!(tx)
     movements = Transaction.get_movements(tx)
 
     %LedgerOperations{transaction_movements: resolved_movements} =

--- a/lib/archethic/replication/transaction_validator.ex
+++ b/lib/archethic/replication/transaction_validator.ex
@@ -312,13 +312,12 @@ defmodule Archethic.Replication.TransactionValidator do
          tx = %Transaction{
            type: tx_type,
            validation_stamp: %ValidationStamp{
-             timestamp: timestamp,
              ledger_operations:
                ops = %LedgerOperations{transaction_movements: transaction_movements}
            }
          }
        ) do
-    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx, timestamp)
+    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx)
     movements = Transaction.get_movements(tx)
 
     %LedgerOperations{transaction_movements: resolved_movements} =

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -795,9 +795,9 @@ defmodule Archethic.TransactionChain do
 
   **This function raises if it cannot fetch a genesis**
   """
-  @spec resolve_transaction_addresses(Transaction.t()) ::
+  @spec resolve_transaction_addresses!(Transaction.t()) ::
           %{Crypto.prepended_hash() => Crypto.prepended_hash()}
-  def resolve_transaction_addresses(
+  def resolve_transaction_addresses!(
         tx = %Transaction{
           type: type,
           address: address,

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -791,13 +791,12 @@ defmodule Archethic.TransactionChain do
   # ------------------------------------------------------------
 
   @doc """
-  Resolve all the last addresses from the transaction data
+  Resolve all the genesis addresses from the transaction data
   """
-  @spec resolve_transaction_addresses(Transaction.t(), DateTime.t()) ::
+  @spec resolve_transaction_addresses(Transaction.t()) ::
           %{Crypto.prepended_hash() => Crypto.prepended_hash()}
   def resolve_transaction_addresses(
-        tx = %Transaction{data: %TransactionData{recipients: recipients}},
-        time = %DateTime{}
+        tx = %Transaction{data: %TransactionData{recipients: recipients}}
       ) do
     burning_address = LedgerOperations.burning_address()
 
@@ -820,11 +819,9 @@ defmodule Archethic.TransactionChain do
           {burning_address, burning_address}
 
         to ->
-          nodes = Election.chain_storage_nodes(to, authorized_nodes)
-
-          case fetch_last_address(to, nodes, timestamp: time) do
-            {:ok, resolved} ->
-              {to, resolved}
+          case fetch_genesis_address(to, Election.chain_storage_nodes(to, authorized_nodes)) do
+            {:ok, genesis} ->
+              {to, genesis}
 
             _ ->
               {to, to}

--- a/lib/archethic/transaction_chain/transaction_summary.ex
+++ b/lib/archethic/transaction_chain/transaction_summary.ex
@@ -3,7 +3,7 @@ defmodule Archethic.TransactionChain.TransactionSummary do
   Represents transaction header or extract to summarize it
   """
 
-  @version 2
+  @version 3
 
   defstruct [
     :timestamp,
@@ -51,6 +51,7 @@ defmodule Archethic.TransactionChain.TransactionSummary do
           type: type,
           validation_stamp:
             validation_stamp = %ValidationStamp{
+              protocol_version: protocol_version,
               timestamp: timestamp,
               ledger_operations:
                 operations = %LedgerOperations{
@@ -65,6 +66,8 @@ defmodule Archethic.TransactionChain.TransactionSummary do
       when is_binary(genesis_address) do
     raw_stamp = validation_stamp |> ValidationStamp.serialize() |> Utils.wrap_binary()
     validation_stamp_checksum = :crypto.hash(:sha256, raw_stamp)
+
+    version = if protocol_version <= 7 and version > 2, do: 2, else: version
 
     movements_addresses =
       if version >= 2 do

--- a/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
@@ -64,7 +64,7 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
   defp resolve_recipient_addresses(
          tx = %Transaction{data: %TransactionData{recipients: recipients}}
        ) do
-    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx)
+    resolved_addresses = TransactionChain.resolve_transaction_addresses!(tx)
 
     Enum.reduce(recipients, [], fn r = %Recipient{address: address}, acc ->
       resolved = Map.get(resolved_addresses, address)

--- a/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
+++ b/lib/archethic_web/api/jsonrpc/methods/estimate_transaction_fee.ex
@@ -49,7 +49,7 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
     uco_eur = previous_price |> Keyword.fetch!(:eur)
     uco_usd = previous_price |> Keyword.fetch!(:usd)
 
-    resolved_recipients = resolve_recipient_addresses(tx, timestamp)
+    resolved_recipients = resolve_recipient_addresses(tx)
 
     {_valid?, recipients_fee} =
       SmartContractValidation.validate_contract_calls(resolved_recipients, tx, timestamp)
@@ -62,10 +62,9 @@ defmodule ArchethicWeb.API.JsonRPC.Method.EstimateTransactionFee do
   end
 
   defp resolve_recipient_addresses(
-         tx = %Transaction{data: %TransactionData{recipients: recipients}},
-         timestamp
+         tx = %Transaction{data: %TransactionData{recipients: recipients}}
        ) do
-    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx, timestamp)
+    resolved_addresses = TransactionChain.resolve_transaction_addresses(tx)
 
     Enum.reduce(recipients, [], fn r = %Recipient{address: address}, acc ->
       resolved = Map.get(resolved_addresses, address)

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -136,9 +136,10 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
 
       transfers = uco_transfers ++ token_transfers ++ transfers_from_content
 
+      transfers_to_resolve = if protocol_version <= 7, do: transfers ++ movements, else: transfers
+
       linked_movements =
-        transfers
-        |> Enum.concat(movements)
+        transfers_to_resolve
         |> Enum.map(& &1.to)
         |> Enum.uniq()
         |> resolve_genesis_addresses()
@@ -182,7 +183,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
          transfers,
          protocol_version
        ) do
-    movement_genesis = Map.get(resolved_genesis, movement_recipient)
+    movement_genesis = Map.get(resolved_genesis, movement_recipient, movement_recipient)
 
     filtered_transfers =
       Enum.filter(transfers, fn
@@ -207,7 +208,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
          transfers,
          _protocol_version
        ) do
-    movement_genesis = Map.get(resolved_genesis, movement_recipient)
+    movement_genesis = Map.get(resolved_genesis, movement_recipient, movement_recipient)
 
     filtered_transfers =
       Enum.filter(transfers, fn

--- a/test/archethic/replication/transaction_validator_test.exs
+++ b/test/archethic/replication/transaction_validator_test.exs
@@ -36,8 +36,8 @@ defmodule Archethic.Replication.TransactionValidatorTest do
     |> NetworkLookup.set_daily_nonce_public_key(DateTime.utc_now() |> DateTime.add(-10))
 
     welcome_node = %Node{
-      first_public_key: "key1",
-      last_public_key: "key1",
+      first_public_key: random_public_key(),
+      last_public_key: random_public_key(),
       authorized?: true,
       authorization_date: DateTime.utc_now() |> DateTime.add(-1),
       available?: true,
@@ -59,8 +59,8 @@ defmodule Archethic.Replication.TransactionValidatorTest do
       %Node{
         ip: {127, 0, 0, 1},
         port: 3000,
-        first_public_key: "key3",
-        last_public_key: "key3",
+        first_public_key: random_public_key(),
+        last_public_key: random_public_key(),
         authorized?: true,
         available?: true,
         geo_patch: "BBB",

--- a/test/archethic/replication/transaction_validator_test.exs
+++ b/test/archethic/replication/transaction_validator_test.exs
@@ -10,6 +10,8 @@ defmodule Archethic.Replication.TransactionValidatorTest do
   alias Archethic.P2P.Message.LastTransactionAddress
   alias Archethic.P2P.Message.SmartContractCallValidation
   alias Archethic.P2P.Message.ValidateSmartContractCall
+  alias Archethic.P2P.Message.GetGenesisAddress
+  alias Archethic.P2P.Message.GenesisAddress
   alias Archethic.P2P.Node
   alias Archethic.Replication.TransactionValidator
   alias Archethic.SharedSecrets
@@ -36,6 +38,8 @@ defmodule Archethic.Replication.TransactionValidatorTest do
     welcome_node = %Node{
       first_public_key: "key1",
       last_public_key: "key1",
+      authorized?: true,
+      authorization_date: DateTime.utc_now() |> DateTime.add(-1),
       available?: true,
       geo_patch: "BBB",
       network_patch: "BBB"
@@ -57,6 +61,7 @@ defmodule Archethic.Replication.TransactionValidatorTest do
         port: 3000,
         first_public_key: "key3",
         last_public_key: "key3",
+        authorized?: true,
         available?: true,
         geo_patch: "BBB",
         network_patch: "BBB",
@@ -247,7 +252,9 @@ defmodule Archethic.Replication.TransactionValidatorTest do
         }
       ]
 
-      recipient = %Recipient{address: random_address()}
+      recipient_address = random_address()
+      recipient_genesis = random_address()
+      recipient = %Recipient{address: recipient_address}
       tx = TransactionFactory.create_valid_transaction(unspent_outputs, recipients: [recipient])
 
       MockClient
@@ -256,6 +263,9 @@ defmodule Archethic.Replication.TransactionValidatorTest do
       end)
       |> expect(:send_message, fn _, %ValidateSmartContractCall{}, _ ->
         {:ok, %SmartContractCallValidation{valid?: false, fee: 0}}
+      end)
+      |> expect(:send_message, fn _, %GetGenesisAddress{address: ^recipient_address}, _ ->
+        {:ok, %GenesisAddress{address: recipient_genesis, timestamp: DateTime.utc_now()}}
       end)
 
       assert {:error, :invalid_recipients_execution} =

--- a/test/archethic/transaction_chain_test.exs
+++ b/test/archethic/transaction_chain_test.exs
@@ -46,7 +46,7 @@ defmodule Archethic.TransactionChainTest do
   import Mox
   import ArchethicCase
 
-  describe "resolve_transaction_addresses/1" do
+  describe "resolve_transaction_addresses!/1" do
     test "should resolve the genesis if local node knows it" do
       address2 = random_address()
       genesis2 = random_address()
@@ -64,7 +64,7 @@ defmodule Archethic.TransactionChainTest do
           }
         )
 
-      assert %{^address2 => ^genesis2} = TransactionChain.resolve_transaction_addresses(tx)
+      assert %{^address2 => ^genesis2} = TransactionChain.resolve_transaction_addresses!(tx)
     end
 
     test "should resolve the genesis if local node does not know it" do
@@ -99,7 +99,7 @@ defmodule Archethic.TransactionChainTest do
           }
         )
 
-      assert %{^address2 => ^genesis2} = TransactionChain.resolve_transaction_addresses(tx)
+      assert %{^address2 => ^genesis2} = TransactionChain.resolve_transaction_addresses!(tx)
     end
 
     test "should resolve the recipients" do
@@ -113,7 +113,7 @@ defmodule Archethic.TransactionChainTest do
           recipients: [%Recipient{address: address2}]
         )
 
-      assert %{^address2 => ^genesis2} = TransactionChain.resolve_transaction_addresses(tx)
+      assert %{^address2 => ^genesis2} = TransactionChain.resolve_transaction_addresses!(tx)
     end
 
     test "should resolve the token creation recipients" do
@@ -145,7 +145,7 @@ defmodule Archethic.TransactionChainTest do
           """
         )
 
-      assert %{^address2 => ^genesis2} = TransactionChain.resolve_transaction_addresses(tx)
+      assert %{^address2 => ^genesis2} = TransactionChain.resolve_transaction_addresses!(tx)
     end
 
     test "should raise if there is a network issue" do
@@ -174,7 +174,7 @@ defmodule Archethic.TransactionChainTest do
         )
 
       assert_raise RuntimeError, "Could not resolve movement address", fn ->
-        TransactionChain.resolve_transaction_addresses(tx)
+        TransactionChain.resolve_transaction_addresses!(tx)
       end
     end
   end

--- a/test/archethic/utxo_test.exs
+++ b/test/archethic/utxo_test.exs
@@ -54,7 +54,6 @@ defmodule Archethic.UTXOTest do
 
   describe "load_transaction/2" do
     test "should load outputs as io storage nodes but not for chain" do
-      destination_address = random_address()
       destination_previous_address = random_address()
       destination_genesis_address = random_address()
 
@@ -70,7 +69,11 @@ defmodule Archethic.UTXOTest do
           protocol_version: current_protocol_version(),
           ledger_operations: %LedgerOperations{
             transaction_movements: [
-              %TransactionMovement{to: destination_address, amount: 100_000_000, type: :UCO}
+              %TransactionMovement{
+                to: destination_genesis_address,
+                amount: 100_000_000,
+                type: :UCO
+              }
             ],
             unspent_outputs: [
               %UnspentOutput{
@@ -88,9 +91,6 @@ defmodule Archethic.UTXOTest do
         },
         previous_public_key: random_public_key()
       }
-
-      MockDB
-      |> expect(:get_genesis_address, fn ^destination_address -> destination_genesis_address end)
 
       me = self()
 
@@ -136,7 +136,6 @@ defmodule Archethic.UTXOTest do
     end
 
     test "should load outputs as chain storage node" do
-      destination_address = random_address()
       destination_previous_address = random_address()
       destination_genesis_address = random_address()
 
@@ -152,7 +151,11 @@ defmodule Archethic.UTXOTest do
           timestamp: ~U[2023-09-10 05:00:00.000Z],
           ledger_operations: %LedgerOperations{
             transaction_movements: [
-              %TransactionMovement{to: destination_address, amount: 100_000_000, type: :UCO}
+              %TransactionMovement{
+                to: destination_genesis_address,
+                amount: 100_000_000,
+                type: :UCO
+              }
             ],
             unspent_outputs: [
               %UnspentOutput{
@@ -180,9 +183,6 @@ defmodule Archethic.UTXOTest do
         },
         previous_public_key: random_public_key()
       }
-
-      MockDB
-      |> expect(:get_genesis_address, fn ^destination_address -> destination_genesis_address end)
 
       me = self()
 
@@ -247,7 +247,7 @@ defmodule Archethic.UTXOTest do
           ledger_operations: %LedgerOperations{
             transaction_movements: [
               %TransactionMovement{
-                to: transaction_previous_address,
+                to: transaction_genesis_address,
                 amount: 100_000_000,
                 type: :UCO
               }
@@ -287,7 +287,11 @@ defmodule Archethic.UTXOTest do
           timestamp: ~U[2023-09-12 05:00:00.000Z],
           ledger_operations: %LedgerOperations{
             transaction_movements: [
-              %TransactionMovement{to: destination_address, amount: 50_000_000, type: :UCO}
+              %TransactionMovement{
+                to: destination_genesis_address,
+                amount: 50_000_000,
+                type: :UCO
+              }
             ],
             unspent_outputs: [
               %UnspentOutput{
@@ -310,12 +314,6 @@ defmodule Archethic.UTXOTest do
         },
         previous_public_key: random_public_key()
       }
-
-      MockDB
-      |> expect(:get_genesis_address, 2, fn
-        ^destination_address -> destination_genesis_address
-        ^transaction_previous_address -> transaction_genesis_address
-      end)
 
       me = self()
 
@@ -368,7 +366,6 @@ defmodule Archethic.UTXOTest do
     end
 
     test "should load contract call unspent output" do
-      destination_address = random_address()
       destination_genesis_address = random_address()
 
       transaction_address = random_address()
@@ -380,13 +377,10 @@ defmodule Archethic.UTXOTest do
         validation_stamp: %ValidationStamp{
           timestamp: ~U[2023-09-10 05:00:00.000Z],
           protocol_version: current_protocol_version(),
-          recipients: [destination_address]
+          recipients: [destination_genesis_address]
         },
         previous_public_key: random_public_key()
       }
-
-      MockDB
-      |> expect(:get_genesis_address, fn ^destination_address -> destination_genesis_address end)
 
       me = self()
 
@@ -423,13 +417,8 @@ defmodule Archethic.UTXOTest do
       transaction_address = random_address()
       transaction_genesis = random_address()
 
-      destination1_address = random_address()
       destination1_genesis = random_address()
-
-      destination2_address = random_address()
       destination2_genesis = random_address()
-
-      destination3_address = random_address()
       destination3_genesis = random_address()
 
       token_address = random_address()
@@ -447,9 +436,9 @@ defmodule Archethic.UTXOTest do
           timestamp: ~U[2023-09-12 05:00:00.000Z],
           ledger_operations: %LedgerOperations{
             transaction_movements: [
-              %TransactionMovement{to: destination1_address, amount: 500_000, type: token_type},
-              %TransactionMovement{to: destination2_address, amount: 300_000, type: token_type},
-              %TransactionMovement{to: destination3_address, amount: 200_000, type: token_type}
+              %TransactionMovement{to: destination1_genesis, amount: 500_000, type: token_type},
+              %TransactionMovement{to: destination2_genesis, amount: 300_000, type: token_type},
+              %TransactionMovement{to: destination3_genesis, amount: 200_000, type: token_type}
             ],
             unspent_outputs: [],
             consumed_inputs: [
@@ -522,11 +511,6 @@ defmodule Archethic.UTXOTest do
       chain3_keep_tx2 = TransactionFactory.create_valid_transaction([uco_utxo, chain3_utxo])
 
       MockDB
-      |> expect(:get_genesis_address, 3, fn
-        ^destination1_address -> destination1_genesis
-        ^destination2_address -> destination2_genesis
-        ^destination3_address -> destination3_genesis
-      end)
       |> expect(:get_last_chain_address, 3, fn
         # Destination 1 does not have transaction after utxo timestamp so it will be stored
         ^destination1_genesis -> {random_address(), ~U[2023-09-11 05:00:00.000Z]}


### PR DESCRIPTION
# Description

Resolve the genesis instead of the last address
Resolve might raise on network_issue instead of providing a potentially erronous default

Fixes #1405

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
