### PR TITLE
Wrap interpreter execution in a task to isolate calls

### DIFF
--- a/test/archethic/beacon_chain/subset/stats_collector_test.exs
+++ b/test/archethic/beacon_chain/subset/stats_collector_test.exs
@@ -32,15 +32,6 @@ defmodule Archethic.BeaconChain.Subset.StatsCollectorTest do
       authorization_date: DateTime.utc_now() |> DateTime.add(-1, :day)
     })
 
-    on_exit(fn ->
-      # global process to reset
-      Registry.select(Archethic.Utils.JobCacheRegistry, [{{:_, :"$1", :_}, [], [:"$1"]}])
-      |> Enum.each(fn pid -> Process.exit(pid, :kill) end)
-
-      # sleep a little because the JobCacheRegistry is informed asynchronously
-      Process.sleep(50)
-    end)
-
     {:ok, %{pid: pid}}
   end
 

--- a/test/archethic/contracts/interpreter/library/common/crypto_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/crypto_test.exs
@@ -68,7 +68,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CryptoTest do
       end
       """
 
-      contract = ContractFactory.create_valid_contract_tx(code) |> Contract.from_transaction!()
+      contract =
+        ContractFactory.create_valid_contract_tx(code, seed: "seed")
+        |> Contract.from_transaction!()
 
       trigger_tx = TransactionFactory.create_valid_transaction([], content: "I'll be signed !")
 
@@ -112,7 +114,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CryptoTest do
       end
       """
 
-      contract = ContractFactory.create_valid_contract_tx(code) |> Contract.from_transaction!()
+      contract =
+        ContractFactory.create_valid_contract_tx(code, seed: "seed")
+        |> Contract.from_transaction!()
 
       trigger_tx = TransactionFactory.create_valid_transaction([], content: "I'll be hmacked !")
 
@@ -138,7 +142,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CryptoTest do
       end
       """
 
-      contract = ContractFactory.create_valid_contract_tx(code) |> Contract.from_transaction!()
+      contract =
+        ContractFactory.create_valid_contract_tx(code, seed: "seed")
+        |> Contract.from_transaction!()
 
       trigger_tx = TransactionFactory.create_valid_transaction([], content: "I'll be hmacked !")
 

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -731,7 +731,7 @@ defmodule Archethic.ContractsTest do
           end
         )
 
-      assert {:error, %Failure{user_friendly_error: "Function timed-out"}} =
+      assert {:error, %Failure{user_friendly_error: "Function's execution timed-out"}} =
                Contracts.execute_function(contract_with_sleep, "meaning_of_life", [])
     end
 

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -228,6 +228,13 @@ defmodule ArchethicCase do
     start_supervised!(TransactionSubscriber)
     start_supervised!(MemoryLedger)
     start_supervised!(Loader)
+
+    on_exit(:terminate_jobcache, fn ->
+      # global process to reset
+      Registry.select(Archethic.Utils.JobCacheRegistry, [{{:_, :"$1", :_}, [], [:"$1"]}])
+      |> Enum.each(fn pid -> Process.exit(pid, :kill) end)
+    end)
+
     :ok
   end
 


### PR DESCRIPTION
# Description

Fix smart contract execution to be run inside a task to avoid intepreter's process limitations

This way the code's execution is isolated and multiple run from condition, actions and after contract renewal will be independent of 
the worker being or not in the same process.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
