### PR TITLE
Smart Contracts: use decimals right after tokenization

### DIFF
--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -114,7 +114,7 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
            {{:atom, "at"}, timestamp}
          ]
        )
-       when is_number(timestamp) do
+       when is_integer(timestamp) do
     case rem(timestamp, 60) do
       0 ->
         datetime = DateTime.from_unix!(timestamp)

--- a/lib/archethic/contracts/interpreter/action_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/action_interpreter.ex
@@ -48,6 +48,9 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreter do
   def execute(ast, constants, %Transaction{data: %TransactionData{code: code}}) do
     :ok = Macro.validate(ast)
 
+    # we need to have a big precision to avoid rounding issue
+    Decimal.Context.set(%Decimal.Context{Decimal.Context.get() | rounding: :floor, precision: 100})
+
     # initiate a transaction that will be used by the "Contract" module
     initial_next_tx = %Transaction{type: :contract, data: %TransactionData{code: code}}
 

--- a/lib/archethic/contracts/interpreter/condition_validator.ex
+++ b/lib/archethic/contracts/interpreter/condition_validator.ex
@@ -16,11 +16,17 @@ defmodule Archethic.Contracts.Interpreter.ConditionValidator do
   @spec execute_condition(Macro.t() | ConditionsSubjects.t(), map()) ::
           {:ok, list(String.t())} | {:error, String.t(), list(String.t())}
   def execute_condition(subjects = %ConditionsSubjects{}, constants = %{}) do
+    # we need to have a big precision to avoid rounding issue
+    Decimal.Context.set(%Decimal.Context{Decimal.Context.get() | rounding: :floor, precision: 100})
+
     # condition triggered_by: <trigger>, as: [ <field>: <expr> ]
     execute_condition_subjects(subjects, constants)
   end
 
   def execute_condition(ast, constants = %{}) do
+    # we need to have a big precision to avoid rounding issue
+    Decimal.Context.set(%Decimal.Context{Decimal.Context.get() | rounding: :floor, precision: 100})
+
     # condition triggered_by: <trigger> do <expr> end
     execute_condition_block(ast, constants)
   end

--- a/lib/archethic/contracts/interpreter/function_interpreter.ex
+++ b/lib/archethic/contracts/interpreter/function_interpreter.ex
@@ -56,6 +56,9 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreter do
   @spec execute(ast :: any(), constants :: map(), args_names :: list(), args_values :: list()) ::
           result :: any()
   def execute(ast, constants, args_names \\ [], args_values \\ []) do
+    # we need to have a big precision to avoid rounding issue
+    Decimal.Context.set(%Decimal.Context{Decimal.Context.get() | rounding: :floor, precision: 100})
+
     Scope.execute(ast, constants, args_names, args_values)
   end
 

--- a/lib/archethic/contracts/interpreter/library/common/list.ex
+++ b/lib/archethic/contracts/interpreter/library/common/list.ex
@@ -2,19 +2,20 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.List do
   @moduledoc false
   @behaviour Archethic.Contracts.Interpreter.Library
 
+  require Decimal
   alias Archethic.Tag
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
 
   use Tag
 
-  @spec at(list(), integer() | float()) :: any()
+  @spec at(list(), integer() | Decimal.t()) :: any()
   def at(list, idx) do
     cond do
       is_integer(idx) ->
         Enum.at(list, idx)
 
-      is_float(idx) && trunc(idx) == idx ->
-        Enum.at(list, trunc(idx))
+      Decimal.is_decimal(idx) && Decimal.integer?(idx) ->
+        Enum.at(list, Decimal.to_integer(idx))
 
       true ->
         raise %FunctionClauseError{

--- a/lib/archethic/contracts/interpreter/library/common/map.ex
+++ b/lib/archethic/contracts/interpreter/library/common/map.ex
@@ -17,7 +17,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Map do
   defdelegate values(map), to: Map
 
   @spec size(map()) :: integer()
-  def size(map), do: map_size(map)
+  defdelegate size(map), to: Kernel, as: :map_size
 
   @spec get(map(), binary(), any()) :: any()
   defdelegate get(map, key, default \\ nil), to: Map

--- a/lib/archethic/contracts/interpreter/library/common/math.ex
+++ b/lib/archethic/contracts/interpreter/library/common/math.ex
@@ -10,9 +10,9 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Math do
 
   @one Decimal.new(1)
 
-  @spec trunc(num :: number()) :: integer()
+  @spec trunc(num :: integer() | Decimal.t()) :: integer()
   def trunc(num) when is_integer(num), do: num
-  def trunc(num) when is_float(num), do: Kernel.trunc(num)
+  def trunc(num = %Decimal{}), do: Decimal.round(num) |> Decimal.to_integer()
 
   @doc """
   ##  Example

--- a/lib/archethic/contracts/interpreter/library/common/string.ex
+++ b/lib/archethic/contracts/interpreter/library/common/string.ex
@@ -4,6 +4,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.String do
 
   alias Archethic.Tag
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
+  alias Archethic.Utils
 
   use Tag
 
@@ -38,34 +39,26 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.String do
     to: String,
     as: :downcase
 
-  @spec to_number(String.t()) :: integer() | float() | nil
+  @spec to_number(String.t()) :: integer() | Decimal.t() | nil
   def to_number(string) do
     try do
-      String.to_integer(string)
+      string
+      |> Decimal.new()
+      |> Utils.maybe_decimal_to_integer()
     rescue
-      _ ->
-        try do
-          String.to_float(string)
-        rescue
-          _ ->
-            nil
-        end
+      _ -> nil
     end
   end
 
-  @spec from_number(integer() | float()) :: String.t()
-  def from_number(int) when is_integer(int) do
-    Integer.to_string(int)
-  end
+  @spec from_number(integer() | Decimal.t()) :: String.t()
+  def from_number(num) when is_integer(num), do: Integer.to_string(num)
 
-  def from_number(float) when is_float(float) do
-    truncated = trunc(float)
-
-    # we display as an int if there is no decimals
-    if truncated == float do
-      Integer.to_string(truncated)
+  def from_number(num = %Decimal{}) do
+    if Decimal.integer?(num) do
+      # we display as an int if there is no decimals
+      num |> Decimal.to_integer() |> Integer.to_string()
     else
-      Float.to_string(float)
+      num |> Decimal.to_string()
     end
   end
 

--- a/lib/archethic/utils.ex
+++ b/lib/archethic/utils.ex
@@ -28,6 +28,48 @@ defmodule Archethic.Utils do
   @type bigint() :: integer()
 
   @doc """
+  Cast a bigint into an integer if possible, fallback to decimal
+
+  ## Examples
+
+    iex> Decimal.eq?(Utils.bigint_to_decimal(100_000_000), Decimal.new(1))
+    true
+
+    iex> Decimal.eq?(Utils.bigint_to_decimal(10_000_000), Decimal.new("0.1"))
+    true
+  """
+  @spec bigint_to_decimal(integer(), integer()) :: Decimal.t()
+  def bigint_to_decimal(bigint, exp \\ 8) do
+    Decimal.new(bigint)
+    |> Decimal.div(10 ** exp)
+  end
+
+  @doc """
+  Cast a number to an integer if possible, fallback to decimal
+
+  ## Examples
+
+    iex> Utils.maybe_decimal_to_integer(100_000_000)
+    100_000_000
+
+    iex> Utils.maybe_decimal_to_integer(Decimal.new(100_000_000))
+    100_000_000
+
+    iex> Decimal.eq?(Utils.maybe_decimal_to_integer(Decimal.new("0.1")), Decimal.new("0.1"))
+    true
+  """
+  @spec maybe_decimal_to_integer(integer() | Decimal.t()) :: integer() | Decimal.t()
+  def maybe_decimal_to_integer(number) do
+    decimal = Decimal.new(number)
+
+    if Decimal.integer?(decimal) do
+      Decimal.to_integer(decimal)
+    else
+      decimal
+    end
+  end
+
+  @doc """
   Convert a number to a bigint
   """
   @spec to_bigint(integer() | float()) :: bigint()

--- a/test/archethic/contracts/interpreter/action_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/action_interpreter_test.exs
@@ -1203,6 +1203,17 @@ defmodule Archethic.Contracts.Interpreter.ActionInterpreterTest do
                sanitize_parse_execute(code)
     end
 
+    test "floats are precise" do
+      code = ~s"""
+      actions triggered_by: transaction do
+        Contract.set_content 67494440.78702811
+      end
+      """
+
+      assert {%Transaction{data: %TransactionData{content: "67494440.78702811"}}, _state} =
+               sanitize_parse_execute(code)
+    end
+
     test "maths are OK" do
       code = ~s"""
       actions triggered_by: transaction do

--- a/test/archethic/contracts/interpreter/function_interpreter_test.exs
+++ b/test/archethic/contracts/interpreter/function_interpreter_test.exs
@@ -21,7 +21,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:ok, "test_private", _, _} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
     end
@@ -35,7 +35,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:ok, "test_public", _, _} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
     end
@@ -49,7 +49,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:ok, "test_private", ["arg1", "arg2"], _} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
     end
@@ -63,7 +63,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:ok, "test_public", ["arg1", "arg2"], _} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
     end
@@ -77,7 +77,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:error, _, "Write contract functions are not allowed in custom functions"} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
 
@@ -89,7 +89,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:error, _, "Write contract functions are not allowed in custom functions"} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
     end
@@ -103,7 +103,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:error, _, "IO function calls not allowed in public functions"} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
     end
@@ -117,7 +117,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:error, _, "IO function calls not allowed in public functions"} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                # mark function as declared
                |> FunctionInterpreter.parse(
@@ -135,7 +135,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:error, _, "IO function calls not allowed in public functions"} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                # mark function as declared
                |> FunctionInterpreter.parse(
@@ -153,7 +153,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:error, _, "Module Hello does not exists"} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
     end
@@ -167,7 +167,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:ok, _, _, _} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
     end
@@ -181,7 +181,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:ok, "test", [], _} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
 
@@ -193,7 +193,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:ok, _, _, _} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse([])
     end
@@ -207,7 +207,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:error, _, "The function hello/0 does not exist"} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                |> FunctionInterpreter.parse(%{})
     end
@@ -221,7 +221,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:ok, "test", _, _} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                # mark function as declared
                |> FunctionInterpreter.parse(
@@ -239,7 +239,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:error, _, "not allowed to call private function from a private function"} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                # mark function as declared
                |> FunctionInterpreter.parse(
@@ -257,7 +257,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:error, _, "not allowed to call function from public function"} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                # mark function as declared
                |> FunctionInterpreter.parse(
@@ -275,7 +275,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       assert {:ok, _, _, _} =
                code
-               |> Interpreter.sanitize_code()
+               |> Interpreter.sanitize_code(check_legacy?: false)
                |> elem(1)
                # mark function as declared
                |> FunctionInterpreter.parse(FunctionKeys.new())
@@ -292,7 +292,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       {:ok, "hello", [], ast_hello} =
         fun1
-        |> Interpreter.sanitize_code()
+        |> Interpreter.sanitize_code(check_legacy?: false)
         |> elem(1)
         |> FunctionInterpreter.parse([])
 
@@ -304,7 +304,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       {:ok, "test", [], ast_test} =
         fun2
-        |> Interpreter.sanitize_code()
+        |> Interpreter.sanitize_code(check_legacy?: false)
         |> elem(1)
         # pass allowed function
         |> FunctionInterpreter.parse(
@@ -314,7 +314,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       function_constant = %{:functions => %{{"hello", 0} => %{args: [], ast: ast_hello}}}
 
-      assert 4 = FunctionInterpreter.execute(ast_test, function_constant)
+      assert Decimal.eq?(4, FunctionInterpreter.execute(ast_test, function_constant))
     end
 
     test "should be able to execute function with arg" do
@@ -326,7 +326,7 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       {:ok, "test", ["var1"], ast_fun} =
         fun
-        |> Interpreter.sanitize_code()
+        |> Interpreter.sanitize_code(check_legacy?: false)
         |> elem(1)
         # pass allowed function
         |> FunctionInterpreter.parse([])
@@ -343,12 +343,15 @@ defmodule Archethic.Contracts.Interpreter.FunctionInterpreterTest do
 
       {:ok, "test", ["var1", "var2"], ast_fun} =
         fun
-        |> Interpreter.sanitize_code()
+        |> Interpreter.sanitize_code(check_legacy?: false)
         |> elem(1)
         # pass allowed function
         |> FunctionInterpreter.parse([])
 
-      assert 12.0 == FunctionInterpreter.execute(ast_fun, %{}, ["var1", "var2"], [4, 8])
+      assert Decimal.eq?(
+               12,
+               FunctionInterpreter.execute(ast_fun, %{}, ["var1", "var2"], [4, 8])
+             )
     end
   end
 end

--- a/test/archethic/contracts/interpreter/library/common/json_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/json_test.exs
@@ -19,11 +19,20 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
     test "should work with float" do
       code = ~S"""
       actions triggered_by: transaction do
+        Contract.set_content Json.to_string(0.1)
+      end
+      """
+
+      assert {%Transaction{data: %TransactionData{content: "0.1"}}, _state} =
+               sanitize_parse_execute(code)
+
+      code = ~S"""
+      actions triggered_by: transaction do
         Contract.set_content Json.to_string(1.0)
       end
       """
 
-      assert {%Transaction{data: %TransactionData{content: "1.0"}}, _state} =
+      assert {%Transaction{data: %TransactionData{content: "1"}}, _state} =
                sanitize_parse_execute(code)
     end
 
@@ -127,6 +136,18 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.JsonTest do
       """
 
       assert {%Transaction{data: %TransactionData{content: "ok"}}, _state} =
+               sanitize_parse_execute(code)
+    end
+
+    test "should work with floats" do
+      code = ~S"""
+      actions triggered_by: transaction do
+        x = Json.parse("{ \"f\": 42.1}")
+        Contract.set_content x.f
+      end
+      """
+
+      assert {%Transaction{data: %TransactionData{content: "42.1"}}, _state} =
                sanitize_parse_execute(code)
     end
 

--- a/test/archethic/contracts/interpreter/library/common/string_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/string_test.exs
@@ -35,7 +35,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
     end
 
     test "should parse float" do
-      assert String.to_number("14.1") == 14.1
+      assert String.to_number("14.1") == Decimal.new("14.1")
     end
 
     test "should return nil if not a number" do
@@ -47,14 +47,15 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.StringTest do
   describe "from_number/1" do
     test "should convert int" do
       assert String.from_number(14) == "14"
+      assert Decimal.new("14") |> String.from_number() == "14"
     end
 
     test "should convert float" do
-      assert String.from_number(14.1) == "14.1"
+      assert Decimal.new("14.1") |> String.from_number() == "14.1"
     end
 
     test "should display float as int if possible" do
-      assert String.from_number(14.0) == "14"
+      assert Decimal.new("14.0") |> String.from_number() == "14"
     end
   end
 

--- a/test/archethic/contracts/interpreter_test.exs
+++ b/test/archethic/contracts/interpreter_test.exs
@@ -1388,7 +1388,7 @@ defmodule Archethic.Contracts.InterpreterTest do
         )
 
       assert Jason.encode!(%{
-               uco: 1.0,
+               uco: 1,
                tokens: %{
                  "#{eth_hex}#0" => 5.0e-6,
                  "#{btc_hex}#0" => 1.0e-6

--- a/test/archethic/contracts_test.exs
+++ b/test/archethic/contracts_test.exs
@@ -928,7 +928,7 @@ defmodule Archethic.ContractsTest do
 
       contract = Contract.from_transaction!(contract_tx)
 
-      assert {:ok, 5.0, _} =
+      assert {:ok, 5, _} =
                Contracts.execute_function(
                  contract,
                  "balance",

--- a/test/archethic_web/api/jsonrpc/methods/call_contract_function_test.exs
+++ b/test/archethic_web/api/jsonrpc/methods/call_contract_function_test.exs
@@ -280,7 +280,8 @@ defmodule ArchethicWeb.API.JsonRPC.Methods.CallContractFunctionTest do
         resolve_last: false
       }
 
-      assert {:ok, 21.0} == CallContractFunction.execute(params)
+      assert {:ok, r} = CallContractFunction.execute(params)
+      assert Decimal.eq?(r, 21)
     end
 
     test "should not be able to call a public function from a public function" do

--- a/test/support/template.ex
+++ b/test/support/template.ex
@@ -301,7 +301,7 @@ defmodule ArchethicCase do
   end
 
   def sanitize_parse_execute(code, constants \\ %{}, functions \\ []) do
-    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code),
+    with {:ok, sanitized_code} <- Interpreter.sanitize_code(code, check_legacy?: false),
          {:ok, _, action_ast} <- ActionInterpreter.parse(sanitized_code, functions) do
       contract_tx = ContractFactory.create_valid_contract_tx(code)
 


### PR DESCRIPTION
# Description

The problem identified is tested by "floats are precise" unit test. 
We fixed it by transforming all floats into %Decimals{}. Most of the code changed is to allow for decimals in the stdlib.

- [ ] write unit tests on lib functions that may return floats (Chain.get_balance etc)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
