### PR TITLE
Fix contract inputs validation with empty list

### DIFF
--- a/lib/archethic/contracts/contract/context.ex
+++ b/lib/archethic/contracts/contract/context.ex
@@ -220,6 +220,22 @@ defmodule Archethic.Contracts.Contract.Context do
       ...>   }
       ...> ])
       false
+
+      iex> %Context{
+      ...>   status: :tx_output,
+      ...>   trigger: {:datetime, 0},
+      ...>   timestamp: ~U[2024-02-02 10:04:10Z],
+      ...>   inputs: []
+      ...> }
+      ...> |> Context.valid_inputs?([
+      ...>   %VersionedUnspentOutput{
+      ...>     unspent_output: %UnspentOutput{from: "@Bob3", type: :UCO, amount: 50_000_000}
+      ...>   },
+      ...>   %VersionedUnspentOutput{
+      ...>     unspent_output: %UnspentOutput{from: "@Bob3", type: :call, amount: 0}
+      ...>   }
+      ...> ])
+      true
   """
   @spec valid_inputs?(t() | nil, list(VersionedUnspentOutput.t())) :: boolean()
   def valid_inputs?(%__MODULE__{inputs: inputs = [_ | _]}, unspent_outputs = [_ | _]) do
@@ -230,7 +246,11 @@ defmodule Archethic.Contracts.Contract.Context do
     end)
   end
 
-  def valid_inputs?(%__MODULE__{inputs: []}, _unspent_outputs = [_ | _]), do: false
+  def valid_inputs?(%__MODULE__{inputs: []}, _unspent_outputs = []), do: true
+
+  def valid_inputs?(%__MODULE__{inputs: []}, unspent_outputs),
+    do: [] == filter_inputs(unspent_outputs)
+
   def valid_inputs?(%__MODULE__{inputs: [_ | _]}, _unspent_outputs = []), do: false
   def valid_inputs?(nil, _unspent_outputs), do: true
 


### PR DESCRIPTION
# Description

Fixes an issue when a contract has no utxos, the contract input validation was returning false while it is normal that the contract inputs list is empty

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Doc test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
