### PR TITLE
Also fetch the inputs when fetching the transactions

### DIFF
--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -281,6 +281,13 @@ defmodule Archethic.SelfRepair do
             self_repair?: true
           )
 
+        # todo parallelize with fetch_tx
+        :ok =
+          TransactionChain.write_inputs(
+            address,
+            TransactionChain.fetch_inputs(address, storage_nodes)
+          )
+
         update_last_address(address, authorized_nodes)
       else
         Replication.synchronize_io_transaction(tx, genesis_address, self_repair?: true)

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -473,9 +473,7 @@ defmodule Archethic.SelfRepair.Sync do
         # todo: parallelize downloads
         tx = TransactionHandler.download_transaction(attestation, download_nodes)
 
-        inputs =
-          TransactionChain.fetch_inputs(address, download_nodes)
-          |> Enum.map(& &1.input)
+        inputs = TransactionChain.fetch_inputs(address, download_nodes)
 
         consolidated_attestation = consolidate_recipients(attestation, tx)
         {consolidated_attestation, tx, inputs}

--- a/test/archethic/self_repair/sync_test.exs
+++ b/test/archethic/self_repair/sync_test.exs
@@ -623,7 +623,7 @@ defmodule Archethic.SelfRepair.SyncTest do
 
       tx = TransactionFactory.create_valid_transaction()
       tx_address = tx.address
-      tx_summary = TransactionSummary.from_transaction(tx, random_address())
+      tx_summary = TransactionSummary.from_transaction(tx, Transaction.previous_address(tx))
 
       MockClient
       |> expect(:send_message, fn ^node1, %GetTransaction{}, _ ->
@@ -650,7 +650,7 @@ defmodule Archethic.SelfRepair.SyncTest do
 
       MockTransactionLedger
       |> expect(:write_inputs, fn ^tx_address, list ->
-        assert 1 = length(list)
+        assert 1 = Enum.count(list)
         :ok
       end)
 


### PR DESCRIPTION
# Description

Based on the branch of PR #1494  (only 2 commits for this one)
- [ ] Sam told me about a new function get_node_synchronized_before, I think I should use it

Fixes #1501

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests
- [x] Manual scenario : 
  - start a new node 
  - after self repair, check with graphql that the inputs of transactions made before are present on the new node

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
