### PR TITLE
AEIP21-P2: Use genesis unspent outputs during transaction's validation

### DIFF
--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -382,12 +382,12 @@ defmodule Archethic do
   @doc """
   Request to fetch the unspent outputs for a transaction address from the closest nodes
   """
-  @spec get_unspent_outputs(address :: Crypto.prepended_hash(), genesis? :: boolean()) ::
+  @spec get_unspent_outputs(address :: Crypto.prepended_hash()) ::
           list(UnspentOutput.t())
-  def get_unspent_outputs(address, genesis? \\ false) do
+  def get_unspent_outputs(address) do
     nodes = Election.storage_nodes(address, P2P.authorized_and_available_nodes())
 
-    TransactionChain.fetch_unspent_outputs(address, nodes, genesis?)
+    TransactionChain.fetch_unspent_outputs(address, nodes)
     |> VersionedUnspentOutput.unwrap_unspent_outputs()
   end
 

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -316,6 +316,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
           timeout: timeout,
           context:
             context = %ValidationContext{
+              genesis_address: genesis_address,
               transaction: tx,
               chain_storage_nodes: chain_storage_nodes,
               beacon_storage_nodes: beacon_storage_nodes,
@@ -335,6 +336,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
      io_storage_nodes_view} =
       TransactionContext.get(
         Transaction.previous_address(tx),
+        genesis_address,
         Enum.map(chain_storage_nodes, & &1.first_public_key),
         Enum.map(beacon_storage_nodes, & &1.first_public_key),
         Enum.map(io_storage_nodes, & &1.first_public_key)

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -105,6 +105,7 @@ defmodule Archethic.Mining.StandaloneWorkflow do
      io_storage_nodes_view} =
       TransactionContext.get(
         Transaction.previous_address(tx),
+        genesis_address,
         Enum.map(chain_storage_nodes, & &1.first_public_key),
         Enum.map(beacon_storage_nodes, & &1.first_public_key),
         Enum.map(io_storage_nodes, & &1.first_public_key)

--- a/lib/archethic/mining/transaction_context.ex
+++ b/lib/archethic/mining/transaction_context.ex
@@ -104,7 +104,7 @@ defmodule Archethic.Mining.TransactionContext do
     genesis_nodes = Election.chain_storage_nodes(genesis_address, authorized_nodes)
 
     Task.Supervisor.async(TaskSupervisor, fn ->
-      TransactionChain.fetch_unspent_outputs(genesis_address, genesis_nodes, true)
+      TransactionChain.fetch_unspent_outputs(genesis_address, genesis_nodes)
       |> Enum.to_list()
     end)
   end

--- a/lib/archethic/mining/transaction_context.ex
+++ b/lib/archethic/mining/transaction_context.ex
@@ -14,8 +14,6 @@ defmodule Archethic.Mining.TransactionContext do
   alias Archethic.P2P.Message.Ping
   alias Archethic.P2P.Node
 
-  alias __MODULE__.NodeDistribution
-
   alias Archethic.TaskSupervisor
 
   alias Archethic.TransactionChain
@@ -32,7 +30,8 @@ defmodule Archethic.Mining.TransactionContext do
   as long as the involved nodes for the retrieval
   """
   @spec get(
-          previous_tx_address :: binary(),
+          previous_tx_address :: Crypto.prepended_hash(),
+          genesis_address :: Crypto.prepended_hash(),
           chain_storage_node_public_keys :: list(Crypto.key()),
           beacon_storage_nodes_public_keys :: list(Crypto.key()),
           io_storage_nodes_public_keys :: list(Crypto.key())
@@ -41,12 +40,12 @@ defmodule Archethic.Mining.TransactionContext do
            bitstring()}
   def get(
         previous_address,
+        genesis_address,
         chain_storage_node_public_keys,
         beacon_storage_node_public_keys,
         io_storage_node_public_keys
       ) do
-    [prev_tx_nodes_split, unspent_outputs_nodes_split] =
-      previous_nodes_distribution(previous_address, 2, 3)
+    authorized_nodes = P2P.authorized_and_available_nodes()
 
     node_public_keys =
       [
@@ -57,8 +56,8 @@ defmodule Archethic.Mining.TransactionContext do
       |> List.flatten()
       |> Enum.uniq()
 
-    prev_tx_task = request_previous_tx(previous_address, prev_tx_nodes_split)
-    utxos_task = request_utxos(previous_address, unspent_outputs_nodes_split)
+    prev_tx_task = request_previous_tx(previous_address, authorized_nodes)
+    utxos_task = request_utxos(genesis_address, authorized_nodes)
     nodes_view_task = request_nodes_view(node_public_keys)
 
     [prev_tx, utxos, nodes_view] = Task.await_many([prev_tx_task, utxos_task, nodes_view_task])
@@ -79,24 +78,15 @@ defmodule Archethic.Mining.TransactionContext do
      io_storage_nodes_view}
   end
 
-  defp previous_nodes_distribution(previous_address, nb_sub_lists, sample_size) do
-    elected_nodes =
-      Election.chain_storage_nodes(previous_address, P2P.authorized_and_available_nodes())
+  defp request_previous_tx(previous_address, authorized_nodes) do
+    previous_storage_nodes = Election.chain_storage_nodes(previous_address, authorized_nodes)
 
-    if Enum.count(elected_nodes) < sample_size do
-      Enum.map(1..nb_sub_lists, fn _ -> elected_nodes end)
-    else
-      NodeDistribution.split_storage_nodes(elected_nodes, nb_sub_lists, sample_size)
-    end
-  end
-
-  defp request_previous_tx(previous_address, nodes) do
     Task.Supervisor.async(
       TaskSupervisor,
       fn ->
         # Timeout of 4 sec because the coordinator node wait 5 sec to get the context
         # from the cross validation nodes
-        case TransactionChain.fetch_transaction(previous_address, nodes,
+        case TransactionChain.fetch_transaction(previous_address, previous_storage_nodes,
                search_mode: :remote,
                timeout: 4000
              ) do
@@ -110,9 +100,12 @@ defmodule Archethic.Mining.TransactionContext do
     )
   end
 
-  defp request_utxos(previous_address, nodes) do
+  defp request_utxos(genesis_address, authorized_nodes) do
+    genesis_nodes = Election.chain_storage_nodes(genesis_address, authorized_nodes)
+
     Task.Supervisor.async(TaskSupervisor, fn ->
-      TransactionChain.fetch_unspent_outputs(previous_address, nodes) |> Enum.to_list()
+      TransactionChain.fetch_unspent_outputs(genesis_address, genesis_nodes, true)
+      |> Enum.to_list()
     end)
   end
 

--- a/lib/archethic/p2p/message/get_unspent_outputs.ex
+++ b/lib/archethic/p2p/message/get_unspent_outputs.ex
@@ -3,16 +3,15 @@ defmodule Archethic.P2P.Message.GetUnspentOutputs do
   Represents a message to request the list of unspent outputs from a transaction
   """
   @enforce_keys [:address]
-  defstruct [:address, offset: 0, limit: 0, genesis?: false]
+  defstruct [:address, offset: 0, limit: 0]
 
-  alias Archethic.Account
-  alias Archethic.Contracts
   alias Archethic.Crypto
   alias Archethic.P2P.Message.UnspentOutputList
 
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
+
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
 
-  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
   alias Archethic.Utils
   alias Archethic.Utils.VarInt
   alias Archethic.UTXO
@@ -27,36 +26,15 @@ defmodule Archethic.P2P.Message.GetUnspentOutputs do
           address: Crypto.versioned_hash(),
           offset: non_neg_integer(),
           # limit is not used
-          limit: non_neg_integer(),
-          genesis?: boolean()
+          limit: non_neg_integer()
         }
 
   @spec process(__MODULE__.t(), Crypto.key()) :: UnspentOutputList.t()
-  def process(%__MODULE__{address: tx_address, offset: offset, genesis?: false}, _) do
-    contract_utxos =
-      tx_address
-      |> Contracts.list_contract_transactions()
-      |> Enum.map(fn {address, timestamp, protocol_version} ->
-        %UnspentOutput{from: address, type: :call, timestamp: timestamp}
-        |> VersionedUnspentOutput.wrap_unspent_output(protocol_version)
-      end)
-
-    ledger_utxos = Account.get_unspent_outputs(tx_address)
-
-    utxos = ledger_utxos ++ contract_utxos
-
-    %{utxos: utxos, offset: offset, more?: more?} = reduce_utxos(utxos, offset)
-
-    %UnspentOutputList{
-      unspent_outputs: utxos,
-      offset: offset,
-      more?: more?
-    }
-  end
-
-  def process(%__MODULE__{address: genesis_address, offset: offset, genesis?: true}, _) do
+  def process(%__MODULE__{address: genesis_address, offset: offset}, _) do
     %{utxos: utxos, offset: offset, more?: more?} =
-      genesis_address |> UTXO.stream_unspent_outputs() |> reduce_utxos(offset)
+      genesis_address
+      |> UTXO.stream_unspent_outputs()
+      |> reduce_utxos(offset)
 
     %UnspentOutputList{
       unspent_outputs: utxos,
@@ -105,16 +83,15 @@ defmodule Archethic.P2P.Message.GetUnspentOutputs do
   end
 
   @spec serialize(t()) :: bitstring()
-  def serialize(%__MODULE__{address: tx_address, offset: offset, genesis?: genesis?}) do
-    genesis_bit = if genesis?, do: 1, else: 0
-    <<tx_address::binary, VarInt.from_value(offset)::binary, genesis_bit::1>>
+  def serialize(%__MODULE__{address: tx_address, offset: offset}) do
+    <<tx_address::binary, VarInt.from_value(offset)::binary>>
   end
 
   @spec deserialize(bitstring()) :: {t(), bitstring()}
   def deserialize(<<rest::bitstring>>) do
     {address, rest} = Utils.deserialize_address(rest)
 
-    {offset, <<genesis_bit::1, rest::bitstring>>} = VarInt.get_value(rest)
-    {%__MODULE__{address: address, offset: offset, genesis?: genesis_bit == 1}, rest}
+    {offset, rest} = VarInt.get_value(rest)
+    {%__MODULE__{address: address, offset: offset}, rest}
   end
 end

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -307,7 +307,7 @@ defmodule Archethic.Replication do
       transaction_type: type
     )
 
-    previous_address
+    tx
     |> TransactionContext.fetch_transaction_unspent_outputs()
     |> tap(fn inputs ->
       Logger.debug("Got #{inspect(inputs)} for #{Base.encode16(previous_address)}",

--- a/lib/archethic/replication/transaction_context.ex
+++ b/lib/archethic/replication/transaction_context.ex
@@ -8,8 +8,6 @@ defmodule Archethic.Replication.TransactionContext do
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
 
-  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
-
   alias Archethic.P2P
 
   require Logger
@@ -68,7 +66,19 @@ defmodule Archethic.Replication.TransactionContext do
 
     genesis_storage_nodes = Election.chain_storage_nodes(genesis_address, authorized_nodes)
 
-    TransactionChain.fetch_unspent_outputs(genesis_address, genesis_storage_nodes, true)
+    Logger.debug(
+      "Fetch inputs for #{Base.encode16(genesis_address)}",
+      transaction_address: Base.encode16(tx.address),
+      transaction_type: tx.type
+    )
+
+    TransactionChain.fetch_unspent_outputs(genesis_address, genesis_storage_nodes)
     |> Enum.to_list()
+    |> tap(fn inputs ->
+      Logger.debug("Got #{inspect(inputs)} for #{Base.encode16(genesis_address)}",
+        transaction_address: Base.encode16(tx.address),
+        type: tx.type
+      )
+    end)
   end
 end

--- a/lib/archethic/transaction_chain/transaction/cross_validation_stamp.ex
+++ b/lib/archethic/transaction_chain/transaction/cross_validation_stamp.ex
@@ -20,6 +20,7 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStamp do
           | :unspent_outputs
           | :error
           | :protocol_version
+          | :consumed_inputs
 
   @typedoc """
   A cross validation stamp is composed from:
@@ -134,6 +135,7 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStamp do
   defp serialize_inconsistency(:unspent_outputs), do: 7
   defp serialize_inconsistency(:error), do: 8
   defp serialize_inconsistency(:protocol_version), do: 9
+  defp serialize_inconsistency(:consumed_inputs), do: 10
 
   @doc """
   Deserialize an encoded cross validation stamp
@@ -199,6 +201,7 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStamp do
   defp do_reduce_inconsistencies(<<7::8, rest::bitstring>>), do: {:unspent_outputs, rest}
   defp do_reduce_inconsistencies(<<8::8, rest::bitstring>>), do: {:error, rest}
   defp do_reduce_inconsistencies(<<9::8, rest::bitstring>>), do: {:protocol_version, rest}
+  defp do_reduce_inconsistencies(<<10::8, rest::bitstring>>), do: {:consumed_inputs, rest}
 
   @spec cast(map()) :: t()
   def cast(stamp = %{}) do

--- a/lib/archethic/utxo/db_ledger/file_impl.ex
+++ b/lib/archethic/utxo/db_ledger/file_impl.ex
@@ -44,6 +44,14 @@ defmodule Archethic.UTXO.DBLedger.FileImpl do
   Flush to disk the unspent outputs for a genesis address
   """
   @spec flush(binary(), list(VersionedUnspentOutput.t())) :: :ok
+  def flush(genesis_address, []) do
+    genesis_address
+    |> file_path()
+    |> File.rm()
+
+    :ok
+  end
+
   def flush(genesis_address, unspent_outputs) do
     bin =
       unspent_outputs
@@ -57,9 +65,9 @@ defmodule Archethic.UTXO.DBLedger.FileImpl do
       end)
       |> :erlang.list_to_binary()
 
-    File.write!(file_path(genesis_address), bin, [
-      :binary
-    ])
+    genesis_address
+    |> file_path()
+    |> File.write!(bin, [:binary])
   end
 
   @doc """

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -300,7 +300,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
 
   defp get_transaction_inputs(address, _debug? = true) do
     case Archethic.fetch_genesis_address(address) do
-      {:ok, genesis_address} -> Archethic.get_unspent_outputs(genesis_address, true)
+      {:ok, genesis_address} -> Archethic.get_unspent_outputs(genesis_address)
       _ -> []
     end
   end

--- a/test/archethic/mining/transaction_context_test.exs
+++ b/test/archethic/mining/transaction_context_test.exs
@@ -101,7 +101,7 @@ defmodule Archethic.Mining.TransactionContextTest do
 
       assert {%Transaction{}, [%VersionedUnspentOutput{}], _, <<1::1, 1::1>>, <<1::1, 1::1>>,
               <<1::1, 1::1>>} =
-               TransactionContext.get("@Alice1", ["key1", "key2"], ["key1", "key2"], [
+               TransactionContext.get("@Alice1", "@Alice1", ["key1", "key2"], ["key1", "key2"], [
                  "key2",
                  "key1"
                ])

--- a/test/archethic/replication_test.exs
+++ b/test/archethic/replication_test.exs
@@ -10,16 +10,11 @@ defmodule Archethic.ReplicationTest do
 
   alias Archethic.P2P
   alias Archethic.P2P.Message
-  alias Archethic.P2P.Message.GetTransactionChainLength
-  alias Archethic.P2P.Message.TransactionChainLength
   alias Archethic.P2P.Message.GetTransaction
-  alias Archethic.P2P.Message.GetUnspentOutputs
-  alias Archethic.P2P.Message.UnspentOutputList
   alias Archethic.P2P.Message.NotifyLastTransactionAddress
   alias Archethic.P2P.Message.NotFound
   alias Archethic.P2P.Message.Ok
   alias Archethic.P2P.Node
-  alias Archethic.P2P.Message.GetGenesisAddress
 
   alias Archethic.Replication
   alias Archethic.Replication.TransactionContext


### PR DESCRIPTION
# Description

This PR modifies the Validation workflow to fetch the UTXOs from genesis nodes.
This PR is based on #1414
Fixes #1408

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests & manual integration tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
