### PR TITLE
Prevent infinite loop on corrupted file

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -387,6 +387,12 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
 
   defp read_transaction(fd, fields, limit, position, acc \\ %{})
 
+  # this prevent an infinite loop in case of corrupted file
+  defp read_transaction(fd, _fields, 0, _position, _acc) do
+    {:ok, filename} = :file.pid2name(fd)
+    raise %RuntimeError{message: "Corrupted file: #{filename}"}
+  end
+
   defp read_transaction(_fd, _fields, limit, position, acc) when limit == position, do: acc
 
   defp read_transaction(fd, fields, limit, position, acc) do


### PR DESCRIPTION
# Description

When a file is corrupted (plenty of 0 written at the end, probably due to prealloc), to avoid an infinite recursion.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
