### PR TITLE
Speedup node start by deactivating unused feature

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -128,6 +128,9 @@ config :archethic, Archethic.P2P.Listener,
 config :archethic, ArchethicWeb.Explorer.FaucetController, enabled: true
 config :archethic, ArchethicWeb.Explorer.FaucetRateLimiter, enabled: true
 
+config :archethic, Archethic.TransactionChain.MemTables.PendingLedger, enabled: false
+config :archethic, Archethic.TransactionChain.MemTablesLoader, enabled: false
+
 config :archethic, Archethic.Contracts.Interpreter.Library.Common.HttpImpl,
   supported_schemes: ["https", "http"]
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,6 +11,9 @@ config :archethic, :root_mut_dir, System.get_env("ARCHETHIC_ROOT_MUT_DIR", "~/ae
 config :archethic, Archethic.Bootstrap,
   reward_address: System.get_env("ARCHETHIC_REWARD_ADDRESS", "") |> Base.decode16!(case: :mixed)
 
+config :archethic, Archethic.TransactionChain.MemTables.PendingLedger, enabled: false
+config :archethic, Archethic.TransactionChain.MemTablesLoader, enabled: false
+
 config :archethic, Archethic.Bootstrap.NetworkInit,
   genesis_pools:
     [

--- a/lib/archethic/contracts/loader.ex
+++ b/lib/archethic/contracts/loader.ex
@@ -121,7 +121,7 @@ defmodule Archethic.Contracts.Loader do
       [{pid, _}] ->
         DynamicSupervisor.terminate_child(ContractSupervisor, pid)
         TransactionLookup.clear_contract_transactions(address)
-        TransactionChain.clear_pending_transactions(address)
+        # TransactionChain.clear_pending_transactions(address)
         Logger.info("Stop smart contract at #{Base.encode16(address)}")
 
       _ ->


### PR DESCRIPTION
Deactivate the TransactionChain.MemTableLoader and PendingLedger as they are not used yet and still do a lot of computation when starting a node