### PR TITLE
Add Crypto.decrypt_with_storage_nonce/1 in Interpreter's library

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/crypto.ex
+++ b/lib/archethic/contracts/interpreter/library/common/crypto.ex
@@ -97,6 +97,19 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Crypto do
     end
   end
 
+  @spec decrypt_with_storage_nonce(binary()) :: binary()
+  def decrypt_with_storage_nonce(cipher) do
+    case cipher
+         |> UtilsInterpreter.maybe_decode_hex()
+         |> Crypto.ec_decrypt_with_storage_nonce() do
+      {:ok, data} ->
+        data
+
+      {:error, :decryption_failed} ->
+        raise Library.Error, message: "Unable to decrypt data with storage nonce"
+    end
+  end
+
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:hash, [first]) do
     AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
@@ -123,6 +136,10 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Crypto do
   def check_types(:hmac, [first, second, third]) do
     check_types(:hmac, [first, second]) &&
       (AST.is_binary?(third) || AST.is_variable_or_function_call?(third))
+  end
+
+  def check_types(:decrypt_with_storage_nonce, [first]) do
+    AST.is_binary?(first) || AST.is_variable_or_function_call?(first)
   end
 
   def check_types(_, _), do: false

--- a/lib/archethic/crypto.ex
+++ b/lib/archethic/crypto.ex
@@ -745,6 +745,8 @@ defmodule Archethic.Crypto do
 
         {:ok, data}
     end
+  rescue
+    _ -> {:error, :decryption_failed}
   end
 
   @doc """
@@ -805,6 +807,8 @@ defmodule Archethic.Crypto do
 
         {:ok, data}
     end
+  rescue
+    _ -> {:error, :decryption_failed}
   end
 
   @doc """
@@ -837,6 +841,8 @@ defmodule Archethic.Crypto do
 
         {:ok, data}
     end
+  rescue
+    _ -> {:error, :decryption_failed}
   end
 
   @doc """

--- a/test/archethic/contracts/interpreter/library/common/crypto_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/crypto_test.exs
@@ -176,4 +176,22 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.CryptoTest do
       assert_raise Library.Error, fn -> Crypto.hmac("data", "invalid", "key") end
     end
   end
+
+  describe "decrypt_with_storage_nonce" do
+    test "should raise when the ciphertext cannot be decrypted by the storage nonce" do
+      assert_raise Library.Error, fn -> Crypto.decrypt_with_storage_nonce("123456") end
+
+      {pub, _} = Archethic.Crypto.derive_keypair("other key", 0)
+      bad_ciphertext = Archethic.Crypto.ec_encrypt("hello", pub)
+
+      assert_raise Library.Error, fn -> Crypto.decrypt_with_storage_nonce(bad_ciphertext) end
+    end
+
+    test "should decrypt the ciphertext with storage nonce" do
+      ciphertext =
+        Archethic.Crypto.ec_encrypt("hello", Archethic.Crypto.storage_nonce_public_key())
+
+      assert "hello" = Crypto.decrypt_with_storage_nonce(ciphertext)
+    end
+  end
 end


### PR DESCRIPTION
# Description

Add `Crypto.decrypt_with_storage_nonce/1` in the Interpreter's library.

This feature allows node to decrypt secrets during the contract's execution.


## Type of change

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- Unit tests
- Integration test with the following code:
```elixir
  @version 1
  actions triggered_by: interval, at: "* * * * * *" do
    cleartext = Crypto.decrypt_with_storage_nonce(0x...)
    Contract.set_content(cleartext)
  end
```

The ciphertext is generated using the `Crypto.ec_encrypt("data to encrypt", Crypto.storage_nonce_public_key())`
# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
