### PR TITLE
Sort ownership authorized keys in serialization

### DIFF
--- a/lib/archethic/transaction_chain/transaction/data/ownership.ex
+++ b/lib/archethic/transaction_chain/transaction/data/ownership.ex
@@ -75,7 +75,9 @@ defmodule Archethic.TransactionChain.TransactionData.Ownership do
   @spec serialize(ownership :: t(), tx_version :: pos_integer()) :: bitstring()
   def serialize(%__MODULE__{secret: secret, authorized_keys: authorized_keys}, _tx_version) do
     authorized_keys_bin =
-      Enum.map(authorized_keys, fn {public_key, encrypted_key} ->
+      authorized_keys
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.map(fn {public_key, encrypted_key} ->
         <<public_key::binary, encrypted_key::binary>>
       end)
       |> :erlang.list_to_binary()


### PR DESCRIPTION
# Description

To ensure serialization of the ownership is the same between node and sdk, ownership's authoized key map is sorted as done by sdk.
This will not be the case by default when upgrading to erlang 26

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
