### PR TITLE
Genesis do not load spent utxo

### DIFF
--- a/lib/archethic/p2p/message/replicate_transaction.ex
+++ b/lib/archethic/p2p/message/replicate_transaction.ex
@@ -47,7 +47,7 @@ defmodule Archethic.P2P.Message.ReplicateTransaction do
           Replication.validate_and_store_transaction_chain(tx, contract_context, genesis_address)
 
         Election.chain_storage_node?(genesis_address, node_public_key, authorized_nodes) ->
-          Replication.validate_and_store_transaction(tx, genesis_address)
+          Replication.validate_and_store_transaction_chain(tx, contract_context, genesis_address)
 
         io_node?(tx, node_public_key, authorized_nodes) ->
           Replication.validate_and_store_transaction(tx, genesis_address)

--- a/lib/archethic/p2p/message/shard_repair.ex
+++ b/lib/archethic/p2p/message/shard_repair.ex
@@ -6,9 +6,7 @@ defmodule Archethic.P2P.Message.ShardRepair do
   defstruct [:first_address, :storage_address, :io_addresses]
 
   alias Archethic.Crypto
-  alias Archethic.Election
   alias Archethic.SelfRepair
-  alias Archethic.P2P
 
   alias Archethic.Utils
   alias Archethic.Utils.VarInt
@@ -30,20 +28,7 @@ defmodule Archethic.P2P.Message.ShardRepair do
         },
         _
       ) do
-    # Ensure all addresses are expected to be replicated
-    nodes = P2P.authorized_and_available_nodes()
-
-    addresses =
-      if storage_address != nil, do: [storage_address | io_addresses], else: io_addresses
-
-    public_key = Crypto.first_node_public_key()
-
-    if Enum.all?(
-         addresses,
-         &(Election.storage_nodes(&1, nodes) |> Utils.key_in_node_list?(public_key))
-       ) do
-      SelfRepair.resync(first_address, storage_address, io_addresses)
-    end
+    SelfRepair.resync(first_address, storage_address, io_addresses)
 
     %Ok{}
   end

--- a/test/archethic/self_repair/sync/transaction_handler_test.exs
+++ b/test/archethic/self_repair/sync/transaction_handler_test.exs
@@ -116,12 +116,9 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
 
     test "should return true when the node only a chain genesis storage node" do
       with_mock(Election, [:passthrough],
-        chain_storage_nodes: fn
-          "@Alice1", _ ->
-            [%Node{first_public_key: ArchethicCase.random_public_key()}]
-
-          "@Alice0", _ ->
-            [%Node{first_public_key: Crypto.first_node_public_key()}]
+        chain_storage_node?: fn
+          "@Alice1", _, _ -> false
+          "@Alice0", _, _ -> true
         end
       ) do
         attestation = %ReplicationAttestation{

--- a/test/archethic/self_repair/sync_test.exs
+++ b/test/archethic/self_repair/sync_test.exs
@@ -564,9 +564,10 @@ defmodule Archethic.SelfRepair.SyncTest do
         assert :ok = Sync.process_summary_aggregate(summary, current_nodes_view)
 
         assert_called(
-          Election.chain_storage_nodes_with_type(
+          Election.chain_storage_node?(
             transfer_tx.address,
             transfer_tx.type,
+            Crypto.first_node_public_key(),
             current_nodes_view_with_self
           )
         )

--- a/test/archethic/utxo_test.exs
+++ b/test/archethic/utxo_test.exs
@@ -7,6 +7,8 @@ defmodule Archethic.UTXOTest do
 
   alias Archethic.Election
 
+  alias Archethic.Reward.MemTables.RewardTokens
+
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.UnspentOutput
   alias Archethic.TransactionChain.VersionedUnspentOutput
@@ -18,9 +20,19 @@ defmodule Archethic.UTXOTest do
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
+  alias Archethic.TransactionChain.TransactionData.Ledger
+  alias Archethic.TransactionChain.TransactionData.TokenLedger
+  alias Archethic.TransactionChain.TransactionData.TokenLedger.Transfer, as: TokenTransfer
+
+  alias Archethic.TransactionFactory
 
   import Mox
   import Mock
+
+  setup do
+    start_supervised!(RewardTokens)
+    :ok
+  end
 
   describe "load_transaction/2" do
     test "should load outputs as io storage nodes but not for chain" do
@@ -367,6 +379,320 @@ defmodule Archethic.UTXOTest do
                         }}
       end
     end
+
+    test "should not load utxos from past if they are already consumed, protocol_version >= 7" do
+      transaction_address = random_address()
+      transaction_genesis = random_address()
+
+      destination1_address = random_address()
+      destination1_genesis = random_address()
+
+      destination2_address = random_address()
+      destination2_genesis = random_address()
+
+      destination3_address = random_address()
+      destination3_genesis = random_address()
+
+      token_address = random_address()
+      token_type = {:token, token_address, 0}
+
+      # Transaction to replicate, node is genesis node of all movements
+      # destination1 chain has no transaction after this new one
+      # destination2 has a chain after this new one and a transaction consume this input
+      # destination3 has a chain after this new one and no transaction consume this input
+      tx = %Transaction{
+        address: transaction_address,
+        type: :transfer,
+        validation_stamp: %ValidationStamp{
+          protocol_version: current_protocol_version(),
+          timestamp: ~U[2023-09-12 05:00:00.000Z],
+          ledger_operations: %LedgerOperations{
+            transaction_movements: [
+              %TransactionMovement{to: destination1_address, amount: 500_000, type: token_type},
+              %TransactionMovement{to: destination2_address, amount: 300_000, type: token_type},
+              %TransactionMovement{to: destination3_address, amount: 200_000, type: token_type}
+            ],
+            unspent_outputs: [],
+            consumed_inputs: [
+              %UnspentOutput{
+                from: random_address(),
+                amount: 1_000_000,
+                type: token_type,
+                timestamp: ~U[2023-09-10 05:00:00.000Z]
+              }
+            ]
+          }
+        },
+        previous_public_key: random_public_key()
+      }
+
+      chain2_keep_address = random_address()
+      chain2_consume_address = random_address()
+
+      chain3_keep_address1 = random_address()
+      chain3_keep_address2 = random_address()
+
+      # Used for fees
+      uco_utxo = %UnspentOutput{
+        from: random_address(),
+        amount: 100_000_000,
+        type: :UCO,
+        timestamp: ~U[2023-09-12 05:00:00.000Z]
+      }
+
+      chain1_utxo = %UnspentOutput{
+        from: transaction_address,
+        amount: 500_000,
+        type: token_type,
+        timestamp: ~U[2023-09-12 05:00:00.000Z]
+      }
+
+      chain2_utxo = %UnspentOutput{
+        from: transaction_address,
+        amount: 300_000,
+        type: token_type,
+        timestamp: ~U[2023-09-12 05:00:00.000Z]
+      }
+
+      chain3_utxo = %UnspentOutput{
+        from: transaction_address,
+        amount: 200_000,
+        type: token_type,
+        timestamp: ~U[2023-09-12 05:00:00.000Z]
+      }
+
+      chain2_keep_tx = TransactionFactory.create_valid_transaction([uco_utxo, chain2_utxo])
+
+      chain2_consume_tx =
+        TransactionFactory.create_valid_transaction([uco_utxo, chain2_utxo],
+          ledger: %Ledger{
+            token: %TokenLedger{
+              transfers: [
+                %TokenTransfer{
+                  to: random_address(),
+                  amount: 200_000,
+                  token_address: token_address,
+                  token_id: 0
+                }
+              ]
+            }
+          }
+        )
+
+      chain3_keep_tx1 = TransactionFactory.create_valid_transaction([uco_utxo, chain3_utxo])
+      chain3_keep_tx2 = TransactionFactory.create_valid_transaction([uco_utxo, chain3_utxo])
+
+      MockDB
+      |> expect(:get_genesis_address, 3, fn
+        ^destination1_address -> destination1_genesis
+        ^destination2_address -> destination2_genesis
+        ^destination3_address -> destination3_genesis
+      end)
+      |> expect(:get_last_chain_address, 3, fn
+        # Destination 1 does not have transaction after utxo timestamp so it will be stored
+        ^destination1_genesis -> {random_address(), ~U[2023-09-11 05:00:00.000Z]}
+        _ -> {random_address(), DateTime.utc_now()}
+      end)
+      |> expect(:list_chain_addresses, 2, fn
+        # Destination 2 consume utxo in last transaction so it will not be stored
+        ^destination2_genesis ->
+          [
+            {random_address(), ~U[2023-09-01 05:00:00.000Z]},
+            {chain2_keep_address, ~U[2023-09-13 05:00:00.000Z]},
+            {chain2_consume_address, ~U[2023-09-13 06:00:00.000Z]}
+          ]
+
+        # Destination 3 does not consume utxo so it will be stored
+        ^destination3_genesis ->
+          [
+            {random_address(), ~U[2023-09-01 05:00:00.000Z]},
+            {chain3_keep_address1, ~U[2023-09-13 05:00:00.000Z]},
+            {chain3_keep_address2, ~U[2023-09-13 06:00:00.000Z]}
+          ]
+      end)
+      |> expect(:get_transaction, 4, fn
+        ^chain2_keep_address, _, _ -> {:ok, chain2_keep_tx}
+        ^chain2_consume_address, _, _ -> {:ok, chain2_consume_tx}
+        ^chain3_keep_address1, _, _ -> {:ok, chain3_keep_tx1}
+        ^chain3_keep_address2, _, _ -> {:ok, chain3_keep_tx2}
+      end)
+
+      MockUTXOLedger |> stub(:append, fn _, _ -> :ok end)
+
+      with_mock(Election, [:passthrough],
+        chain_storage_node?: fn
+          ^transaction_genesis, _, _ -> false
+          _, _, _ -> true
+        end
+      ) do
+        UTXO.load_transaction(tx, transaction_genesis)
+
+        assert [%VersionedUnspentOutput{unspent_output: ^chain1_utxo}] =
+                 destination1_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+
+        assert [] =
+                 destination2_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+
+        assert [%VersionedUnspentOutput{unspent_output: ^chain3_utxo}] =
+                 destination3_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+      end
+    end
+
+    test "should not load utxos from past if they are already consumed, protocol_version < 7" do
+      # Same test as before with transaction created using protocol_version 6
+
+      transaction_address = random_address()
+      transaction_genesis = random_address()
+
+      destination1_address = random_address()
+      destination1_genesis = random_address()
+
+      destination2_address = random_address()
+      destination2_genesis = random_address()
+
+      destination3_address = random_address()
+      destination3_genesis = random_address()
+
+      token_address = random_address()
+      token_type = {:token, token_address, 0}
+
+      tx = %Transaction{
+        address: transaction_address,
+        type: :transfer,
+        validation_stamp: %ValidationStamp{
+          protocol_version: 6,
+          timestamp: ~U[2023-09-12 05:00:00.000Z],
+          ledger_operations: %LedgerOperations{
+            transaction_movements: [
+              %TransactionMovement{to: destination1_address, amount: 500_000, type: token_type},
+              %TransactionMovement{to: destination2_address, amount: 300_000, type: token_type},
+              %TransactionMovement{to: destination3_address, amount: 200_000, type: token_type}
+            ],
+            unspent_outputs: []
+          }
+        },
+        previous_public_key: random_public_key()
+      }
+
+      chain2_keep_address = random_address()
+      chain2_consume_address = random_address()
+
+      chain3_keep_address1 = random_address()
+      chain3_keep_address2 = random_address()
+
+      chain1_utxo = %UnspentOutput{
+        from: transaction_address,
+        amount: 500_000,
+        type: token_type,
+        timestamp: ~U[2023-09-12 05:00:00.000Z]
+      }
+
+      chain2_utxo = %UnspentOutput{
+        from: transaction_address,
+        amount: 300_000,
+        type: token_type,
+        timestamp: ~U[2023-09-12 05:00:00.000Z]
+      }
+
+      chain3_utxo = %UnspentOutput{
+        from: transaction_address,
+        amount: 200_000,
+        type: token_type,
+        timestamp: ~U[2023-09-12 05:00:00.000Z]
+      }
+
+      uco_utxo = %UnspentOutput{
+        from: random_address(),
+        amount: 100_000_000,
+        type: :UCO,
+        timestamp: ~U[2023-09-12 05:00:00.000Z]
+      }
+
+      # type oracle used to have free fee and so no consumption of inputs
+      chain2_keep_tx =
+        TransactionFactory.create_valid_transaction([uco_utxo, chain2_utxo])
+        |> set_ledger_operations_and_version([chain2_utxo])
+
+      chain2_consume_tx =
+        TransactionFactory.create_valid_transaction([uco_utxo, chain2_utxo],
+          ledger: %Ledger{
+            token: %TokenLedger{
+              transfers: [
+                %TokenTransfer{
+                  to: random_address(),
+                  amount: 300_000,
+                  token_address: token_address,
+                  token_id: 0
+                }
+              ]
+            }
+          }
+        )
+        |> set_ledger_operations_and_version([])
+
+      chain3_keep_tx1 =
+        TransactionFactory.create_valid_transaction([uco_utxo, chain3_utxo])
+        |> set_ledger_operations_and_version([chain3_utxo])
+
+      chain3_keep_tx2 =
+        TransactionFactory.create_valid_transaction([uco_utxo, chain3_utxo])
+        |> set_ledger_operations_and_version([chain3_utxo])
+
+      MockDB
+      |> expect(:get_genesis_address, 3, fn
+        ^destination1_address -> destination1_genesis
+        ^destination2_address -> destination2_genesis
+        ^destination3_address -> destination3_genesis
+      end)
+      |> expect(:get_last_chain_address, 3, fn
+        # Destination 1 does not have transaction after utxo timestamp so it will be ingested
+        ^destination1_genesis -> {random_address(), ~U[2023-09-11 05:00:00.000Z]}
+        _ -> {random_address(), DateTime.utc_now()}
+      end)
+      |> expect(:list_chain_addresses, 2, fn
+        # Destination 2 consume utxo in last transaction so it will not be ingested
+        ^destination2_genesis ->
+          [
+            {random_address(), ~U[2023-09-01 05:00:00.000Z]},
+            {chain2_keep_address, ~U[2023-09-13 05:00:00.000Z]},
+            {chain2_consume_address, ~U[2023-09-13 06:00:00.000Z]}
+          ]
+
+        # Destination 3 does not consume utxo so it will be ingested
+        ^destination3_genesis ->
+          [
+            {random_address(), ~U[2023-09-01 05:00:00.000Z]},
+            {chain3_keep_address1, ~U[2023-09-13 05:00:00.000Z]},
+            {chain3_keep_address2, ~U[2023-09-13 06:00:00.000Z]}
+          ]
+      end)
+      |> expect(:get_transaction, 4, fn
+        ^chain2_keep_address, _, _ -> {:ok, chain2_keep_tx}
+        ^chain2_consume_address, _, _ -> {:ok, chain2_consume_tx}
+        ^chain3_keep_address1, _, _ -> {:ok, chain3_keep_tx1}
+        ^chain3_keep_address2, _, _ -> {:ok, chain3_keep_tx2}
+      end)
+
+      MockUTXOLedger |> stub(:append, fn _, _ -> :ok end)
+
+      with_mock(Election, [:passthrough],
+        chain_storage_node?: fn
+          ^transaction_genesis, _, _ -> false
+          _, _, _ -> true
+        end
+      ) do
+        UTXO.load_transaction(tx, transaction_genesis)
+
+        assert [%VersionedUnspentOutput{unspent_output: ^chain1_utxo}] =
+                 destination1_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+
+        assert [] =
+                 destination2_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+
+        assert [%VersionedUnspentOutput{unspent_output: ^chain3_utxo}] =
+                 destination3_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+      end
+    end
   end
 
   describe("stream_unspent_outputs/1") do
@@ -410,5 +736,20 @@ defmodule Archethic.UTXOTest do
                |> UTXO.stream_unspent_outputs()
                |> Enum.to_list()
     end
+  end
+
+  defp set_ledger_operations_and_version(tx, unspent_outputs) do
+    update_in(
+      tx,
+      [Access.key!(:validation_stamp), Access.key!(:ledger_operations)],
+      fn ledger_operations ->
+        %LedgerOperations{
+          ledger_operations
+          | consumed_inputs: [],
+            unspent_outputs: unspent_outputs
+        }
+      end
+    )
+    |> put_in([Access.key!(:validation_stamp), Access.key!(:protocol_version)], 6)
   end
 end


### PR DESCRIPTION
# Description

This PR adds a new behavior for a genesis node of a chain.
- Now a genesis node will store the transaction as a chain and not as IO transaction. This will help to ensure having consolidated utxo view.
- When a genesis node adds an input for a chain, it will ensure this input has not been already consumed in a future transaction. This can happen during self repair or notifier.

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
