### PR TITLE
Smart Contracts: change cache key

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -95,19 +95,15 @@ defmodule Archethic.Contracts do
         _ -> opts
       end
 
-    key =
+    trigger_tx_address =
       case maybe_trigger_tx do
-        nil ->
-          time = Keyword.fetch!(opts, :time_now)
-          {:execute_trigger, trigger_type, contract_address, nil, time, inputs_digest(inputs)}
-
-        %Transaction{
-          address: trigger_tx_address,
-          validation_stamp: %ValidationStamp{timestamp: time}
-        } ->
-          {:execute_trigger, trigger_type, contract_address, trigger_tx_address, time,
-           inputs_digest(inputs)}
+        nil -> nil
+        %Transaction{address: addr} -> addr
       end
+
+    key =
+      {:execute_trigger, trigger_type, contract_address, trigger_tx_address,
+       Keyword.fetch!(opts, :time_now), inputs_digest(inputs)}
 
     fn ->
       Interpreter.execute_trigger(


### PR DESCRIPTION
# Description

This does not concern the node directly but applications that depends on it (playground).
The cache key was using the validation_time but it should use the :time_now because that's what the interpreter actually use. 

ALSO: **Make the cache optional**

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via the playground + run the tests

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
