### PR TITLE
Fix notifier genesis_address in ShardRepair msg

### DIFF
--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -871,7 +871,7 @@ defmodule Archethic.P2P.MessageTest do
 
     test "%ShardRepair" do
       msg = %ShardRepair{
-        first_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
+        genesis_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
         storage_address: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
         io_addresses: [
           <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,

--- a/test/archethic/self_repair/notifier_test.exs
+++ b/test/archethic/self_repair/notifier_test.exs
@@ -170,7 +170,7 @@ defmodule Archethic.SelfRepair.NotifierTest do
 
     MockClient
     |> stub(:send_message, fn
-      node, %ShardRepair{first_address: "Alice1", storage_address: "Alice2"}, _ ->
+      node, %ShardRepair{genesis_address: "Alice1", storage_address: "Alice2"}, _ ->
         if Enum.member?(new_possible_nodes, node.first_public_key) do
           send(me, :new_node)
         end


### PR DESCRIPTION
# Description

Fixes an issue where the notifier sent the wrong genesis address in the message ShardRepair. This result a node to store the UTXO of a chain to the wrong genesis address and not consuming UTXO.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
