### PR TITLE
Fix flaky tests on uco_price and repair_worker

### DIFF
--- a/test/archethic/oracle_chain/services/uco_price_test.exs
+++ b/test/archethic/oracle_chain/services/uco_price_test.exs
@@ -34,7 +34,7 @@ defmodule Archethic.OracleChain.Services.UCOPriceTest do
         mfa: {MockUCOProvider2, :fetch, [["usd", "eur"]]}
       )
 
-      Process.sleep(1)
+      Process.sleep(10)
 
       assert {:ok, %{"eur" => 0.20, "usd" => 0.12}} = UCOPrice.fetch()
     end
@@ -62,7 +62,7 @@ defmodule Archethic.OracleChain.Services.UCOPriceTest do
         mfa: {MockUCOProvider2, :fetch, [["usd", "eur"]]}
       )
 
-      Process.sleep(1)
+      Process.sleep(10)
 
       assert {:ok, %{"eur" => 0.12346, "usd" => 0.12345}} = UCOPrice.fetch()
     end
@@ -91,7 +91,7 @@ defmodule Archethic.OracleChain.Services.UCOPriceTest do
         mfa: {MockUCOProvider2, :fetch, [["usd", "eur"]]}
       )
 
-      Process.sleep(1)
+      Process.sleep(10)
 
       assert {:ok, %{"eur" => 0.20, "usd" => 0.20}} = UCOPrice.fetch()
     end
@@ -119,7 +119,7 @@ defmodule Archethic.OracleChain.Services.UCOPriceTest do
         mfa: {MockUCOProvider2, :fetch, [["usd", "eur"]]}
       )
 
-      Process.sleep(1)
+      Process.sleep(10)
 
       assert {:ok, %{"eur" => 0.25, "usd" => 0.25}} = UCOPrice.fetch()
     end
@@ -147,7 +147,7 @@ defmodule Archethic.OracleChain.Services.UCOPriceTest do
         mfa: {MockUCOProvider2, :fetch, [["usd", "eur"]]}
       )
 
-      Process.sleep(1)
+      Process.sleep(10)
 
       assert {:error, "no data fetched from any service"} = UCOPrice.fetch()
     end
@@ -177,7 +177,7 @@ defmodule Archethic.OracleChain.Services.UCOPriceTest do
         mfa: {MockUCOProvider2, :fetch, [["usd", "eur"]]}
       )
 
-      Process.sleep(1)
+      Process.sleep(10)
 
       assert UCOPrice.verify?(%{"eur" => 0.25, "usd" => 0.25})
     end
@@ -205,7 +205,7 @@ defmodule Archethic.OracleChain.Services.UCOPriceTest do
         mfa: {MockUCOProvider2, :fetch, [["usd", "eur"]]}
       )
 
-      Process.sleep(1)
+      Process.sleep(10)
 
       refute UCOPrice.verify?(%{"eur" => 0.25, "usd" => 0.25})
     end
@@ -234,7 +234,7 @@ defmodule Archethic.OracleChain.Services.UCOPriceTest do
       mfa: {MockUCOProvider2, :fetch, [["usd", "eur"]]}
     )
 
-    Process.sleep(1)
+    Process.sleep(10)
 
     {result, log} = with_log(fn -> UCOPrice.verify?(%{"eur" => 0.25, "usd" => 0.25}) end)
     assert result == false
@@ -264,7 +264,7 @@ defmodule Archethic.OracleChain.Services.UCOPriceTest do
       mfa: {MockUCOProvider2, :fetch, [["usd", "eur"]]}
     )
 
-    Process.sleep(1)
+    Process.sleep(10)
 
     assert UCOPrice.verify?(%{"eur" => 0.25, "usd" => 0.25})
   end

--- a/test/archethic/self_repair/repair_worker_test.exs
+++ b/test/archethic/self_repair/repair_worker_test.exs
@@ -24,10 +24,16 @@ defmodule Archethic.SelfRepair.RepairWorkerTest do
   test "should replicate the transactions coming from sequential calls" do
     assert 0 = Registry.count(Archethic.SelfRepair.RepairRegistry)
 
-    with_mock(SelfRepair, replicate_transaction: fn _, _, _ -> :ok end) do
+    with_mock(SelfRepair,
+      replicate_transaction: fn _, _, _ ->
+        Process.sleep(10)
+        :ok
+      end
+    ) do
       :ok = RepairWorker.repair_addresses("Alice1", "Alice2", ["Bob1", "Bob2"])
       :ok = RepairWorker.repair_addresses("Alice1", "Alice3", [])
       :ok = RepairWorker.repair_addresses("Alice1", "Alice4", ["Bob3"])
+
       assert 1 = Registry.count(Archethic.SelfRepair.RepairRegistry)
 
       Process.sleep(100)


### PR DESCRIPTION
It's always because the Registry is not updated synchronously.

<img width="980" alt="Capture d’écran 2024-04-19 à 11 27 35" src="https://github.com/archethic-foundation/archethic-node/assets/74045243/e79e00df-a2a4-439c-a6bc-ffe0a233656d">
<img width="1103" alt="Capture d’écran 2024-04-19 à 11 27 19" src="https://github.com/archethic-foundation/archethic-node/assets/74045243/6681ba66-8c04-469f-ad0a-cf10414c547a">
