### PR TITLE
Add std deviation acceptance for fee's validation

### DIFF
--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1163,7 +1163,13 @@ defmodule Archethic.Mining.ValidationContext do
          %ValidationStamp{ledger_operations: %LedgerOperations{fee: stamp_fee}},
          expected_fee
        ) do
-    stamp_fee == expected_fee
+    deviation =
+      [Utils.from_bigint(stamp_fee), Utils.from_bigint(expected_fee)]
+      |> Utils.standard_deviation()
+      |> Float.round(3)
+
+    deviation_threshold = 0.01
+    deviation < deviation_threshold
   end
 
   defp valid_stamp_error?(%ValidationStamp{error: nil}, %__MODULE__{mining_error: nil}), do: true


### PR DESCRIPTION
# Description

Resolve the inconsistency in the transaction's validation fee verification

This PR addsa std deviation like UCO oracles to accept drift or slippage of transaction's fee value

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
