### PR TITLE
Smart Contracts: add `genesis_address` fields to global constants

### DIFF
--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -239,6 +239,7 @@ defmodule Archethic.Contracts do
           contract_tx
           |> Constants.from_transaction(contract_version)
           |> Constants.set_balance(inputs)
+          |> Constants.resolve_genesis_address()
 
         constants = %{
           "contract" => contract_constants,
@@ -474,11 +475,13 @@ defmodule Archethic.Contracts do
       transaction
       |> Constants.from_transaction(contract_version)
       |> Constants.set_balance(new_inputs)
+      |> Constants.resolve_genesis_address()
 
     previous_contract_constants =
       contract_tx
       |> Constants.from_transaction(contract_version)
       |> Constants.set_balance(inputs)
+      |> Constants.resolve_genesis_address()
 
     %{
       "previous" => previous_contract_constants,
@@ -506,9 +509,12 @@ defmodule Archethic.Contracts do
       contract_tx
       |> Constants.from_transaction(contract_version)
       |> Constants.set_balance(inputs)
+      |> Constants.resolve_genesis_address()
 
     %{
-      "transaction" => Constants.from_transaction(transaction, contract_version),
+      "transaction" =>
+        Constants.from_transaction(transaction, contract_version)
+        |> Constants.resolve_genesis_address(),
       "contract" => contract_constants,
       :time_now => DateTime.to_unix(datetime),
       :functions => functions,

--- a/lib/archethic/contracts/conditions.ex
+++ b/lib/archethic/contracts/conditions.ex
@@ -13,6 +13,7 @@ defmodule Archethic.Contracts.Conditions do
 
     defstruct [
       :address,
+      :genesis_address,
       :type,
       :content,
       :code,
@@ -27,6 +28,7 @@ defmodule Archethic.Contracts.Conditions do
 
     @type t :: %__MODULE__{
             address: binary() | Macro.t() | nil,
+            genesis_address: binary() | Macro.t() | nil,
             type: Transaction.transaction_type() | nil,
             content: binary() | Macro.t() | nil,
             code: binary() | Macro.t() | nil,
@@ -46,6 +48,7 @@ defmodule Archethic.Contracts.Conditions do
         args: [],
         subjects: %Subjects{
           address: nil,
+          genesis_address: nil,
           type: nil,
           content: nil,
           code: nil,

--- a/lib/archethic/contracts/interpreter.ex
+++ b/lib/archethic/contracts/interpreter.ex
@@ -160,15 +160,20 @@ defmodule Archethic.Contracts.Interpreter do
 
         transaction_constant =
           case maybe_trigger_tx do
-            nil -> nil
+            nil ->
+              nil
+
             # :oracle & :transaction
-            trigger_tx -> Constants.from_transaction(trigger_tx, version)
+            trigger_tx ->
+              Constants.from_transaction(trigger_tx, version)
+              |> Constants.resolve_genesis_address()
           end
 
         contract_constants =
           contract_tx
           |> Constants.from_contract_transaction(version)
           |> Constants.set_balance(inputs)
+          |> Constants.resolve_genesis_address()
 
         constants =
           named_action_constants

--- a/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/legacy/action_interpreter_test.exs
@@ -500,6 +500,9 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ActionInterpreterTest do
     address = "000077003155E556981870BAEA665910C98679AE501598D11640FE37F58F72B3F06F"
     b_address = Base.decode16!(address)
 
+    MockDB
+    |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
     MockClient
     |> expect(:send_message, fn _, _, _ ->
       {:ok, %GenesisAddress{address: b_address, timestamp: DateTime.utc_now()}}

--- a/test/archethic/contracts/interpreter/legacy/condition_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/legacy/condition_interpreter_test.exs
@@ -219,6 +219,9 @@ defmodule Archethic.Contracts.Interpreter.Legacy.ConditionInterpreterTest do
       address = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>> |> Base.encode16()
       b_address = Base.decode16!(address)
 
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
       MockClient
       |> expect(:send_message, fn _, _, _ ->
         {:ok, %GenesisAddress{address: b_address, timestamp: DateTime.utc_now()}}

--- a/test/archethic/contracts/interpreter/library/common/chain_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/chain_test.exs
@@ -80,6 +80,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
       end
       """
 
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
       MockClient
       |> expect(:send_message, fn
         _, %GetGenesisAddress{address: ^tx_address}, _ ->
@@ -280,6 +283,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
       non_fungible_token_address = random_address()
       non_fungible_token_address_hex = Base.encode16(non_fungible_token_address)
 
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
       MockClient
       |> expect(:send_message, fn _, %GetGenesisAddress{address: ^address}, _ ->
         {:ok, %GenesisAddress{address: genesis_address, timestamp: DateTime.utc_now()}}
@@ -339,6 +345,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
     end
 
     test "should raise an error on network issue" do
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
       MockClient
       |> expect(:send_message, fn _, %GetLastTransactionAddress{}, _ ->
         {:error, :network_issue}
@@ -354,6 +363,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
     test "should return uco balance" do
       address = random_address()
       genesis_address = random_address()
+
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
 
       MockClient
       |> expect(:send_message, fn _, %GetGenesisAddress{address: ^address}, _ ->
@@ -388,6 +400,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
       fungible_token_address_hex = Base.encode16(fungible_token_address)
       non_fungible_token_address = random_address()
       non_fungible_token_address_hex = Base.encode16(non_fungible_token_address)
+
+      MockDB
+      |> stub(:find_genesis_address, fn _ -> {:error, :not_found} end)
 
       MockClient
       |> stub(:send_message, fn
@@ -450,6 +465,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
       non_fungible_token_address = random_address()
       non_fungible_token_address_hex = Base.encode16(non_fungible_token_address)
 
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
       MockClient
       |> expect(:send_message, fn _, %GetGenesisAddress{address: ^address}, _ ->
         {:ok, %GenesisAddress{address: genesis_address, timestamp: DateTime.utc_now()}}
@@ -509,6 +527,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.ChainTest do
       fungible_token_address_hex = Base.encode16(fungible_token_address)
       non_fungible_token_address = random_address()
       non_fungible_token_address_hex = Base.encode16(non_fungible_token_address)
+
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
 
       MockClient
       |> stub(:send_message, fn

--- a/test/archethic/contracts/interpreter/library/common/time_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/time_test.exs
@@ -1,5 +1,7 @@
 defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
   use ArchethicCase
+  import ArchethicCase
+  import Mox
 
   alias Archethic.ContractFactory
   alias Archethic.Contracts
@@ -148,6 +150,11 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.TimeTest do
           content: "konnichiwa",
           timestamp: datetime
         )
+
+      genesis_address = random_address()
+
+      # this mock is required to have the same genesis address on `next`  and `previous`
+      MockDB |> stub(:find_genesis_address, fn _ -> {:ok, genesis_address} end)
 
       assert {:ok, _} =
                Contracts.execute_condition(

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -90,6 +90,12 @@ defmodule Archethic.ContractsTest do
 
       next_tx = ContractFactory.create_next_contract_tx(contract_tx, ledger: ledger)
 
+      genesis_address = random_address()
+
+      # this mock is required to have the same genesis address on `next`  and `previous`
+      MockDB
+      |> stub(:find_genesis_address, fn _ -> {:ok, genesis_address} end)
+
       assert {:error, %ConditionRejected{}} =
                Contracts.execute_condition(
                  :inherit,
@@ -117,6 +123,12 @@ defmodule Archethic.ContractsTest do
       contract_tx = ContractFactory.create_valid_contract_tx(code)
 
       next_tx = ContractFactory.create_next_contract_tx(contract_tx, content: "hola")
+
+      genesis_address = random_address()
+
+      # this mock is required to have the same genesis address on `next`  and `previous`
+      MockDB
+      |> stub(:find_genesis_address, fn _ -> {:ok, genesis_address} end)
 
       assert {:error, %ConditionRejected{}} =
                Contracts.execute_condition(
@@ -161,6 +173,12 @@ defmodule Archethic.ContractsTest do
           type: :transfer
         )
 
+      genesis_address = random_address()
+
+      # this mock is required to have the same genesis address on `next`  and `previous`
+      MockDB
+      |> stub(:find_genesis_address, fn _ -> {:ok, genesis_address} end)
+
       assert {:ok, _} =
                Contracts.execute_condition(
                  :inherit,
@@ -183,6 +201,12 @@ defmodule Archethic.ContractsTest do
       contract_tx = ContractFactory.create_valid_contract_tx(code)
 
       next_tx = ContractFactory.create_next_contract_tx(contract_tx, content: "hello")
+
+      genesis_address = random_address()
+
+      # this mock is required to have the same genesis address on `next`  and `previous`
+      MockDB
+      |> stub(:find_genesis_address, fn _ -> {:ok, genesis_address} end)
 
       assert {:ok, _} =
                Contracts.execute_condition(

--- a/test/archethic/mining_test.exs
+++ b/test/archethic/mining_test.exs
@@ -99,6 +99,11 @@ defmodule Archethic.MiningTest do
 
       {ok_nodes, error_nodes} = Enum.split(storage_nodes, nb_ok_nodes)
 
+      genesis_address = Crypto.derive_address(tx.previous_public_key)
+
+      MockDB
+      |> stub(:find_genesis_address, fn _ -> {:ok, genesis_address} end)
+
       Enum.each(ok_nodes, fn node ->
         MockClient
         |> expect(:send_message, fn ^node, ^message, _ -> {:ok, %Ok{}} end)

--- a/test/archethic/transaction_chain_test.exs
+++ b/test/archethic/transaction_chain_test.exs
@@ -83,6 +83,9 @@ defmodule Archethic.TransactionChainTest do
         authorization_date: ~U[2021-03-25 15:11:29Z]
       })
 
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
       MockClient
       |> expect(:send_message, fn _, %GetGenesisAddress{address: ^address2}, _ ->
         {:ok, %GenesisAddress{address: genesis2, timestamp: DateTime.utc_now()}}
@@ -162,6 +165,9 @@ defmodule Archethic.TransactionChainTest do
         authorized?: true,
         authorization_date: ~U[2021-03-25 15:11:29Z]
       })
+
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
 
       MockClient
       |> expect(:send_message, fn _, %GetGenesisAddress{address: ^address2}, _ ->
@@ -1190,6 +1196,9 @@ defmodule Archethic.TransactionChainTest do
     end
 
     test "should work when no conflict", %{nodes: nodes} do
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
       MockClient
       |> stub(:send_message, fn
         _, %GetGenesisAddress{address: "addr2"}, _ ->
@@ -1203,6 +1212,9 @@ defmodule Archethic.TransactionChainTest do
       node1 = Enum.at(nodes, 0)
       node2 = Enum.at(nodes, 1)
       node3 = Enum.at(nodes, 2)
+
+      MockDB
+      |> stub(:find_genesis_address, fn _ -> {:error, :not_found} end)
 
       MockClient
       |> stub(:send_message, fn

--- a/test/archethic_test.exs
+++ b/test/archethic_test.exs
@@ -562,6 +562,9 @@ defmodule ArchethicTest do
         authorization_date: DateTime.utc_now()
       })
 
+      MockDB
+      |> stub(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
       MockClient
       |> expect(:send_message, 1, fn _, %GetUnspentOutputs{}, _ ->
         {:ok,
@@ -647,6 +650,9 @@ defmodule ArchethicTest do
         authorized?: true,
         authorization_date: ~U[2020-01-01 10:00:00Z]
       })
+
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
 
       MockClient
       |> stub(:send_message, fn

--- a/test/archethic_web/api/graphql/schema_test.exs
+++ b/test/archethic_web/api/graphql/schema_test.exs
@@ -565,6 +565,9 @@ defmodule ArchethicWeb.API.GraphQL.SchemaTest do
 
       genesis_addr = <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
 
+      MockDB
+      |> expect(:find_genesis_address, fn _ -> {:error, :not_found} end)
+
       MockClient
       |> stub(:send_message, fn _, %GetGenesisAddress{}, _ ->
         {:ok, %GenesisAddress{address: genesis_addr, timestamp: DateTime.utc_now()}}

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -53,7 +53,7 @@ defmodule ArchethicCase do
     |> stub(:get_last_chain_address, fn addr, _ -> {addr, DateTime.utc_now()} end)
     |> stub(:get_first_public_key, fn pub -> pub end)
     |> stub(:get_genesis_address, fn addr -> addr end)
-    |> stub(:find_genesis_address, fn _ -> {:error, :not_found} end)
+    |> stub(:find_genesis_address, fn addr -> {:ok, addr} end)
     |> stub(:chain_size, fn _ -> 0 end)
     |> stub(:list_transactions_by_type, fn _, _ -> [] end)
     |> stub(:list_chain_addresses, fn _ -> [] end)


### PR DESCRIPTION
# Description

Add genesis_address to `transaction` `contract` `next` `previous` constants.
Fixes #1526

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
