### PR TITLE
Set a minimum concurrency so it is never 0

### DIFF
--- a/lib/archethic/self_repair/notifier.ex
+++ b/lib/archethic/self_repair/notifier.ex
@@ -178,7 +178,7 @@ defmodule Archethic.SelfRepair.Notifier do
             [address, resolved_genesis_address]
           end,
           on_timeout: :kill_task,
-          max_concurrency: length(movements_addresses)
+          max_concurrency: max(System.schedulers_online(), length(movements_addresses))
         )
         |> Stream.filter(&match?({:ok, _}, &1))
         |> Stream.flat_map(fn {:ok, addresses} -> addresses end)


### PR DESCRIPTION
Avoid this error: 

```
** (ArgumentError) :max_concurrency must be an integer greater than zero
    (elixir 1.14.1) lib/task/supervised.ex:181: Task.Supervised.stream/7
    (elixir 1.14.1) lib/stream.ex:1811: Enumerable.Stream.do_each/4
    (elixir 1.14.1) lib/stream.ex:942: Stream.do_transform/5
    (elixir 1.14.1) lib/enum.ex:4307: anonymous fn/3 in Enum.concat_enum/1
    (elixir 1.14.1) lib/enum.ex:2468: Enum."-concat_enum/1-lists^foldl/2-1-"/3
    (elixir 1.14.1) lib/enum.ex:2468: Enum.concat_enum/1
    (archethic 1.4.7) lib/archethic/self_repair/notifier.ex:185: Archethic.SelfRepair.Notifier.get_previous_election/3
```