### PR TITLE
Compare consumed input without protocol version

### DIFF
--- a/lib/archethic/utxo/loader.ex
+++ b/lib/archethic/utxo/loader.ex
@@ -108,10 +108,12 @@ defmodule Archethic.UTXO.Loader do
 
     transaction_unspent_outputs = stamp_unspent_outputs(stamp, transaction_address)
 
+    consumed_inputs = VersionedUnspentOutput.unwrap_unspent_outputs(consumed_inputs)
+
     new_unspent_outputs =
       genesis_address
       |> UTXO.stream_unspent_outputs()
-      |> Stream.reject(&Enum.member?(consumed_inputs, &1))
+      |> Stream.reject(&Enum.member?(consumed_inputs, &1.unspent_output))
       |> Enum.concat(transaction_unspent_outputs)
 
     # We compact all the unspent outputs into new ones, cleaning the previous unspent outputs

--- a/lib/archethic/utxo/memory_ledger.ex
+++ b/lib/archethic/utxo/memory_ledger.ex
@@ -93,11 +93,11 @@ defmodule Archethic.UTXO.MemoryLedger do
   """
   @spec remove_consumed_inputs(
           genesis_address :: Crypto.prepended_hash(),
-          utxos :: list(VersionedUnspentOutput.t())
+          consumed_inputs :: list(UnspentOutput.t())
         ) :: :ok
-  def remove_consumed_inputs(genesis_address, utxos) do
+  def remove_consumed_inputs(genesis_address, consumed_inputs) do
     :ets.lookup(@table_name, genesis_address)
-    |> Enum.filter(fn {_, utxo} -> Enum.member?(utxos, utxo) end)
+    |> Enum.filter(fn {_, utxo} -> Enum.member?(consumed_inputs, utxo.unspent_output) end)
     |> Enum.each(fn elem = {_, utxo} ->
       size = :erlang.external_size(utxo)
       :ets.delete_object(@table_name, elem)

--- a/test/archethic/contracts/worker_test.exs
+++ b/test/archethic/contracts/worker_test.exs
@@ -17,6 +17,8 @@ defmodule Archethic.Contracts.WorkerTest do
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.Transaction.ValidationStamp
 
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
+
   alias Archethic.TransactionChain.TransactionData.Ledger
   alias Archethic.TransactionChain.TransactionData.Recipient
   alias Archethic.TransactionChain.TransactionData.TokenLedger
@@ -881,6 +883,7 @@ defmodule Archethic.Contracts.WorkerTest do
               genesis
               |> UTXO.stream_unspent_outputs()
               |> Enum.find(&(&1.unspent_output.from == valid_trigger_tx_address))
+              |> VersionedUnspentOutput.unwrap_unspent_output()
 
             UTXO.MemoryLedger.remove_consumed_inputs(genesis, [utxo])
             send(me, :transaction_valid_sent)

--- a/test/archethic/utxo/memory_ledger_test.exs
+++ b/test/archethic/utxo/memory_ledger_test.exs
@@ -219,7 +219,9 @@ defmodule Archethic.UTXO.MemoryLedgerTest do
 
       assert %{size: ^expected_size} = MemoryLedger.get_genesis_stats(address)
 
-      MemoryLedger.remove_consumed_inputs(address, [utxo2])
+      MemoryLedger.remove_consumed_inputs(address, [
+        VersionedUnspentOutput.unwrap_unspent_output(utxo2)
+      ])
 
       expected_size = div(expected_size, 2)
 


### PR DESCRIPTION
# Description

To avoid issue with consumed inputs that could have a wrong protocol version, the consumed utxos are compared without using the protocol version

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
