### PR TITLE
Improve UTXO streamning using :ets.lookup for memory UTXOs retrieval

### DIFF
--- a/lib/archethic/utxo.ex
+++ b/lib/archethic/utxo.ex
@@ -250,12 +250,12 @@ defmodule Archethic.UTXO do
   """
   @spec stream_unspent_outputs(binary()) :: list(VersionedUnspentOutput.t())
   def stream_unspent_outputs(address) do
-    mem_stream = MemoryLedger.stream_unspent_outputs(address)
+    case MemoryLedger.get_unspent_outputs(address) do
+      [] ->
+        DBLedger.stream(address)
 
-    if Enum.empty?(mem_stream) do
-      DBLedger.stream(address)
-    else
-      mem_stream
+      memory_utxos ->
+        memory_utxos
     end
   end
 

--- a/lib/archethic/utxo/memory_ledger.ex
+++ b/lib/archethic/utxo/memory_ledger.ex
@@ -122,31 +122,11 @@ defmodule Archethic.UTXO.MemoryLedger do
   @doc """
   Returns the list of all the inputs which have not been consumed for the given chain's address
   """
-  @spec stream_unspent_outputs(binary()) :: Enumerable.t() | list(VersionedUnspentOutput.t())
-  def stream_unspent_outputs(genesis_address) do
-    match_pattern = [{{:"$1", :"$2"}, [{:==, :"$1", genesis_address}], [:"$2"]}]
-
-    Stream.resource(
-      fn ->
-        # Fix the table to avoid "invalid continuation" error
-        # source: https://www.erlang.org/doc/man/ets#safe_fixtable-2
-        :ets.safe_fixtable(@table_name, true)
-        :ets.select(@table_name, match_pattern, 1)
-      end,
-      &do_stream_genesis_utxo/1,
-      fn _ ->
-        :ets.safe_fixtable(@table_name, false)
-        :ok
-      end
-    )
-  end
-
-  defp do_stream_genesis_utxo(:"$end_of_table") do
-    {:halt, :"$end_of_table"}
-  end
-
-  defp do_stream_genesis_utxo({utxo, continuation}) do
-    {utxo, :ets.select(continuation)}
+  @spec get_unspent_outputs(binary()) :: list(VersionedUnspentOutput.t())
+  def get_unspent_outputs(genesis_address) do
+    @table_name
+    |> :ets.lookup(genesis_address)
+    |> Enum.map(fn {_, utxo} -> utxo end)
   end
 
   @spec get_genesis_stats(binary()) :: %{size: non_neg_integer()}

--- a/test/archethic/utxo/loader_test.exs
+++ b/test/archethic/utxo/loader_test.exs
@@ -46,7 +46,7 @@ defmodule Archethic.UTXO.LoaderTest do
 
       Loader.add_utxo(utxo, "@Alice0")
 
-      assert [^utxo] = "@Alice0" |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+      assert [^utxo] = MemoryLedger.get_unspent_outputs("@Alice0")
       assert_receive {:append, "@Alice0", ^utxo}
     end
   end
@@ -118,10 +118,7 @@ defmodule Archethic.UTXO.LoaderTest do
                %VersionedUnspentOutput{
                  unspent_output: %UnspentOutput{from: ^tx_address, amount: 90_000_000}
                }
-             ] =
-               genesis_address
-               |> MemoryLedger.stream_unspent_outputs()
-               |> Enum.to_list()
+             ] = MemoryLedger.get_unspent_outputs(genesis_address)
     end
 
     test "should consumed inputs and flush after memory threshold" do
@@ -148,7 +145,7 @@ defmodule Archethic.UTXO.LoaderTest do
 
       Enum.each(utxos, fn utxo -> Loader.add_utxo(utxo, genesis_address) end)
 
-      assert genesis_address |> MemoryLedger.stream_unspent_outputs() |> Enum.empty?()
+      assert [] = MemoryLedger.get_unspent_outputs(genesis_address)
       assert 5 = agent_pid |> Agent.get(& &1) |> length()
 
       me = self()
@@ -257,7 +254,7 @@ defmodule Archethic.UTXO.LoaderTest do
 
       Enum.each(utxos, fn utxo -> Loader.add_utxo(utxo, genesis_address) end)
 
-      assert genesis_address |> MemoryLedger.stream_unspent_outputs() |> Enum.empty?()
+      assert [] = MemoryLedger.get_unspent_outputs(genesis_address)
       assert 4 = agent_pid |> Agent.get(& &1) |> length()
 
       me = self()

--- a/test/archethic/utxo_test.exs
+++ b/test/archethic/utxo_test.exs
@@ -115,14 +115,9 @@ defmodule Archethic.UTXOTest do
                      type: :UCO
                    }
                  }
-               ] =
-                 destination_genesis_address
-                 |> MemoryLedger.stream_unspent_outputs()
-                 |> Enum.to_list()
+               ] = MemoryLedger.get_unspent_outputs(destination_genesis_address)
 
-        assert transaction_genesis_address
-               |> MemoryLedger.stream_unspent_outputs()
-               |> Enum.empty?()
+        assert [] = MemoryLedger.get_unspent_outputs(transaction_genesis_address)
 
         assert_receive {:append_utxo, ^destination_genesis_address,
                         %VersionedUnspentOutput{
@@ -208,14 +203,9 @@ defmodule Archethic.UTXOTest do
                      amount: 300_000_000
                    }
                  }
-               ] =
-                 transaction_genesis_address
-                 |> MemoryLedger.stream_unspent_outputs()
-                 |> Enum.to_list()
+               ] = MemoryLedger.get_unspent_outputs(transaction_genesis_address)
 
-        assert destination_genesis_address
-               |> MemoryLedger.stream_unspent_outputs()
-               |> Enum.empty?()
+        assert [] = MemoryLedger.get_unspent_outputs(destination_genesis_address)
 
         assert_receive {:flush_outputs, ^transaction_genesis_address,
                         [
@@ -342,10 +332,7 @@ defmodule Archethic.UTXOTest do
                      amount: 100_000_000
                    }
                  }
-               ] =
-                 transaction_genesis_address
-                 |> MemoryLedger.stream_unspent_outputs()
-                 |> Enum.to_list()
+               ] = MemoryLedger.get_unspent_outputs(transaction_genesis_address)
 
         UTXO.load_transaction(tx2, transaction_genesis_address)
 
@@ -358,10 +345,7 @@ defmodule Archethic.UTXOTest do
                      timestamp: ~U[2023-09-12 05:00:00.000Z]
                    }
                  }
-               ] =
-                 transaction_genesis_address
-                 |> MemoryLedger.stream_unspent_outputs()
-                 |> Enum.to_list()
+               ] = MemoryLedger.get_unspent_outputs(transaction_genesis_address)
       end
     end
 
@@ -401,10 +385,7 @@ defmodule Archethic.UTXOTest do
                  %VersionedUnspentOutput{
                    unspent_output: %UnspentOutput{from: ^transaction_address, type: :call}
                  }
-               ] =
-                 destination_genesis_address
-                 |> MemoryLedger.stream_unspent_outputs()
-                 |> Enum.to_list()
+               ] = MemoryLedger.get_unspent_outputs(destination_genesis_address)
 
         assert_receive {:append_utxo, ^destination_genesis_address,
                         %VersionedUnspentOutput{
@@ -551,13 +532,12 @@ defmodule Archethic.UTXOTest do
         UTXO.load_transaction(tx, transaction_genesis)
 
         assert [%VersionedUnspentOutput{unspent_output: ^chain1_utxo}] =
-                 destination1_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+                 destination1_genesis |> MemoryLedger.get_unspent_outputs()
 
-        assert [] =
-                 destination2_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+        assert [] = destination2_genesis |> MemoryLedger.get_unspent_outputs()
 
         assert [%VersionedUnspentOutput{unspent_output: ^chain3_utxo}] =
-                 destination3_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+                 destination3_genesis |> MemoryLedger.get_unspent_outputs()
       end
     end
 
@@ -707,13 +687,12 @@ defmodule Archethic.UTXOTest do
         UTXO.load_transaction(tx, transaction_genesis)
 
         assert [%VersionedUnspentOutput{unspent_output: ^chain1_utxo}] =
-                 destination1_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+                 destination1_genesis |> MemoryLedger.get_unspent_outputs()
 
-        assert [] =
-                 destination2_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+        assert [] = destination2_genesis |> MemoryLedger.get_unspent_outputs()
 
         assert [%VersionedUnspentOutput{unspent_output: ^chain3_utxo}] =
-                 destination3_genesis |> MemoryLedger.stream_unspent_outputs() |> Enum.to_list()
+                 destination3_genesis |> MemoryLedger.get_unspent_outputs()
       end
     end
   end


### PR DESCRIPTION
# Description

Improve performance of UTXO lookup using ets lookup instead of select match

## Type of change

Enhancements

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
