### PR TITLE
Forbid user do send fraction of non fungible token

### DIFF
--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -82,13 +82,14 @@ defmodule Archethic.Mining.PendingTransactionValidation do
       ) do
     start = System.monotonic_time()
 
-    with :ok <- validate_size(tx),
-         :ok <- valid_not_exists(tx),
+    with :ok <- do_accept_transaction(tx, validation_time),
          :ok <- valid_previous_signature(tx),
+         :ok <- validate_size(tx),
          :ok <- validate_contract(tx),
          :ok <- validate_ownerships(tx),
-         :ok <- do_accept_transaction(tx, validation_time),
-         :ok <- validate_previous_transaction_type(tx) do
+         :ok <- validate_non_fungible_token_transfer(tx),
+         :ok <- validate_previous_transaction_type(tx),
+         :ok <- valid_not_exists(tx) do
       :telemetry.execute(
         [:archethic, :mining, :pending_transaction_validation],
         %{duration: System.monotonic_time() - start},
@@ -183,6 +184,15 @@ defmodule Archethic.Mining.PendingTransactionValidation do
           {:halt, {:error, formated_reason}}
       end
     end)
+  end
+
+  defp validate_non_fungible_token_transfer(%Transaction{
+         data: %TransactionData{ledger: %Ledger{token: %TokenLedger{transfers: token_transfer}}}
+       }) do
+    # non fungible token can be sent only by unit
+    if Enum.any?(token_transfer, &(&1.token_id != 0 and &1.amount != @unit_uco)),
+      do: {:error, "Non fungible token can only be sent by unit"},
+      else: :ok
   end
 
   defp do_accept_transaction(

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -380,7 +380,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
           acc
 
         recv_amount when recv_amount - amount_to_spend > 0 ->
-          remaining_amount = recv_amount - trunc_token_amount(token_id, amount_to_spend)
+          remaining_amount = recv_amount - amount_to_spend
           type = {:token, token_address, token_id}
 
           # Do not create new UTXO if one is already the same in the inputs
@@ -403,10 +403,6 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       end
     end)
   end
-
-  # We prevent part of non-fungible token to be spent
-  defp trunc_token_amount(0, amount), do: amount
-  defp trunc_token_amount(_token_id, amount), do: trunc(amount / @unit_uco) * @unit_uco
 
   defp get_inputs_to_consume(
          inputs,

--- a/lib/archethic_web/explorer/components/amount.ex
+++ b/lib/archethic_web/explorer/components/amount.ex
@@ -63,29 +63,27 @@ defmodule ArchethicWeb.Explorer.Components.Amount do
     """
   end
 
-  defp get_token_name(_, _, token_id) when token_id > 0, do: "NFT ##{token_id}"
-
-  defp get_token_name(token_properties, token_address, _token_id) do
+  defp get_token_name(token_properties, token_address, token_id) do
     case Map.get(token_properties, :symbol) do
       nil ->
         short_address(token_address)
 
       symbol ->
-        if String.length(symbol) > @max_symbol_len do
-          content_tag(
-            "span",
-            String.slice(symbol, 0..(@max_symbol_len - 1)) <> "...",
-            "data-tooltip": symbol <> " minted at " <> Base.encode16(token_address),
-            class: "mono"
-          )
-        else
-          content_tag(
-            "span",
-            symbol,
-            "data-tooltip": symbol <> " minted at " <> Base.encode16(token_address),
-            class: "mono"
-          )
-        end
+        text =
+          if String.length(symbol) > @max_symbol_len do
+            String.slice(symbol, 0..(@max_symbol_len - 1)) <> "..."
+          else
+            symbol
+          end
+
+        text = text <> if token_id > 0, do: " ##{token_id}", else: ""
+
+        content_tag(
+          "span",
+          text,
+          "data-tooltip": symbol <> " minted at " <> Base.encode16(token_address),
+          class: "mono"
+        )
     end
   end
 

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -68,6 +68,84 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
     :ok
   end
 
+  describe "validate_non_fungible_token_transfer" do
+    test "should return error if nft token is not sent by unit" do
+      ledger = %Ledger{
+        token: %TokenLedger{
+          transfers: [
+            %TokenTransfer{
+              to: random_address(),
+              amount: 123,
+              token_address: random_address(),
+              token_id: 1
+            }
+          ]
+        }
+      }
+
+      tx = TransactionFactory.create_non_valided_transaction(type: :transfer, ledger: ledger)
+
+      assert {:error, "Non fungible token can only be sent by unit"} =
+               PendingTransactionValidation.validate(tx)
+
+      ledger = %Ledger{
+        token: %TokenLedger{
+          transfers: [
+            %TokenTransfer{
+              to: random_address(),
+              amount: 200_000_000,
+              token_address: random_address(),
+              token_id: 1
+            }
+          ]
+        }
+      }
+
+      tx = TransactionFactory.create_non_valided_transaction(type: :transfer, ledger: ledger)
+
+      assert {:error, "Non fungible token can only be sent by unit"} =
+               PendingTransactionValidation.validate(tx)
+    end
+
+    test "should return ok if nft token is sent in unit" do
+      ledger = %Ledger{
+        token: %TokenLedger{
+          transfers: [
+            %TokenTransfer{
+              to: random_address(),
+              amount: 100_000_000,
+              token_address: random_address(),
+              token_id: 1
+            }
+          ]
+        }
+      }
+
+      tx = TransactionFactory.create_non_valided_transaction(type: :transfer, ledger: ledger)
+
+      assert :ok = PendingTransactionValidation.validate(tx)
+    end
+
+    test "should return ok if fungible token is sent in fraction" do
+      ledger = %Ledger{
+        token: %TokenLedger{
+          transfers: [
+            %TokenTransfer{
+              to: random_address(),
+              amount: 123,
+              token_address: random_address(),
+              token_id: 0
+            }
+          ]
+        }
+      }
+
+      tx = TransactionFactory.create_non_valided_transaction(type: :transfer, ledger: ledger)
+
+      assert :ok = PendingTransactionValidation.validate(tx)
+    end
+  end
+
   describe "validate_size/1" do
     test "should return :ok when the transaction size is less than 3.1MB" do
       tx =
@@ -504,33 +582,14 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
     end
 
     test "should return an error when a node transaction content is greater than content_max_size " do
-      {public_key, _} = Crypto.derive_keypair("seed", 0)
-      certificate = Crypto.get_key_certificate(public_key)
-
-      content_pretext =
-        <<80, 20, 10, 200, 3000::16, 4000::16, 1, 0, 4, 221, 19, 74, 75, 69, 16, 50, 149, 253, 24,
-          115, 128, 241, 110, 118, 139, 7, 48, 217, 58, 43, 145, 233, 77, 125, 190, 207, 31, 64,
-          157, 137>>
-
-      random_content = :crypto.strong_rand_bytes(4 * 1024 * 1024)
-
-      content =
-        content_pretext <> random_content <> <<byte_size(certificate)::16, certificate::binary>>
+      content = :crypto.strong_rand_bytes(4 * 1024 * 1024)
 
       tx =
         TransactionFactory.create_non_valided_transaction(
-          type: :node,
+          type: :data,
           content: content,
           seed: "seed"
         )
-
-      MockDB
-      |> stub(:get_last_chain_address, fn address ->
-        address
-      end)
-      |> stub(:get_transaction, fn _address, [:address, :type], _ ->
-        {:error, :transaction_not_exists}
-      end)
 
       assert {:error, "Transaction data exceeds limit"} =
                PendingTransactionValidation.validate(tx)


### PR DESCRIPTION
# Description

Currently there is the possibility for a use to send fraction of a NFT token which should not be possible.
This PR adds a new control in the pending transaction validation to allow user to send NFT token only by unit (1e8).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a NFT token and try to send it by fraction. It is refused (same case using token mint recipient as well).

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
