### PR TITLE
Improve fetch genesis address

### DIFF
--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -63,7 +63,10 @@ defmodule Archethic.DB do
   @callback get_last_chain_address(binary(), DateTime.t()) :: {binary(), DateTime.t()}
   @callback get_last_chain_public_key(binary()) :: Crypto.key()
   @callback get_last_chain_public_key(binary(), DateTime.t()) :: Crypto.key()
-  @callback get_genesis_address(binary()) :: binary()
+  @callback get_genesis_address(address :: Crypto.prepended_hash()) ::
+              genesis_address :: Crypto.prepended_hash()
+  @callback find_genesis_address(address :: Crypto.prepended_hash()) ::
+              {:ok, genesis_address :: Crypto.prepended_hash()} | {:error, :not_found}
   @callback get_first_public_key(Crypto.key()) :: binary()
   @callback register_stats(DateTime.t(), float(), non_neg_integer(), non_neg_integer()) :: :ok
   @callback get_latest_tps() :: float()

--- a/lib/archethic/db/embedded_impl.ex
+++ b/lib/archethic/db/embedded_impl.ex
@@ -274,11 +274,23 @@ defmodule Archethic.DB.EmbeddedImpl do
   end
 
   @doc """
-  Return the first address of given chain's address
+  Return the genesis address of given chain's address
+
+  If no genesis address is found, the given address is returned by default
   """
-  @spec get_genesis_address(address :: binary()) :: binary()
+  @spec get_genesis_address(address :: Crypto.prepended_hash()) ::
+          genesis_address :: Crypto.prepended_hash()
   def get_genesis_address(address) when is_binary(address) do
     ChainIndex.get_genesis_address(address, filepath())
+  end
+
+  @doc """
+  Return the genesis address of given chain's address
+  """
+  @spec find_genesis_address(address :: Crypto.prepended_hash()) ::
+          {:ok, genesis_address :: Crypto.prepended_hash()} | {:error, :not_found}
+  def find_genesis_address(address) when is_binary(address) do
+    ChainIndex.find_genesis_address(address, filepath())
   end
 
   @doc """

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -208,9 +208,19 @@ defmodule Archethic.TransactionChain do
 
   @doc """
   Get the genesis address from a given chain address
+
+  If no genesis address is found, the given address is returned by default
   """
-  @spec get_genesis_address(binary()) :: binary()
+  @spec get_genesis_address(address :: Crypto.prepended_hash()) ::
+          genesis_address :: Crypto.prepended_hash()
   defdelegate get_genesis_address(address), to: DB
+
+  @doc """
+  Get the genesis address from a given chain address
+  """
+  @spec find_genesis_address(address :: Crypto.prepended_hash()) ::
+          {:ok, genesis_address :: Crypto.prepended_hash()} | {:error, :not_found}
+  defdelegate find_genesis_address(address), to: DB
 
   @doc """
   Retrieve the last transaction address for a chain stored locally

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -813,8 +813,8 @@ defmodule Archethic.TransactionChain do
   @spec fetch_genesis_address(address :: binary(), list(Node.t())) ::
           {:ok, binary()} | {:error, :network_issue}
   def fetch_genesis_address(address, nodes) when is_binary(address) do
-    case get_genesis_address(address) do
-      ^address ->
+    case find_genesis_address(address) do
+      {:error, :not_found} ->
         conflict_resolver = fn results ->
           Enum.min_by(results, & &1.timestamp, DateTime)
         end
@@ -827,8 +827,8 @@ defmodule Archethic.TransactionChain do
             {:error, :network_issue}
         end
 
-      genesis_address ->
-        {:ok, genesis_address}
+      res ->
+        res
     end
   end
 

--- a/test/archethic/contracts/interpreter/legacy/library_test.exs
+++ b/test/archethic/contracts/interpreter/legacy/library_test.exs
@@ -50,12 +50,11 @@ defmodule Archethic.Contracts.Interpreter.Legacy.LibraryTest do
 
       MockDB
       |> stub(:get_transaction, fn _, _, _ -> {:ok, tx} end)
-      |> stub(:get_genesis_address, fn _ -> genesis_address end)
+      |> stub(:find_genesis_address, fn _ -> {:ok, genesis_address} end)
 
       {:ok, %{id: token_id}} = Utils.get_token_properties(genesis_address, tx)
 
-      assert token_id ==
-               Library.get_token_id(tx.address)
+      assert token_id == Library.get_token_id(tx.address)
     end
   end
 

--- a/test/archethic/contracts/interpreter/library/common/token_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/token_test.exs
@@ -62,7 +62,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TokenTest do
         )
 
       MockDB
-      |> expect(:get_genesis_address, fn ^token_address -> genesis_address end)
+      |> expect(:find_genesis_address, fn ^token_address -> {:ok, genesis_address} end)
       |> stub(:get_transaction, fn ^token_address, _, _ -> {:ok, tx} end)
 
       {:ok, %{id: token_id}} = Utils.get_token_properties(genesis_address, tx)

--- a/test/archethic/utxo_test.exs
+++ b/test/archethic/utxo_test.exs
@@ -644,10 +644,10 @@ defmodule Archethic.UTXOTest do
         |> set_ledger_operations_and_version([chain3_utxo])
 
       MockDB
-      |> expect(:get_genesis_address, 3, fn
-        ^destination1_address -> destination1_genesis
-        ^destination2_address -> destination2_genesis
-        ^destination3_address -> destination3_genesis
+      |> expect(:find_genesis_address, 3, fn
+        ^destination1_address -> {:ok, destination1_genesis}
+        ^destination2_address -> {:ok, destination2_genesis}
+        ^destination3_address -> {:ok, destination3_genesis}
       end)
       |> expect(:get_last_chain_address, 3, fn
         # Destination 1 does not have transaction after utxo timestamp so it will be ingested

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -53,6 +53,7 @@ defmodule ArchethicCase do
     |> stub(:get_last_chain_address, fn addr, _ -> {addr, DateTime.utc_now()} end)
     |> stub(:get_first_public_key, fn pub -> pub end)
     |> stub(:get_genesis_address, fn addr -> addr end)
+    |> stub(:find_genesis_address, fn _ -> {:error, :not_found} end)
     |> stub(:chain_size, fn _ -> 0 end)
     |> stub(:list_transactions_by_type, fn _, _ -> [] end)
     |> stub(:list_chain_addresses, fn _ -> [] end)


### PR DESCRIPTION
# Description

Created a new function `DB.find_genesis_address` returning a tuple instead of a default value
This function is used in `TransactionChain.fetch_genesis_address` to improve performance when the requested address is already a genesis address that can be found in local DB

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
