### PR TITLE
Fix acceptance_resolver when syncing network chains

### DIFF
--- a/lib/archethic/self_repair/network_chain.ex
+++ b/lib/archethic/self_repair/network_chain.ex
@@ -165,7 +165,8 @@ defmodule Archethic.SelfRepair.NetworkChain do
 
     case TransactionChain.fetch_last_address(genesis_address, nodes,
            consistency_level: 8,
-           acceptance_resolver: &(&1.timestamp > local_last_address_timestamp)
+           acceptance_resolver:
+             &(DateTime.compare(&1.timestamp, local_last_address_timestamp) == :gt)
          ) do
       {:ok, remote_last_address} ->
         {:error, {genesis_address, remote_last_address}}

--- a/test/archethic/transaction_chain_test.exs
+++ b/test/archethic/transaction_chain_test.exs
@@ -288,7 +288,7 @@ defmodule Archethic.TransactionChainTest do
       nodes = P2P.authorized_and_available_nodes()
 
       acceptance_resolver = fn %LastTransactionAddress{timestamp: remote_last_address_timestamp} ->
-        now < remote_last_address_timestamp
+        DateTime.compare(now, remote_last_address_timestamp) == :lt
       end
 
       assert {:error, :acceptance_failed} =
@@ -331,7 +331,7 @@ defmodule Archethic.TransactionChainTest do
       nodes = P2P.authorized_and_available_nodes()
 
       acceptance_resolver = fn %LastTransactionAddress{timestamp: remote_last_address_timestamp} ->
-        now < remote_last_address_timestamp
+        DateTime.compare(now, remote_last_address_timestamp) == :lt
       end
 
       assert {:ok, ^latest_address} =


### PR DESCRIPTION
# Description

Issue found by @Neylix, because the datetime comparaison was done by comparing strings instead of datetime, the acceptance resolver of the networkchain resync was broken.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
