### PR TITLE
Fix explorer issue when displaying a state with maps that cannot be transformed to json

### DIFF
--- a/lib/archethic_web/api/graphql/schema/transaction_type.ex
+++ b/lib/archethic_web/api/graphql/schema/transaction_type.ex
@@ -4,6 +4,7 @@ defmodule ArchethicWeb.API.GraphQL.Schema.TransactionType do
   use Absinthe.Schema.Notation
 
   alias ArchethicWeb.API.GraphQL.Schema.Resolver
+  alias Archethic.Contracts.Contract.State
 
   alias Archethic.TransactionChain.Transaction
 
@@ -209,7 +210,7 @@ defmodule ArchethicWeb.API.GraphQL.Schema.TransactionType do
     [State] represents the smart contract state
   """
   scalar :state do
-    serialize(& &1)
+    serialize(&State.to_json/1)
   end
 
   @desc """

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -332,7 +332,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
   end
 
   def print_state(%UnspentOutput{encoded_payload: encoded_state}) do
-    encoded_state |> State.deserialize() |> elem(0) |> Jason.encode!(pretty: true)
+    encoded_state |> State.deserialize() |> elem(0) |> inspect(pretty: true)
   end
 
   defp similar?(

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -332,7 +332,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
   end
 
   def print_state(%UnspentOutput{encoded_payload: encoded_state}) do
-    encoded_state |> State.deserialize() |> elem(0) |> inspect(pretty: true)
+    encoded_state |> State.deserialize() |> elem(0) |> State.format()
   end
 
   defp similar?(

--- a/test/archethic/contracts/state_test.exs
+++ b/test/archethic/contracts/state_test.exs
@@ -14,6 +14,14 @@ defmodule Archethic.Contracts.Contract.StateTest do
     end
   end
 
+  describe "format/1" do
+    test "should return a valid JSON prettified" do
+      state = complex_state()
+
+      assert {:ok, _} = State.format(state) |> Jason.decode()
+    end
+  end
+
   defp complex_state() do
     %{
       "foo" => "bar",


### PR DESCRIPTION
# Description

Use inspect instead of Json.encode to handle map with non-string keys
Fixes #1523

<img width="890" alt="Capture d’écran 2024-06-03 à 09 49 24" src="https://github.com/archethic-foundation/archethic-node/assets/74045243/a2567ebf-9480-453b-aed2-b095d935fc40">



## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
