### PR TITLE
Use Elixir Version module on migrate version compare

### DIFF
--- a/lib/mix/tasks/migrate.ex
+++ b/lib/mix/tasks/migrate.ex
@@ -65,7 +65,9 @@ defmodule Mix.Tasks.Archethic.Migrate do
       migration_version = Regex.run(~r/.*(?=@)/, file_name) |> List.first()
       {migration_version, migration_path}
     end)
-    |> Enum.filter(fn {migration_version, _} -> last_version < migration_version end)
+    |> Enum.filter(fn {migration_version, _} ->
+      Version.compare(last_version, migration_version) == :lt
+    end)
     |> Enum.map(fn {version, path} -> {version, Code.eval_file(path)} end)
     |> Enum.filter(fn
       {_version, {{:module, module, _, _}, _}} ->
@@ -80,6 +82,7 @@ defmodule Mix.Tasks.Archethic.Migrate do
         false
     end)
     |> Enum.map(fn {version, {{_, module, _, _}, _}} -> {version, module} end)
+    |> Enum.sort_by(&elem(&1, 0), Version)
   end
 
   defp get_migrations_path() do


### PR DESCRIPTION
# Description

Fixes an issue where a version is for example "1.5.10" and a migration task is created for version "1.5.9".
The Migrate module compare version as string and 1.5.9 > 1.5.10 while it should not be.
Used the Elixir `Version` module to fix it

## Type of change

- Bug fix (non-breaking change which fixes an issue)

On current version (1.5.10) run a node, stop it and restart it, without the fix it will try to run the migration for 1.5.9 that fail.
It does not run the migration after the fix

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
