### PR TITLE
Fix TransactionInput.set_spent to compare only using from and type

### DIFF
--- a/lib/archethic/transaction_chain/transaction_input.ex
+++ b/lib/archethic/transaction_chain/transaction_input.ex
@@ -300,13 +300,8 @@ defmodule Archethic.TransactionChain.TransactionInput do
 
   """
   @spec set_spent(t(), list(t())) :: t()
-  def set_spent(input = %__MODULE__{}, genesis_inputs) do
-    spent? =
-      genesis_inputs
-      |> MapSet.new()
-      |> MapSet.member?(input)
-      |> Kernel.not()
-
+  def set_spent(input = %__MODULE__{type: type, from: from}, genesis_inputs) do
+    spent? = not Enum.any?(genesis_inputs, &(&1.type == type and &1.from == from))
     %{input | spent?: spent?}
   end
 end


### PR DESCRIPTION
# Description

Fix comparison with inputs which have different timestamp due to different serialization

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
