### PR TITLE
Improve self repair

### DIFF
--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -90,6 +90,7 @@ defmodule Archethic.SelfRepair do
     0..@max_retry_count
     |> Enum.reduce_while(:error, fn _, _ ->
       try do
+        Process.flag(:trap_exit, true)
         :ok = last_sync_date() |> Sync.load_missed_transactions(download_nodes)
         {:halt, :ok}
       rescue

--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -34,6 +34,19 @@ defmodule Archethic.SelfRepair do
 
   require Logger
 
+  defmodule Error do
+    defexception [:function, :message, :address]
+
+    @impl Exception
+    def message(%__MODULE__{function: function, message: message, address: nil}) do
+      "Self repair encounter an error in function #{function} with error #{message}"
+    end
+
+    def message(%__MODULE__{function: function, message: message, address: address}) do
+      "Self repair encounter an error in function #{function} on address: #{Base.encode16(address)} with error #{message}"
+    end
+  end
+
   @max_retry_count 10
 
   @doc """

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -178,7 +178,7 @@ defmodule Archethic.SelfRepair.Sync do
       {:ok, {:error, :not_exists}} ->
         false
 
-      _ ->
+      {:ok, _} ->
         raise SelfRepair.Error,
           function: "fetch_summaries_aggregates",
           message: "Previous summary aggregate not fetched"

--- a/lib/archethic/transaction_chain/transaction_summary.ex
+++ b/lib/archethic/transaction_chain/transaction_summary.ex
@@ -247,15 +247,16 @@ defmodule Archethic.TransactionChain.TransactionSummary do
           {:ok, genesis_address} ->
             [genesis_address, address]
 
-          _ ->
-            [address]
+          {:error, reason} ->
+            raise Archethic.SelfRepair.Error,
+              function: "resolve_movements_addresses",
+              message: "Failed to fetch genesis address with error #{inspect(reason)}",
+              address: Base.encode16(address)
         end
       end,
-      on_timeout: :kill_task,
       max_concurrency: length(addresses)
     )
-    |> Stream.filter(&match?({:ok, _}, &1))
-    |> Stream.flat_map(fn {:ok, res} -> res end)
+    |> Enum.flat_map(fn {:ok, res} -> res end)
   end
 
   def resolve_movements_addresses(

--- a/lib/archethic/transaction_chain/transaction_summary.ex
+++ b/lib/archethic/transaction_chain/transaction_summary.ex
@@ -245,7 +245,7 @@ defmodule Archethic.TransactionChain.TransactionSummary do
 
         case TransactionChain.fetch_genesis_address(address, storage_nodes) do
           {:ok, genesis_address} ->
-            [genesis_address, address]
+            [address, genesis_address]
 
           {:error, reason} ->
             raise Archethic.SelfRepair.Error,

--- a/test/archethic/self_repair/sync/transaction_handler_test.exs
+++ b/test/archethic/self_repair/sync/transaction_handler_test.exs
@@ -18,6 +18,7 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
   alias Archethic.P2P.Message.GenesisAddress
   alias Archethic.P2P.Node
 
+  alias Archethic.SelfRepair
   alias Archethic.SelfRepair.Sync.TransactionHandler
   alias Archethic.SharedSecrets.MemTables.NetworkLookup
 
@@ -362,7 +363,10 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
           TransactionSummary.from_transaction(tx, Transaction.previous_address(tx))
       }
 
-      assert_raise RuntimeError, "Error downloading transaction", fn ->
+      message =
+        "Self repair encounter an error in function download_transaction on address: #{Base.encode16(tx.address)} with error Cannot fetch the transaction to sync because of :acceptance_failed"
+
+      assert_raise SelfRepair.Error, message, fn ->
         TransactionHandler.download_transaction(
           attestation,
           P2P.authorized_and_available_nodes()
@@ -395,9 +399,10 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
           TransactionSummary.from_transaction(tx, Transaction.previous_address(tx))
       }
 
-      message = "Error downloading transaction"
+      message =
+        "Self repair encounter an error in function download_transaction on address: #{Base.encode16(tx.address)} with error Cannot fetch the transaction to sync because of :acceptance_failed"
 
-      assert_raise RuntimeError, message, fn ->
+      assert_raise SelfRepair.Error, message, fn ->
         TransactionHandler.download_transaction(
           attestation,
           P2P.authorized_and_available_nodes()
@@ -625,7 +630,10 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
         transaction_summary: tx_summary
       }
 
-      assert_raise RuntimeError, "Transaction signature error in self repair", fn ->
+      message =
+        "Self repair encounter an error in function verify_transaction on address: #{Base.encode16(tx.address)} with error Transaction signature error in self repair"
+
+      assert_raise SelfRepair.Error, message, fn ->
         TransactionHandler.process_transaction(
           attestation,
           tx,
@@ -664,9 +672,7 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandlerTest do
         confirmations: [{index, signature}]
       }
 
-      message = "Attestation error in self repair"
-
-      assert_raise RuntimeError, message, fn ->
+      assert_raise SelfRepair.Error, fn ->
         TransactionHandler.process_transaction(
           attestation,
           tx,


### PR DESCRIPTION
# Description

Improve Self repair so it is faster and return proper error in case of failure.
- New `SelfRepair.Error` exception
- Function `adjust_attestation` is more clever and parallelizes requests
- Retrieve resolved genesis address map in before replication so UTXO does not need to resolve again
- Add trap exit flag to have better self repair retry

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Self repair using testnet bootstrap

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
