### PR TITLE
Add `Math.bigint` in SC

### DIFF
--- a/lib/archethic/contracts/interpreter/library/common/math.ex
+++ b/lib/archethic/contracts/interpreter/library/common/math.ex
@@ -4,6 +4,7 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Math do
 
   alias Archethic.Tag
   alias Archethic.Contracts.Interpreter.ASTHelper, as: AST
+  alias Archethic.Contracts.Interpreter.Library
 
   use Tag
   import Bitwise
@@ -137,6 +138,12 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Math do
     iex> Math.bigint(1.994e-4, 18)
     199_400_000_000_000
 
+    iex> Math.bigint(0.19941234, 18)
+    199_412_340_000_000_000
+
+    iex> Math.bigint(0.10000006, 18)
+    100_000_060_000_000_000
+
     iex> Math.bigint(0.002, 18)
     2_000_000_000_000_000
 
@@ -156,7 +163,13 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Math do
     |> to_string()
     |> Decimal.new()
     |> Decimal.mult(Decimal.new(10 ** decimals))
-    |> to_number(true)
+    |> then(fn dec ->
+      if Decimal.integer?(dec) do
+        Decimal.to_integer(dec)
+      else
+        raise Library.Error, message: "Number exceeds decimals"
+      end
+    end)
   end
 
   @spec check_types(atom(), list()) :: boolean()

--- a/lib/archethic/contracts/interpreter/library/common/math.ex
+++ b/lib/archethic/contracts/interpreter/library/common/math.ex
@@ -127,6 +127,38 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Math do
     to_number(res, is_integer(num1) and is_integer(num2))
   end
 
+  @doc """
+
+  ## Example
+
+    iex> Math.bigint(49.85024327, 18)
+    49_850_243_270_000_000_000
+
+    iex> Math.bigint(1.994e-4, 18)
+    199_400_000_000_000
+
+    iex> Math.bigint(0.002, 18)
+    2_000_000_000_000_000
+
+    iex> Math.bigint(1.2390131, 18)
+    1_239_013_100_000_000_000
+
+    iex> Math.bigint(10, 18)
+    10_000_000_000_000_000_000
+
+    iex> Math.bigint(1, 8)
+    100_000_000
+
+  """
+  @spec bigint(num :: number(), decimals :: number()) :: number()
+  def bigint(num, decimals) do
+    num
+    |> to_string()
+    |> Decimal.new()
+    |> Decimal.mult(Decimal.new(10 ** decimals))
+    |> to_number(true)
+  end
+
   @spec check_types(atom(), list()) :: boolean()
   def check_types(:trunc, [first]) do
     AST.is_number?(first) || AST.is_variable_or_function_call?(first)
@@ -142,6 +174,11 @@ defmodule Archethic.Contracts.Interpreter.Library.Common.Math do
   end
 
   def check_types(:rem, [first, second]) do
+    (AST.is_number?(first) || AST.is_variable_or_function_call?(first)) &&
+      (AST.is_number?(second) || AST.is_variable_or_function_call?(second))
+  end
+
+  def check_types(:bigint, [first, second]) do
     (AST.is_number?(first) || AST.is_variable_or_function_call?(first)) &&
       (AST.is_number?(second) || AST.is_variable_or_function_call?(second))
   end

--- a/test/archethic/contracts/interpreter/library/common/math_test.exs
+++ b/test/archethic/contracts/interpreter/library/common/math_test.exs
@@ -1,7 +1,18 @@
 defmodule Archethic.Contracts.Interpreter.Library.Common.MathTest do
   use ArchethicCase
 
+  alias Archethic.Contracts.Interpreter.Library
   alias Archethic.Contracts.Interpreter.Library.Common.Math
 
   doctest Math
+
+  test "exceed decimals raise" do
+    assert_raise Library.Error, "Number exceeds decimals", fn ->
+      Math.bigint(0.1234, 2)
+    end
+
+    assert_raise Library.Error, "Number exceeds decimals", fn ->
+      Math.bigint(0.12345874564, 8)
+    end
+  end
 end


### PR DESCRIPTION
# Description

Add `Math.bigint` in smart contract, converting a number into its bigint representation for a given number of decimals


## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The use case has been tested with the bridge to set EVM big int

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
