### PR TITLE
Add previous public key pending validation

### DIFF
--- a/lib/archethic/mining/pending_transaction_validation.ex
+++ b/lib/archethic/mining/pending_transaction_validation.ex
@@ -82,6 +82,7 @@ defmodule Archethic.Mining.PendingTransactionValidation do
 
     with :ok <- validate_size(tx),
          :ok <- valid_not_exists(tx),
+         :ok <- valid_previous_public_key(tx),
          :ok <- valid_previous_signature(tx),
          :ok <- validate_contract(tx),
          :ok <- validate_ownerships(tx),
@@ -128,7 +129,14 @@ defmodule Archethic.Mining.PendingTransactionValidation do
     end
   end
 
-  @spec valid_previous_signature(tx :: Transaction.t()) :: :ok | {:error, any()}
+  defp valid_previous_public_key(tx = %Transaction{address: address}) do
+    if Transaction.previous_address(tx) == address do
+      {:error, "Invalid previous public key (should be chain index - 1)"}
+    else
+      :ok
+    end
+  end
+
   defp valid_previous_signature(tx = %Transaction{}) do
     if Transaction.verify_previous_signature?(tx) do
       :ok

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -23,6 +23,7 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
 
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Recipient
   alias Archethic.TransactionChain.TransactionData.Ledger
   alias Archethic.TransactionChain.TransactionData.Ownership
@@ -87,6 +88,24 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
         )
 
       assert {:error, "Transaction data exceeds limit"} =
+               PendingTransactionValidation.validate(tx)
+    end
+  end
+
+  describe "validate_previous_public_key" do
+    test "should return error if previous transaction address is the same address as the current transaction" do
+      {public_key, private_key} = Crypto.derive_keypair("seed", 0)
+
+      tx =
+        Transaction.new_with_keys(
+          :transfer,
+          %TransactionData{},
+          private_key,
+          public_key,
+          public_key
+        )
+
+      assert {:error, "Invalid previous public key (should be chain index - 1)"} =
                PendingTransactionValidation.validate(tx)
     end
   end


### PR DESCRIPTION
# Description

Fixes an issue where a user could create a transaction with the previous public key as the next public, breaking the chain as the previous transaction address is the current transaction address

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
