### PR TITLE
API: fix transaction_chain when the paging_address == genesis_address

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -132,18 +132,8 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
     filepath = ChainWriter.chain_path(db_path, genesis_address)
 
     if File.exists?(filepath) do
-      fd = File.open!(filepath, [:binary, :read])
-
       {transactions, more?, paging_address} =
-        case Keyword.get(opts, :order, :asc) do
-          :asc ->
-            process_get_chain(fd, fields, opts, db_path)
-
-          :desc ->
-            process_get_chain_desc(fd, genesis_address, fields, opts, db_path)
-        end
-
-      File.close(fd)
+        get_chain(filepath, db_path, fields, genesis_address, opts)
 
       # we want different metrics for ASC and DESC
       :telemetry.execute([:archethic, :db], %{duration: System.monotonic_time() - start}, %{
@@ -268,6 +258,35 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
     File.close(fd)
 
     tx
+  end
+
+  defp get_chain(filepath, db_path, fields, genesis_address, opts) do
+    fd = File.open!(filepath, [:binary, :read])
+
+    {transactions, more?, paging_address} =
+      case Keyword.get(opts, :order, :asc) do
+        :asc ->
+          # if the paging_address=genesis_address,
+          # the same behaviour as no paging_address
+          opts =
+            case Keyword.get(opts, :paging_address) do
+              ^genesis_address -> Keyword.delete(opts, :paging_address)
+              _ -> opts
+            end
+
+          process_get_chain(fd, fields, opts, db_path)
+
+        :desc ->
+          # if the paging_address=genesis_address,
+          # we return empty
+          case Keyword.get(opts, :paging_address) do
+            ^genesis_address -> {[], false, nil}
+            _ -> process_get_chain_desc(fd, genesis_address, fields, opts, db_path)
+          end
+      end
+
+    File.close(fd)
+    {transactions, more?, paging_address}
   end
 
   defp process_get_chain(fd, fields, opts, db_path) do

--- a/test/archethic/transaction_chain_test.exs
+++ b/test/archethic/transaction_chain_test.exs
@@ -1246,7 +1246,6 @@ defmodule Archethic.TransactionChainTest do
       [{paging_address, _}, _, {address3, _}] = chain_addresses
 
       MockDB
-      |> expect(:get_genesis_address, 0, fn _ -> :ok end)
       |> expect(:list_chain_addresses, 0, fn _ -> :ok end)
 
       assert {:ok, paging_address} ==


### PR DESCRIPTION
# Description

When querying a chain with paging_state = genesis we should act as if paging_state is nil

Example of broken behaviour (testnet data)
```
query {
 transactionChain(
    address: "00006AF4C3AE64D435DA162B27918D6BE3AF8610494E3021148709BBE11A5520334C",
    pagingAddress: "00006AF4C3AE64D435DA162B27918D6BE3AF8610494E3021148709BBE11A5520334C"
  ) {
		address
    
  }
}
```

This should reply the same thing as the following query

```
query {
 transactionChain(
    address: "00006AF4C3AE64D435DA162B27918D6BE3AF8610494E3021148709BBE11A5520334C"
  ) {
		address
  }
}
```

It currently return empty (instead of 2 txs)

## Type of change


- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test + manual test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
