### PR TITLE
Fix get balance when amount is nil on the chain page

### DIFF
--- a/lib/archethic_web/explorer/live/chains/transaction_chain_live.ex
+++ b/lib/archethic_web/explorer/live/chains/transaction_chain_live.ex
@@ -137,7 +137,7 @@ defmodule ArchethicWeb.Explorer.TransactionChainLive do
 
   defp get_balance(utxos) do
     Enum.reduce(utxos, %{}, fn
-      %UnspentOutput{type: type, amount: amount}, acc ->
+      %UnspentOutput{type: type, amount: amount}, acc when amount != nil ->
         Map.update(acc, type, amount, &(&1 + amount))
 
       _, acc ->


### PR DESCRIPTION
# Description

Fix get balance with amount == nil on the transaction chain page on the exploreer

## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
