### PR TITLE
Improve mining timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -142,6 +142,8 @@ config :archethic, ArchethicWeb.Endpoint,
 
 config :archethic, Archethic.Mining.StandaloneWorkflow, global_timeout: 10_000
 
+config :archethic, Archethic.Mining, start_mining_message_drift: 5_000
+
 config :archethic, Archethic.Mining.DistributedWorkflow,
   global_timeout: 60_000,
   coordinator_timeout_supplement: 2_000,

--- a/config/config.exs
+++ b/config/config.exs
@@ -142,12 +142,12 @@ config :archethic, ArchethicWeb.Endpoint,
 
 config :archethic, Archethic.Mining.StandaloneWorkflow, global_timeout: 10_000
 
-config :archethic, Archethic.Mining, start_mining_message_drift: 5_000
+config :archethic, Archethic.Mining, start_mining_message_drift: 4_000
 
 config :archethic, Archethic.Mining.DistributedWorkflow,
   global_timeout: 60_000,
-  coordinator_timeout_supplement: 2_000,
-  context_notification_timeout: 3_000
+  coordinator_timeout_supplement: 7_000,
+  context_notification_timeout: 4_000
 
 config :archethic, Archethic.OracleChain,
   services: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -55,6 +55,13 @@ config :archethic, Archethic.Crypto,
     ]
   ]
 
+config :archethic, Archethic.Mining, start_mining_message_drift: 100
+
+config :archethic, Archethic.Mining.DistributedWorkflow,
+  global_timeout: 60_000,
+  coordinator_timeout_supplement: 200,
+  context_notification_timeout: 100
+
 config :archethic, MockCrypto.NodeKeystore, enabled: false
 config :archethic, MockCrypto.NodeKeystore.Origin, enabled: false
 config :archethic, MockCrypto.SharedSecretsKeystore, enabled: false

--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -121,7 +121,8 @@ defmodule Archethic do
       validation_node_public_keys: Enum.map(validation_nodes, & &1.last_public_key),
       network_chains_view_hash: NetworkView.get_chains_hash(),
       p2p_view_hash: NetworkView.get_p2p_hash(),
-      contract_context: contract_context
+      contract_context: contract_context,
+      ref_timestamp: DateTime.utc_now()
     }
 
     Task.Supervisor.async_stream_nolink(

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -47,9 +47,10 @@ defmodule Archethic.Mining do
           transaction :: Transaction.t(),
           welcome_node_public_key :: Crypto.key(),
           validation_node_public_keys :: list(Crypto.key()),
-          contract_context :: nil | Contract.Context.t()
+          contract_context :: nil | Contract.Context.t(),
+          ref_timestamp :: DateTime.t()
         ) :: {:ok, pid()}
-  def start(tx = %Transaction{}, welcome_node_public_key, [_ | []], contract_context) do
+  def start(tx = %Transaction{}, welcome_node_public_key, [_ | []], contract_context, _) do
     StandaloneWorkflow.start_link(
       transaction: tx,
       welcome_node: P2P.get_node_info!(welcome_node_public_key),
@@ -61,7 +62,8 @@ defmodule Archethic.Mining do
         tx = %Transaction{},
         welcome_node_public_key,
         validation_node_public_keys,
-        contract_context
+        contract_context,
+        ref_timestamp
       )
       when is_binary(welcome_node_public_key) and is_list(validation_node_public_keys) do
     DynamicSupervisor.start_child(WorkerSupervisor, {
@@ -70,7 +72,8 @@ defmodule Archethic.Mining do
       welcome_node: P2P.get_node_info!(welcome_node_public_key),
       validation_nodes: Enum.map(validation_node_public_keys, &P2P.get_node_info!/1),
       node_public_key: Crypto.last_node_public_key(),
-      contract_context: contract_context
+      contract_context: contract_context,
+      ref_timestamp: ref_timestamp
     })
   end
 

--- a/lib/archethic/p2p/message/start_mining.ex
+++ b/lib/archethic/p2p/message/start_mining.ex
@@ -68,7 +68,15 @@ defmodule Archethic.P2P.Message.StartMining do
          :ok <- check_current_node_is_elected(validation_nodes),
          :ok <- check_not_already_mining(tx.address),
          :ok <- Mining.request_chain_lock(tx) do
-      {:ok, _} = Mining.start(tx, welcome_node_public_key, validation_nodes, contract_context)
+      {:ok, _} =
+        Mining.start(
+          tx,
+          welcome_node_public_key,
+          validation_nodes,
+          contract_context,
+          ref_timestamp
+        )
+
       %Ok{}
     else
       {:error, reason} -> get_response(tx, reason)

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -161,7 +161,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
         Workflow.start_link(
           transaction: tx,
           welcome_node: %Node{},
-          validation_nodes: validation_nodes
+          validation_nodes: validation_nodes,
+          ref_timestamp: DateTime.utc_now()
         )
 
       assert {_,
@@ -257,7 +258,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           transaction: tx,
           welcome_node_public_key: welcome_node,
           validation_nodes: validation_nodes,
-          node_public_key: List.first(validation_nodes).last_public_key
+          node_public_key: List.first(validation_nodes).last_public_key,
+          ref_timestamp: DateTime.utc_now()
         )
 
       previous_storage_nodes = [
@@ -365,7 +367,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           transaction: tx,
           welcome_node: welcome_node,
           validation_nodes: validation_nodes,
-          node_public_key: List.first(validation_nodes).last_public_key
+          node_public_key: List.first(validation_nodes).last_public_key,
+          ref_timestamp: DateTime.utc_now()
         )
 
       previous_storage_nodes = [
@@ -491,7 +494,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           transaction: tx,
           welcome_node: welcome_node,
           validation_nodes: validation_nodes,
-          node_public_key: List.first(validation_nodes).last_public_key
+          node_public_key: List.first(validation_nodes).last_public_key,
+          ref_timestamp: DateTime.utc_now()
         )
 
       previous_storage_nodes = [
@@ -533,7 +537,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
         <<>>
       )
 
-      Process.sleep(4_000)
+      Process.sleep(500)
 
       {:wait_cross_validation_stamps,
        %{
@@ -659,7 +663,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           transaction: tx,
           welcome_node: welcome_node,
           validation_nodes: validation_nodes,
-          node_public_key: List.first(validation_nodes).last_public_key
+          node_public_key: List.first(validation_nodes).last_public_key,
+          ref_timestamp: DateTime.utc_now()
         )
 
       {:ok, cross_validator_pid} =
@@ -667,7 +672,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           transaction: tx,
           welcome_node: welcome_node,
           validation_nodes: validation_nodes,
-          node_public_key: List.last(validation_nodes).last_public_key
+          node_public_key: List.last(validation_nodes).last_public_key,
+          ref_timestamp: DateTime.utc_now()
         )
 
       Workflow.add_mining_context(
@@ -922,7 +928,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           transaction: tx,
           welcome_node: welcome_node,
           validation_nodes: validation_nodes,
-          node_public_key: List.first(validation_nodes).last_public_key
+          node_public_key: List.first(validation_nodes).last_public_key,
+          ref_timestamp: DateTime.utc_now()
         )
 
       {:ok, cross_validator_pid} =
@@ -930,7 +937,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           transaction: tx,
           welcome_node: welcome_node,
           validation_nodes: validation_nodes,
-          node_public_key: List.last(validation_nodes).last_public_key
+          node_public_key: List.last(validation_nodes).last_public_key,
+          ref_timestamp: DateTime.utc_now()
         )
 
       previous_storage_nodes = [
@@ -1093,7 +1101,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           transaction: context.transaction,
           welcome_node: context.welcome_node,
           validation_nodes: [context.coordinator_node | context.cross_validation_nodes],
-          node_public_key: context.coordinator_node.last_public_key
+          node_public_key: context.coordinator_node.last_public_key,
+          ref_timestamp: DateTime.utc_now()
         )
 
       :sys.replace_state(coordinator_pid, fn {:coordinator, state} ->
@@ -1173,7 +1182,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           transaction: context.transaction,
           welcome_node: context.welcome_node,
           validation_nodes: [context.coordinator_node | context.cross_validation_nodes],
-          node_public_key: context.coordinator_node.last_public_key
+          node_public_key: context.coordinator_node.last_public_key,
+          ref_timestamp: DateTime.utc_now()
         )
 
       :sys.replace_state(coordinator_pid, fn {:coordinator, state} ->

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -181,6 +181,7 @@ defmodule Archethic.P2P.MessageTest do
 
       network_hash = :crypto.hash(:sha256, "networkview")
       p2p_hash = :crypto.hash(:sha256, "p2pview")
+      ref_timestamp = DateTime.utc_now() |> DateTime.truncate(:millisecond)
 
       # no context
       assert %StartMining{
@@ -188,14 +189,16 @@ defmodule Archethic.P2P.MessageTest do
                welcome_node_public_key: welcome_node_public_key,
                validation_node_public_keys: validation_node_public_keys,
                network_chains_view_hash: network_hash,
-               p2p_view_hash: p2p_hash
+               p2p_view_hash: p2p_hash,
+               ref_timestamp: ref_timestamp
              } ==
                %StartMining{
                  transaction: tx,
                  welcome_node_public_key: welcome_node_public_key,
                  validation_node_public_keys: validation_node_public_keys,
                  network_chains_view_hash: network_hash,
-                 p2p_view_hash: p2p_hash
+                 p2p_view_hash: p2p_hash,
+                 ref_timestamp: ref_timestamp
                }
                |> Message.encode()
                |> Message.decode()
@@ -214,7 +217,8 @@ defmodule Archethic.P2P.MessageTest do
                validation_node_public_keys: validation_node_public_keys,
                network_chains_view_hash: network_hash,
                p2p_view_hash: p2p_hash,
-               contract_context: ctx
+               contract_context: ctx,
+               ref_timestamp: ref_timestamp
              } ==
                %StartMining{
                  transaction: tx,
@@ -222,7 +226,8 @@ defmodule Archethic.P2P.MessageTest do
                  validation_node_public_keys: validation_node_public_keys,
                  network_chains_view_hash: network_hash,
                  p2p_view_hash: p2p_hash,
-                 contract_context: ctx
+                 contract_context: ctx,
+                 ref_timestamp: ref_timestamp
                }
                |> Message.encode()
                |> Message.decode()


### PR DESCRIPTION
# Description

Improve mining timeout with a reference timeout. As it all the nodes will have the timeout at the same time.
Also placed prior validation after building context
Also updated the mining timeout with new values based on new smart contract validation

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Started 3 nodes, launched some benchmark, it worked well.
Stopped one and did some faucet, it worked well after coordinator or context timeout

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
