### PR TITLE
feat: update SmartContractCallValidation struct to use status field instead of valid? field

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -248,7 +248,7 @@ defmodule Archethic.Contracts do
           Transaction.t(),
           nil | Recipient.t(),
           DateTime.t()
-        ) :: {:ok, logs :: list(String.t())} | {:error, :condition_rejected | Failure.t()}
+        ) :: {:ok, logs :: list(String.t())} | {:error, ConditionRejected.t() | Failure.t()}
   def execute_condition(
         condition_key,
         contract = %Contract{version: version, conditions: conditions},

--- a/lib/archethic/contracts/contract.ex
+++ b/lib/archethic/contracts/contract.ex
@@ -40,10 +40,11 @@ defmodule Archethic.Contracts.Contract do
 
   @type trigger_key() ::
           :oracle
-          | {:transaction, nil, nil}
-          | {:transaction, String.t(), non_neg_integer()}
+          | trigger_recipient()
           | {:datetime, DateTime.t()}
           | {:interval, String.t()}
+
+  @type trigger_recipient :: {:transaction, nil | String.t(), nil | non_neg_integer()}
 
   @type condition_key() ::
           :oracle
@@ -163,7 +164,7 @@ defmodule Archethic.Contracts.Contract do
   @doc """
   Return the args names for this recipient or nil
   """
-  @spec get_trigger_for_recipient(Recipient.t()) :: nil | trigger_key()
+  @spec get_trigger_for_recipient(Recipient.t()) :: trigger_recipient()
   def get_trigger_for_recipient(%Recipient{action: nil, args: nil}), do: {:transaction, nil, nil}
 
   def get_trigger_for_recipient(%Recipient{action: action, args: args_values}),

--- a/lib/archethic/p2p/message/smart_contract_call_validation.ex
+++ b/lib/archethic/p2p/message/smart_contract_call_validation.ex
@@ -4,48 +4,63 @@ defmodule Archethic.P2P.Message.SmartContractCallValidation do
   """
 
   @type t :: %__MODULE__{
-          valid?: boolean(),
+          status: :ok | {:error, :transaction_not_exists | :invalid_execution},
           fee: non_neg_integer()
         }
 
-  defstruct [:valid?, :fee]
+  defstruct [:status, :fee]
 
   @doc """
   Serialize message into binary
 
   ## Examples
 
-      iex> %SmartContractCallValidation{valid?: true, fee: 186435476} |> SmartContractCallValidation.serialize()
-      <<128, 0, 0, 0, 5, 142, 99, 202, 0::size(1)>>
+      iex> %SmartContractCallValidation{status: :ok, fee: 186435476} |> SmartContractCallValidation.serialize()
+      <<0, 0, 0, 0, 0, 11, 28, 199, 148>>
 
-      iex> %SmartContractCallValidation{valid?: false, fee: 186435476} |> SmartContractCallValidation.serialize()
-      <<0, 0, 0, 0, 5, 142, 99, 202, 0::size(1)>>
+      iex> %SmartContractCallValidation{status: {:error, :transaction_not_exists}, fee: 0} |> SmartContractCallValidation.serialize()
+      <<1, 0, 0, 0, 0, 0, 0, 0, 0>>
+
+      iex> %SmartContractCallValidation{status: {:error, :invalid_execution}, fee: 0} |> SmartContractCallValidation.serialize()
+      <<2, 0, 0, 0, 0, 0, 0, 0, 0>>
   """
-  def serialize(%__MODULE__{valid?: valid?, fee: fee}) do
-    valid_bit = if valid?, do: 1, else: 0
-    <<valid_bit::1, fee::64>>
+  def serialize(%__MODULE__{status: status, fee: fee}) do
+    <<serialize_status(status)::8, fee::64>>
   end
+
+  defp serialize_status(:ok), do: 0
+  defp serialize_status({:error, :transaction_not_exists}), do: 1
+  defp serialize_status({:error, :invalid_execution}), do: 2
 
   @doc """
   Deserialize the encoded message
 
   ## Examples
 
-      iex> SmartContractCallValidation.deserialize(<<128, 0, 0, 0, 5, 142, 99, 202, 0::size(1)>>)
+      iex> SmartContractCallValidation.deserialize(<<0, 0, 0, 0, 0, 11, 28, 199, 148>>)
       {
-        %SmartContractCallValidation{valid?: true, fee: 186435476},
+        %SmartContractCallValidation{status: :ok, fee: 186435476},
         ""
       }
 
-      iex> SmartContractCallValidation.deserialize(<<0, 0, 0, 0, 5, 142, 99, 202, 0::size(1)>>)
+      iex> SmartContractCallValidation.deserialize(<<1, 0, 0, 0, 0, 0, 0, 0, 0>>)
       {
-        %SmartContractCallValidation{valid?: false, fee: 186435476},
+        %SmartContractCallValidation{status: {:error, :transaction_not_exists}, fee: 0},
+        ""
+      }
+
+      iex> SmartContractCallValidation.deserialize(<<2, 0, 0, 0, 0, 0, 0, 0, 0>>)
+      {
+        %SmartContractCallValidation{status: {:error, :invalid_execution}, fee: 0},
         ""
       }
   """
-  def deserialize(<<valid_bit::1, fee::64, rest::bitstring>>) do
-    valid? = if valid_bit == 1, do: true, else: false
-
-    {%__MODULE__{valid?: valid?, fee: fee}, rest}
+  def deserialize(<<status_byte::8, fee::64, rest::bitstring>>) do
+    status = deserialize_status(status_byte)
+    {%__MODULE__{status: status, fee: fee}, rest}
   end
+
+  defp deserialize_status(0), do: :ok
+  defp deserialize_status(1), do: {:error, :transaction_not_exists}
+  defp deserialize_status(2), do: {:error, :invalid_execution}
 end

--- a/test/archethic/mining/pending_transaction_validation_test.exs
+++ b/test/archethic/mining/pending_transaction_validation_test.exs
@@ -177,7 +177,15 @@ defmodule Archethic.Mining.PendingTransactionValidationTest do
       tx =
         Transaction.new_with_keys(
           :transfer,
-          %TransactionData{},
+          %TransactionData{
+            ledger: %Ledger{
+              uco: %UCOLedger{
+                transfers: [
+                  %UCOLedger.Transfer{to: ArchethicCase.random_address(), amount: 100_000_000}
+                ]
+              }
+            }
+          },
           private_key,
           public_key,
           public_key

--- a/test/archethic/mining/smart_contract_validation_test.exs
+++ b/test/archethic/mining/smart_contract_validation_test.exs
@@ -14,6 +14,8 @@ defmodule Archethic.Mining.SmartContractValidationTest do
 
   import Mox
 
+  doctest SmartContractValidation
+
   describe "validate_contract_calls/2" do
     test "should returns {true, fees} if all contracts calls are valid" do
       MockClient
@@ -21,10 +23,10 @@ defmodule Archethic.Mining.SmartContractValidationTest do
         :send_message,
         fn
           _, %ValidateSmartContractCall{recipient: %Recipient{address: "@SC1"}}, _ ->
-            {:ok, %SmartContractCallValidation{valid?: true, fee: 123_456}}
+            {:ok, %SmartContractCallValidation{status: :ok, fee: 123_456}}
 
           _, %ValidateSmartContractCall{recipient: %Recipient{address: "@SC2"}}, _ ->
-            {:ok, %SmartContractCallValidation{valid?: true, fee: 654_321}}
+            {:ok, %SmartContractCallValidation{status: :ok, fee: 654_321}}
         end
       )
 
@@ -58,10 +60,10 @@ defmodule Archethic.Mining.SmartContractValidationTest do
         :send_message,
         fn
           _, %ValidateSmartContractCall{recipient: %Recipient{address: "@SC1"}}, _ ->
-            {:ok, %SmartContractCallValidation{valid?: false, fee: 0}}
+            {:ok, %SmartContractCallValidation{status: {:error, :invalid_execution}, fee: 0}}
 
           _, %ValidateSmartContractCall{recipient: %Recipient{address: "@SC2"}}, _ ->
-            {:ok, %SmartContractCallValidation{valid?: true, fee: 0}}
+            {:ok, %SmartContractCallValidation{status: :ok, fee: 0}}
         end
       )
 
@@ -101,12 +103,12 @@ defmodule Archethic.Mining.SmartContractValidationTest do
           %Node{port: 1234},
           %ValidateSmartContractCall{recipient: %Recipient{address: "@SC1"}},
           _ ->
-            {:ok, %SmartContractCallValidation{valid?: false, fee: 0}}
+            {:ok, %SmartContractCallValidation{status: {:error, :invalid_execution}, fee: 0}}
 
           %Node{port: 1235},
           %ValidateSmartContractCall{recipient: %Recipient{address: "@SC1"}},
           _ ->
-            {:ok, %SmartContractCallValidation{valid?: true, fee: 123_456}}
+            {:ok, %SmartContractCallValidation{status: :ok, fee: 123_456}}
         end
       )
 
@@ -149,10 +151,10 @@ defmodule Archethic.Mining.SmartContractValidationTest do
         :send_message,
         fn
           _, %ValidateSmartContractCall{recipient: %Recipient{address: "@SC1"}}, _ ->
-            {:ok, %SmartContractCallValidation{valid?: false, fee: 0}}
+            {:ok, %SmartContractCallValidation{status: {:error, :invalid_execution}, fee: 0}}
 
           _, %ValidateSmartContractCall{recipient: %Recipient{address: "@SC2"}}, _ ->
-            {:ok, %SmartContractCallValidation{valid?: true, fee: 123_456}}
+            {:ok, %SmartContractCallValidation{status: :ok, fee: 123_456}}
         end
       )
 

--- a/test/archethic/p2p/message/validate_smart_contract_call_test.exs
+++ b/test/archethic/p2p/message/validate_smart_contract_call_test.exs
@@ -82,7 +82,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
 
       incoming_tx = TransactionFactory.create_valid_transaction([], content: "hola")
 
-      assert %SmartContractCallValidation{valid?: true} =
+      assert %SmartContractCallValidation{status: :ok} =
                %ValidateSmartContractCall{
                  recipient: %Recipient{address: "@SC1"},
                  transaction: incoming_tx,
@@ -108,7 +108,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
 
       incoming_tx = TransactionFactory.create_valid_transaction([], content: "hola")
 
-      assert %SmartContractCallValidation{valid?: true} =
+      assert %SmartContractCallValidation{status: :ok} =
                %ValidateSmartContractCall{
                  recipient: %Recipient{address: "@SC1", action: "upgrade", args: []},
                  transaction: incoming_tx,
@@ -141,7 +141,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
         ContractFactory.create_valid_contract_tx(code, content: "hello")
         |> Fee.calculate(nil, 0.07, DateTime.utc_now(), nil, 0, current_protocol_version())
 
-      assert %SmartContractCallValidation{valid?: true, fee: expected_fee} ==
+      assert %SmartContractCallValidation{status: :ok, fee: expected_fee} ==
                %ValidateSmartContractCall{
                  recipient: %Recipient{address: "@SC1"},
                  transaction: incoming_tx,
@@ -166,7 +166,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
 
       incoming_tx = TransactionFactory.create_valid_transaction([], content: "hola")
 
-      assert %SmartContractCallValidation{valid?: false, fee: 0} =
+      assert %SmartContractCallValidation{status: {:error, :invalid_execution}, fee: 0} =
                %ValidateSmartContractCall{
                  recipient: %Recipient{address: "@SC1"},
                  transaction: incoming_tx,
@@ -195,7 +195,7 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
 
       incoming_tx = TransactionFactory.create_valid_transaction([], content: "hi")
 
-      assert %SmartContractCallValidation{valid?: false, fee: 0} =
+      assert %SmartContractCallValidation{status: {:error, :invalid_execution}, fee: 0} =
                %ValidateSmartContractCall{
                  recipient: %Recipient{address: "@SC1"},
                  transaction: incoming_tx,

--- a/test/archethic/replication/transaction_validator_test.exs
+++ b/test/archethic/replication/transaction_validator_test.exs
@@ -255,7 +255,7 @@ defmodule Archethic.Replication.TransactionValidatorTest do
         {:ok, %LastTransactionAddress{address: random_address()}}
       end)
       |> expect(:send_message, fn _, %ValidateSmartContractCall{}, _ ->
-        {:ok, %SmartContractCallValidation{valid?: false, fee: 0}}
+        {:ok, %SmartContractCallValidation{status: :invalid_execution, fee: 0}}
       end)
 
       assert {:error, :invalid_recipients_execution} =


### PR DESCRIPTION
The `SmartContractCallValidation` struct in the `Archethic.Contracts` module has been updated to replace the `valid?` field with a `status` field. The `status` field can have the values `:ok`, `{:error, :transaction_not_exists}`, or `{:error, :invalid_execution}`. This change allows for more descriptive and meaningful status reporting in smart contract call validations.

This change also introduces priorization of the status

Fixes #1423