### PR TITLE
Add consumed_utxo control also for recipient

### DIFF
--- a/lib/archethic/utxo.ex
+++ b/lib/archethic/utxo.ex
@@ -115,8 +115,11 @@ defmodule Archethic.UTXO do
        ) do
     recipients
     |> Enum.each(fn recipient ->
-      if Election.chain_storage_node?(recipient, node_public_key, authorized_nodes) do
-        %UnspentOutput{from: address, type: :call, timestamp: timestamp}
+      utxo = %UnspentOutput{from: address, type: :call, timestamp: timestamp}
+
+      with true <- Election.chain_storage_node?(recipient, node_public_key, authorized_nodes),
+           false <- utxo_consumed?(recipient, utxo) do
+        utxo
         |> VersionedUnspentOutput.wrap_unspent_output(protocol_version)
         |> Loader.add_utxo(recipient)
       end


### PR DESCRIPTION
# Description

Add control to ensure a call has not been already consumed in UTXO

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
