### PR TITLE
Consume inputs even if not genesis node

### DIFF
--- a/lib/archethic/utxo.ex
+++ b/lib/archethic/utxo.ex
@@ -67,9 +67,7 @@ defmodule Archethic.UTXO do
     |> Enum.each(fn {to, utxos} -> Loader.add_utxos(utxos, to) end)
 
     # Consume the transaction to update the unspent outputs from the consumed inputs
-    if not skip_consume_inputs? and
-         Election.chain_storage_node?(genesis_address, node_public_key, authorized_nodes),
-       do: Loader.consume_inputs(tx, genesis_address)
+    unless skip_consume_inputs?, do: Loader.consume_inputs(tx, genesis_address)
 
     Logger.info("Loaded into in memory UTXO tables",
       transaction_address: Base.encode16(tx.address),


### PR DESCRIPTION
# Description

Currently when a node is not genesis node of a transaction, it does not consume or update the UTXO of the genesis address of the chain.
But in some case, it is possible that a node is genesis node for a chain and store its UTXO, then the election change and it is not genesis node anymore but still store some transaction of the chain as storage node.
Then is become genesis node again, but since it already stored the transaction of this chain it will node re ingest the transaction and consume the inputs. So we encounter an issue where a the node keeps already spent UTXO in its view.

To fix it, even if the node is not genesis node of a chain, it consume the inputs and update the utxo of the genesis.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
