### PR TITLE
Metrics: add P2P.nodes_connected

### DIFF
--- a/lib/archethic/p2p.ex
+++ b/lib/archethic/p2p.ex
@@ -103,6 +103,26 @@ defmodule Archethic.P2P do
   end
 
   @doc """
+  Called by the telemetry poller
+  """
+  def nodes_connected_count() do
+    nodes_connected =
+      authorized_and_available_nodes()
+      |> Enum.reject(&(&1.first_public_key == Crypto.first_node_public_key()))
+      |> Enum.filter(&node_connected?/1)
+      |> Enum.count()
+
+    :telemetry.execute(
+      [:archethic, :p2p],
+      %{nodes_connected: nodes_connected}
+    )
+  rescue
+    _ ->
+      # this will fail at startup because ETS table does not exist yet
+      :ok
+  end
+
+  @doc """
   List the nodes registered.
   """
   @spec list_nodes() :: list(Node.t())

--- a/lib/archethic/telemetry.ex
+++ b/lib/archethic/telemetry.ex
@@ -18,7 +18,8 @@ defmodule Archethic.Telemetry do
 
   defp periodic_metrics do
     [
-      {Archethic.Contracts, :maximum_calls_in_queue, []}
+      {Archethic.Contracts, :maximum_calls_in_queue, []},
+      {Archethic.P2P, :nodes_connected_count, []}
     ]
   end
 
@@ -108,6 +109,7 @@ defmodule Archethic.Telemetry do
           buckets: [500, 700, 1000, 1500, 2000, 3000, 5000, 10000]
         ]
       ),
+      last_value("archethic.p2p.nodes_connected"),
       distribution("archethic.p2p.send_message.duration",
         unit: {:native, :millisecond},
         measurement: :duration,


### PR DESCRIPTION
Add a metric to count the number of nodes currently connected. 
This will be useful to detect splits or nodes that are not connected to anyone but still accept incoming connections (so they appear available, but in the end they cannot request anything outside of its shard resulting in wrong replies)