### PR TITLE
Fix utxo sort on state without timestamp

### DIFF
--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -798,8 +798,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
             context = %ValidationContext{
               welcome_node: welcome_node = %Node{},
               storage_nodes_confirmations: confirmations,
-              genesis_address: genesis_address,
-              contract_context: contract_context
+              genesis_address: genesis_address
             }
         }
       ) do
@@ -824,7 +823,6 @@ defmodule Archethic.Mining.DistributedWorkflow do
     |> ValidationContext.get_io_replication_nodes()
     |> P2P.broadcast_message(%ReplicateTransaction{
       transaction: validated_tx,
-      contract_context: contract_context,
       genesis_address: genesis_address
     })
 

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -402,12 +402,7 @@ defmodule Archethic.Mining.StandaloneWorkflow do
     |> P2P.broadcast_message(attestation)
   end
 
-  defp notify_io_nodes(
-         context = %ValidationContext{
-           genesis_address: genesis_address,
-           contract_context: contract_context
-         }
-       ) do
+  defp notify_io_nodes(context = %ValidationContext{genesis_address: genesis_address}) do
     validated_tx = ValidationContext.get_validated_transaction(context)
 
     context
@@ -421,7 +416,6 @@ defmodule Archethic.Mining.StandaloneWorkflow do
     end)
     |> P2P.broadcast_message(%ReplicateTransaction{
       transaction: validated_tx,
-      contract_context: contract_context,
       genesis_address: genesis_address
     })
   end

--- a/lib/archethic/p2p/message/get_unspent_outputs.ex
+++ b/lib/archethic/p2p/message/get_unspent_outputs.ex
@@ -69,7 +69,11 @@ defmodule Archethic.P2P.Message.GetUnspentOutputs do
     utxos_length = Enum.count(utxos)
 
     utxos
-    |> Enum.sort_by(& &1.unspent_output.timestamp, {:desc, DateTime})
+    |> Enum.sort_by(fn %VersionedUnspentOutput{
+                         unspent_output: %UnspentOutput{timestamp: timestamp}
+                       } ->
+      if is_nil(timestamp), do: DateTime.from_unix!(0), else: timestamp
+    end)
     |> Enum.with_index()
     |> Enum.drop(offset)
     |> Enum.reduce_while(

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -146,9 +146,9 @@ defmodule Archethic.Replication do
       # we also ingest the transaction if we are storage node of it
 
       ingest? =
-        if Transaction.network_type?(type),
-          do: true,
-          else: Election.chain_storage_node?(address, first_node_key, download_nodes)
+        Transaction.network_type?(type) or
+          Election.chain_storage_node?(address, first_node_key, download_nodes) or
+          Election.chain_storage_node?(genesis_address, first_node_key, download_nodes)
 
       opts = Keyword.delete(ingest_opts, :resolved_addresses)
       if ingest?, do: ingest_transaction(tx, genesis_address, opts)

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -243,7 +243,11 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
     consolidated_inputs =
       Enum.sort_by(
         tokens_to_mint ++ inputs,
-        &{DateTime.to_unix(&1.unspent_output.timestamp), &1.unspent_output.from}
+        fn %VersionedUnspentOutput{
+             unspent_output: %UnspentOutput{timestamp: timestamp, from: from}
+           } ->
+          if is_nil(timestamp), do: {0, from}, else: {DateTime.to_unix(timestamp), from}
+        end
       )
 
     %{uco: uco_balance, token: tokens_balance} = ledger_balances(consolidated_inputs)


### PR DESCRIPTION
# Description

Fixes an issue where utxo of type state can have a nil timestamp, and this crashes a DateTime.compare

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
