### PR TITLE
Ensure enough funds during smart contract call validation

### DIFF
--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -181,16 +181,7 @@ defmodule Archethic.Contracts.Interpreter do
           })
 
         {maybe_next_tx, next_state} =
-          case version do
-            0 ->
-              {
-                Legacy.execute_trigger(trigger_code, constants, contract_tx),
-                State.empty()
-              }
-
-            _ ->
-              ActionInterpreter.execute(trigger_code, constants, contract_tx)
-          end
+          do_execute_trigger(version, trigger_code, constants, contract_tx)
 
         logs = Scope.read_global([:logs])
 
@@ -201,6 +192,17 @@ defmodule Archethic.Contracts.Interpreter do
       logs = Scope.read_global([:logs])
 
       {:error, err, __STACKTRACE__, logs}
+  end
+
+  defp do_execute_trigger(0, trigger_code, constants, contract_tx) do
+    {
+      Legacy.execute_trigger(trigger_code, constants, contract_tx),
+      State.empty()
+    }
+  end
+
+  defp do_execute_trigger(_, trigger_code, constants, contract_tx) do
+    ActionInterpreter.execute(trigger_code, constants, contract_tx)
   end
 
   @doc """

--- a/lib/archethic/crypto.ex
+++ b/lib/archethic/crypto.ex
@@ -660,7 +660,6 @@ defmodule Archethic.Crypto do
 
   Invalid message to decrypt or key return an error:
 
-      ```
       iex> cipher =
       ...>   <<20, 95, 27, 87, 71, 195, 100, 164, 225, 201, 163, 220, 15, 111, 201, 224, 41, 34,
       ...>     143, 78, 201, 109, 157, 196, 108, 109, 155, 91, 239, 118, 23, 100, 161, 195, 39, 117,
@@ -670,7 +669,6 @@ defmodule Archethic.Crypto do
       ...> {_, pv} = Crypto.generate_deterministic_keypair("otherseed")
       ...> Crypto.ec_decrypt!(cipher, pv)
       ** (RuntimeError) Decryption failed
-                                                                  ```
   """
   @spec ec_decrypt!(encoded_cipher :: binary(), private_key :: key()) :: binary()
   def ec_decrypt!(encoded_cipher, private_key)

--- a/lib/archethic/governance/code/proposal/parser.ex
+++ b/lib/archethic/governance/code/proposal/parser.ex
@@ -47,11 +47,8 @@ defmodule Archethic.Governance.Code.Proposal.Parser do
       ...> @@ -1,107 +1,107 @@
       ...> "
       ...> |> Parser.get_changes()
-      {:ok, "diff --git a/lib/archethic/governance.ex b/lib/archethic/governance.ex
-                                                                   index 30787f1..6535f52 100644
-                                                                   --- a/lib/archethic/governance.ex
-                                                                   +++ b/lib/archethic/governance.ex
-                                                                   @@ -1,107 +1,107 @@\n"}
+      {:ok,
+       "diff --git a/lib/archethic/governance.ex b/lib/archethic/governance.ex\n index 30787f1..6535f52 100644\n --- a/lib/archethic/governance.ex\n +++ b/lib/archethic/governance.ex\n @@ -1,107 +1,107 @@\n"}
   """
   @spec get_changes(binary()) :: {:ok, binary()} | {:error, :missing_changes}
   def get_changes(content) when is_binary(content) do

--- a/lib/archethic/p2p/message/smart_contract_call_validation.ex
+++ b/lib/archethic/p2p/message/smart_contract_call_validation.ex
@@ -4,7 +4,8 @@ defmodule Archethic.P2P.Message.SmartContractCallValidation do
   """
 
   @type t :: %__MODULE__{
-          status: :ok | {:error, :transaction_not_exists | :invalid_execution},
+          status:
+            :ok | {:error, :transaction_not_exists | :invalid_execution | :insufficient_funds},
           fee: non_neg_integer()
         }
 
@@ -34,6 +35,7 @@ defmodule Archethic.P2P.Message.SmartContractCallValidation do
   defp serialize_status(:ok), do: 0
   defp serialize_status({:error, :transaction_not_exists}), do: 1
   defp serialize_status({:error, :invalid_execution}), do: 2
+  defp serialize_status({:error, :insufficient_funds}), do: 3
 
   @doc """
   Deserialize the encoded message
@@ -66,4 +68,5 @@ defmodule Archethic.P2P.Message.SmartContractCallValidation do
   defp deserialize_status(0), do: :ok
   defp deserialize_status(1), do: {:error, :transaction_not_exists}
   defp deserialize_status(2), do: {:error, :invalid_execution}
+  defp deserialize_status(3), do: {:error, :insufficient_funds}
 end

--- a/test/archethic/p2p/message/validate_smart_contract_call_test.exs
+++ b/test/archethic/p2p/message/validate_smart_contract_call_test.exs
@@ -2,16 +2,28 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
   use ArchethicCase
   import ArchethicCase
 
+  alias Archethic.P2P.Message.UnspentOutputList
+  alias Archethic.P2P.Message.GetUnspentOutputs
   alias Archethic.Mining.Fee
   alias Archethic.P2P
   alias Archethic.P2P.Node
   alias Archethic.P2P.Message.SmartContractCallValidation
   alias Archethic.P2P.Message.ValidateSmartContractCall
 
+  alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
+
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
+
   alias Archethic.TransactionChain.TransactionData.Recipient
+  alias Archethic.TransactionChain.TransactionData.Ledger
+  alias Archethic.TransactionChain.TransactionData.UCOLedger
+  alias Archethic.TransactionChain.TransactionData.UCOLedger.Transfer
 
   alias Archethic.ContractFactory
   alias Archethic.TransactionFactory
+
+  alias Archethic.Utils
 
   doctest ValidateSmartContractCall
 
@@ -223,6 +235,136 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCallTest do
       assert %SmartContractCallValidation{status: {:error, :invalid_execution}, fee: 0} =
                %ValidateSmartContractCall{
                  recipient: %Recipient{address: "@SC1_for_contract_with_invalid_message"},
+                 transaction: incoming_tx,
+                 timestamp: DateTime.utc_now()
+               }
+               |> ValidateSmartContractCall.process(:crypto.strong_rand_bytes(32))
+    end
+
+    test "should return insufficient_funds if contract has not enough funds " do
+      tx =
+        %Transaction{address: contract_address} =
+        ~s"""
+        @version 1
+
+        condition triggered_by: transaction, as: []
+
+        actions triggered_by: transaction do
+          amount = Map.get(transaction.uco_transfers, contract.address)
+          Contract.add_uco_transfer to: transaction.address, amount: amount + 5
+        end
+        """
+        |> ContractFactory.create_valid_contract_tx(seed: random_seed())
+
+      contract_genesis_address = Transaction.previous_address(tx)
+
+      v_utxo =
+        %UnspentOutput{
+          from: random_address(),
+          amount: Utils.to_bigint(3),
+          type: :UCO,
+          timestamp: DateTime.utc_now()
+        }
+        |> VersionedUnspentOutput.wrap_unspent_output(current_protocol_version())
+
+      utxo = %UnspentOutput{
+        from: random_address(),
+        amount: Utils.to_bigint(5),
+        type: :UCO,
+        timestamp: DateTime.utc_now()
+      }
+
+      recipient = %Recipient{address: contract_genesis_address}
+
+      incoming_tx =
+        TransactionFactory.create_valid_transaction([utxo],
+          ledger: %Ledger{
+            uco: %UCOLedger{transfers: [%Transfer{to: contract_address, amount: 4}]}
+          },
+          recipients: [recipient]
+        )
+
+      MockClient
+      |> expect(:send_message, fn _, %GetUnspentOutputs{address: ^contract_genesis_address}, _ ->
+        {:ok, %UnspentOutputList{unspent_outputs: [v_utxo]}}
+      end)
+
+      MockDB
+      |> expect(:get_last_chain_address, fn ^contract_genesis_address ->
+        {contract_address, DateTime.utc_now()}
+      end)
+      |> expect(:get_transaction, fn ^contract_address, _, _ ->
+        {:ok, tx}
+      end)
+
+      assert %SmartContractCallValidation{status: {:error, :insufficient_funds}, fee: 0} =
+               %ValidateSmartContractCall{
+                 recipient: recipient,
+                 transaction: incoming_tx,
+                 timestamp: DateTime.utc_now()
+               }
+               |> ValidateSmartContractCall.process(:crypto.strong_rand_bytes(32))
+    end
+
+    test "should return :ok if contract has enough funds " do
+      tx =
+        %Transaction{address: contract_address} =
+        ~s"""
+        @version 1
+
+        condition triggered_by: transaction, as: []
+
+        actions triggered_by: transaction do
+          amount = Map.get(transaction.uco_transfers, contract.address)
+          Contract.add_uco_transfer to: transaction.address, amount: amount + 1
+        end
+        """
+        |> ContractFactory.create_valid_contract_tx(seed: random_seed())
+
+      contract_genesis_address = Transaction.previous_address(tx)
+
+      v_utxo =
+        %UnspentOutput{
+          from: random_address(),
+          amount: Utils.to_bigint(3),
+          type: :UCO,
+          timestamp: DateTime.utc_now()
+        }
+        |> VersionedUnspentOutput.wrap_unspent_output(current_protocol_version())
+
+      utxo = %UnspentOutput{
+        from: random_address(),
+        amount: Utils.to_bigint(5),
+        type: :UCO,
+        timestamp: DateTime.utc_now()
+      }
+
+      recipient = %Recipient{address: contract_genesis_address}
+
+      incoming_tx =
+        TransactionFactory.create_valid_transaction([utxo],
+          ledger: %Ledger{
+            uco: %UCOLedger{transfers: [%Transfer{to: contract_address, amount: 4}]}
+          },
+          recipients: [recipient]
+        )
+
+      MockClient
+      |> expect(:send_message, fn _, %GetUnspentOutputs{address: ^contract_genesis_address}, _ ->
+        {:ok, %UnspentOutputList{unspent_outputs: [v_utxo]}}
+      end)
+
+      MockDB
+      |> expect(:get_last_chain_address, fn ^contract_genesis_address ->
+        {contract_address, DateTime.utc_now()}
+      end)
+      |> expect(:get_transaction, fn ^contract_address, _, _ ->
+        {:ok, tx}
+      end)
+
+      assert %SmartContractCallValidation{status: :ok, fee: _} =
+               %ValidateSmartContractCall{
+                 recipient: recipient,
                  transaction: incoming_tx,
                  timestamp: DateTime.utc_now()
                }


### PR DESCRIPTION
# Description

This PR aims to fix an issue to accept a smart contract call if the contract doesn't have funds for the transaction triggered by the contract based on the movements.


## Type of change

Please delete options that are not relevant.

- Enhancements

# How Has This Been Tested?

Create a smart contract which send UCO once a trigger transaction is received.
Do not funds the contract with the UCO to send in the action;
If a client call the contract it should be rejected.
Fund more the contract to satisfy the UCO to send in the action
Resent the transaction from the client to call the contract, the contract's transaction should be validated and emitted.

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
