### PR TITLE
Smart Contracts: reschedule triggers on node responsiveness timeout

### DIFF
--- a/lib/archethic/contracts/worker.ex
+++ b/lib/archethic/contracts/worker.ex
@@ -86,6 +86,9 @@ defmodule Archethic.Contracts.Worker do
       ) do
     triggers_type = Map.keys(triggers)
 
+    # stop all existing timers
+    data = cancel_schedulers(data)
+
     new_data =
       Enum.reduce(triggers_type, data, fn trigger_type, acc ->
         case schedule_trigger(trigger_type, triggers_type) do
@@ -225,7 +228,7 @@ defmodule Archethic.Contracts.Worker do
     end
 
     new_data = Map.delete(data, :last_call_processed)
-    {:keep_state, new_data, @process_trigger}
+    {:keep_state, new_data, @schedule_and_process_trigger}
   end
 
   def code_change(_old_vsn, state, data, _extra), do: {:ok, state, data}


### PR DESCRIPTION
# Description

When a resulting contract's transaction fails to be validated, we reschedule it.
Fixes #1547

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Scenario:
- start 2 nodes
- create a contract that will create a failing transaction 
```
  @version 1

  actions triggered_by: datetime, at: 1848657600 do
    Contract.set_content "that's all folks"
  end

  actions triggered_by: interval, at: "* * * * *" do
    Contract.add_uco_transfer to: "00000000000000000000000000000000000000000000000000000000000000000000", amount: 1_000_000_000
  end
```
- the contract should run every minute even if the transaction cannot be validated (Insufficient funds).

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
