### PR TITLE
Filter p2p view size on during aggregation of summaries

### DIFF
--- a/test/archethic/beacon_chain/summary_aggregate_test.exs
+++ b/test/archethic/beacon_chain/summary_aggregate_test.exs
@@ -117,6 +117,30 @@ defmodule Archethic.BeaconChain.SummaryAggregateTest do
                }
                |> SummaryAggregate.aggregate()
     end
+
+    test "should keep the node availabilities with the maximum frequency of list size" do
+      assert %SummaryAggregate{
+               p2p_availabilities: %{
+                 <<0>> => %{
+                   node_availabilities: <<1::1, 0::1>>,
+                   node_average_availabilities: [0.93, 0.65],
+                   end_of_node_synchronizations: [],
+                   network_patches: ["BA6", "DEF"]
+                 }
+               }
+             } =
+               %SummaryAggregate{
+                 p2p_availabilities: %{
+                   <<0>> => %{
+                     node_availabilities: [[1, 0], [1, 0], [0]],
+                     node_average_availabilities: [[0.95, 0.7], [0.91, 0.6], [0.4]],
+                     end_of_node_synchronizations: [],
+                     network_patches: [["ABC", "DEF"], ["C90", "DEF"], ["FFF"]]
+                   }
+                 }
+               }
+               |> SummaryAggregate.aggregate()
+    end
   end
 
   describe "add_summary/2" do
@@ -171,7 +195,7 @@ defmodule Archethic.BeaconChain.SummaryAggregateTest do
              } = SummaryAggregate.add_summary(aggregate, summary)
     end
 
-    test "should not add p2p view when summary one is invalid", %{
+    test "should add p2p view with any size of list size", %{
       aggregate: aggregate = %SummaryAggregate{replication_attestations: previous_attestations},
       attestation2: attestation2
     } do
@@ -187,8 +211,8 @@ defmodule Archethic.BeaconChain.SummaryAggregateTest do
                replication_attestations: [^attestation2 | ^previous_attestations],
                p2p_availabilities: %{
                  <<0>> => %{
-                   node_availabilities: [[1, 0]],
-                   node_average_availabilities: [[0.95, 0.7]],
+                   node_availabilities: [[1, 0], [1]],
+                   node_average_availabilities: [[0.95, 0.7], [0.8]],
                    end_of_node_synchronizations: [],
                    network_patches: [["ABC", "DEF"], ["DEF", "ABC"]]
                  }


### PR DESCRIPTION
# Description

In some case this is possible that a node start it's self repair but as missed a new node transaction and so doesn't know this node.
Before starting the synchronize the missed transactions, the node aggregate the P2P view and ensure the p2p view of each summary has the same size of the expected node to sample for the summary subset. But since don't know all the node, the size comparison will fail and will make the p2p view empty

To fix this, instead of ensuring the p2p view size with local data, during aggregation the node will take the most frequent size across all summaries.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Starts 3 nodes at the same time, after the first summary, the 3rd node will have a wrong p2p view compared to others

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
