### PR TITLE
Add a metric for the sum of all the calls queued for the workers

### DIFF
--- a/lib/archethic/telemetry.ex
+++ b/lib/archethic/telemetry.ex
@@ -92,6 +92,7 @@ defmodule Archethic.Telemetry do
         ]
       ),
       last_value("archethic.contract.queued_calls"),
+      last_value("archethic.contract.invalid_calls"),
       distribution("archethic.contract.parsing.duration",
         unit: {:native, :millisecond},
         measurement: :duration,

--- a/lib/archethic/telemetry.ex
+++ b/lib/archethic/telemetry.ex
@@ -10,12 +10,19 @@ defmodule Archethic.Telemetry do
 
   def init(_arg) do
     [
-      {TelemetryMetricsPrometheus.Core, [metrics: metrics()]}
+      {TelemetryMetricsPrometheus.Core, [metrics: metrics()]},
+      {:telemetry_poller, measurements: periodic_metrics(), period: 60_000}
     ]
     |> Supervisor.init(strategy: :one_for_one)
   end
 
-  def metrics do
+  defp periodic_metrics do
+    [
+      {Archethic.Contracts, :maximum_calls_in_queue, []}
+    ]
+  end
+
+  defp metrics do
     [
       # VM
       last_value("vm.memory.atom", unit: :byte),
@@ -35,6 +42,7 @@ defmodule Archethic.Telemetry do
       last_value("vm.total_run_queue_lengths.total"),
       last_value("vm.total_run_queue_lengths.cpu"),
       last_value("vm.total_run_queue_lengths.io"),
+
       # Archethic
       distribution("archethic.election.validation_nodes.duration",
         unit: {:native, :millisecond},
@@ -83,6 +91,7 @@ defmodule Archethic.Telemetry do
           buckets: [500, 700, 1000, 1500, 2000, 3000, 5000, 10000]
         ]
       ),
+      last_value("archethic.contract.queued_calls"),
       distribution("archethic.contract.parsing.duration",
         unit: {:native, :millisecond},
         measurement: :duration,


### PR DESCRIPTION
# Description

Add a metric to count the number of calls in the workers queues. 

## Type of change

- New feature

# How Has This Been Tested?

Manually tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
