### PR TITLE
Use the acceptance_resolver more often

### DIFF
--- a/lib/archethic/mining/transaction_context.ex
+++ b/lib/archethic/mining/transaction_context.ex
@@ -57,7 +57,13 @@ defmodule Archethic.Mining.TransactionContext do
       |> List.flatten()
       |> Enum.uniq()
 
-    prev_tx_task = request_previous_tx(previous_address, authorized_nodes)
+    prev_tx_task =
+      if previous_address == genesis_address do
+        Task.completed(nil)
+      else
+        request_previous_tx(previous_address, authorized_nodes)
+      end
+
     utxos_task = request_utxos(genesis_address, authorized_nodes)
     nodes_view_task = request_nodes_view(node_public_keys)
 
@@ -88,7 +94,7 @@ defmodule Archethic.Mining.TransactionContext do
         # Timeout of 4 sec because the coordinator node wait 5 sec to get the context
         # from the cross validation nodes
         case TransactionChain.fetch_transaction(previous_address, previous_storage_nodes,
-               search_mode: :remote,
+               acceptance_resolver: :accept_transaction,
                timeout: 4000
              ) do
           {:ok, tx} ->

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -307,12 +307,22 @@ defmodule Archethic.Replication do
 
     genesis_task =
       Task.Supervisor.async(TaskSupervisor, fn ->
-        TransactionContext.fetch_genesis_address(previous_address)
+        fetch_opts =
+          if TransactionChain.first_transaction?(tx),
+            do: [],
+            else: [acceptance_resolver: :accept_different_genesis]
+
+        TransactionContext.fetch_genesis_address(previous_address, fetch_opts)
       end)
 
     previous_transaction_task =
       Task.Supervisor.async(TaskSupervisor, fn ->
-        TransactionContext.fetch_transaction(previous_address)
+        fetch_opts =
+          if TransactionChain.first_transaction?(tx),
+            do: [],
+            else: [acceptance_resolver: :accept_transaction]
+
+        TransactionContext.fetch_transaction(previous_address, fetch_opts)
       end)
 
     resolved_addresses_task =

--- a/lib/archethic/replication/transaction_context.ex
+++ b/lib/archethic/replication/transaction_context.ex
@@ -1,30 +1,26 @@
 defmodule Archethic.Replication.TransactionContext do
   @moduledoc false
 
-  alias Archethic.Crypto
-
   alias Archethic.BeaconChain
-
+  alias Archethic.Crypto
   alias Archethic.Election
-
+  alias Archethic.P2P
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
-
-  alias Archethic.P2P
 
   require Logger
 
   @doc """
   Fetch transaction
   """
-  @spec fetch_transaction(address :: Crypto.versioned_hash()) ::
+  @spec fetch_transaction(address :: Crypto.versioned_hash(), opts :: Keyword.t()) ::
           Transaction.t() | nil
-  def fetch_transaction(address) when is_binary(address) do
+  def fetch_transaction(address, opts \\ []) when is_binary(address) do
     storage_nodes = Election.chain_storage_nodes(address, P2P.authorized_and_available_nodes())
 
-    case TransactionChain.fetch_transaction(address, storage_nodes) do
+    case TransactionChain.fetch_transaction(address, storage_nodes, opts) do
       {:ok, tx} ->
         tx
 
@@ -36,12 +32,12 @@ defmodule Archethic.Replication.TransactionContext do
   @doc """
   Fetch genesis address
   """
-  @spec fetch_genesis_address(address :: Crypto.prepended_hash()) ::
+  @spec fetch_genesis_address(address :: Crypto.prepended_hash(), opts :: Keyword.t()) ::
           genesis_address :: Crypto.prepended_hash()
-  def fetch_genesis_address(address) do
+  def fetch_genesis_address(address, opts \\ []) do
     storage_nodes = Election.chain_storage_nodes(address, P2P.authorized_and_available_nodes())
 
-    case TransactionChain.fetch_genesis_address(address, storage_nodes) do
+    case TransactionChain.fetch_genesis_address(address, storage_nodes, opts) do
       {:ok, genesis_address} -> genesis_address
       {:error, _} -> address
     end

--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -3,28 +3,20 @@ defmodule Archethic.SelfRepair do
   Synchronization for all the Archethic nodes relies on the self-repair mechanism started during
   the bootstrapping phase and stores last synchronization date after each cycle.
   """
+  alias __MODULE__.Notifier
+  alias __MODULE__.NotifierSupervisor
+  alias __MODULE__.RepairWorker
+  alias __MODULE__.Scheduler
+  alias __MODULE__.Sync
   alias Archethic.BeaconChain
-
   alias Archethic.Crypto
-
   alias Archethic.Election
-
   alias Archethic.P2P
   alias Archethic.P2P.Message
   alias Archethic.P2P.Node
-
   alias Archethic.Replication
-
   alias Archethic.TransactionChain
-  alias Archethic.TransactionChain.Transaction
-
   alias Archethic.Utils
-
-  alias __MODULE__.Notifier
-  alias __MODULE__.NotifierSupervisor
-  alias __MODULE__.Scheduler
-  alias __MODULE__.Sync
-  alias __MODULE__.RepairWorker
 
   require Logger
 
@@ -287,19 +279,13 @@ defmodule Archethic.SelfRepair do
   defp fetch_transaction_data(address, authorized_nodes) do
     timeout = Message.get_max_timeout()
 
-    acceptance_resolver = fn
-      %Transaction{address: ^address} -> true
-      _ -> false
-    end
-
     storage_nodes = Election.chain_storage_nodes(address, authorized_nodes)
 
     [
       Task.async(fn ->
         TransactionChain.fetch_transaction(address, storage_nodes,
-          search_mode: :remote,
           timeout: timeout,
-          acceptance_resolver: acceptance_resolver
+          acceptance_resolver: :accept_transaction
         )
       end),
       Task.async(fn -> TransactionChain.fetch_inputs(address, storage_nodes) end)

--- a/lib/archethic/self_repair.ex
+++ b/lib/archethic/self_repair.ex
@@ -284,6 +284,7 @@ defmodule Archethic.SelfRepair do
     [
       Task.async(fn ->
         TransactionChain.fetch_transaction(address, storage_nodes,
+          search_mode: :remote,
           timeout: timeout,
           acceptance_resolver: :accept_transaction
         )

--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -412,7 +412,9 @@ defmodule Archethic.SelfRepair.Sync do
       Task.async(fn ->
         storage_nodes = Election.chain_storage_nodes(tx_address, download_nodes)
 
-        case TransactionChain.fetch_genesis_address(tx_address, storage_nodes) do
+        case TransactionChain.fetch_genesis_address(tx_address, storage_nodes,
+               acceptance_resolver: :accept_different_genesis
+             ) do
           {:ok, genesis_address} ->
             genesis_address
 
@@ -516,7 +518,9 @@ defmodule Archethic.SelfRepair.Sync do
         fn recipient ->
           genesis_nodes = Election.chain_storage_nodes(recipient, authorized_nodes)
 
-          case TransactionChain.fetch_genesis_address(recipient, genesis_nodes) do
+          case TransactionChain.fetch_genesis_address(recipient, genesis_nodes,
+                 acceptance_resolver: :accept_different_genesis
+               ) do
             {:ok, genesis_address} ->
               [recipient, genesis_address]
 

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -119,6 +119,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
 
     {:ok,
      %{
+       genesis: Transaction.previous_address(tx),
        tx: tx,
        sorting_seed: Election.validation_nodes_election_seed_sorting(tx, ~U[2021-05-11 08:50:21Z])
      }}
@@ -127,6 +128,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
   describe "start_link/1" do
     test "should start mining by fetching the transaction context and elect storage nodes", %{
       tx: tx,
+      genesis: genesis,
       sorting_seed: sorting_seed
     } do
       validation_nodes =
@@ -146,7 +148,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           {:ok, %NotFound{}}
 
         _, %GetGenesisAddress{}, _ ->
-          {:ok, %GenesisAddress{address: "@Alice0", timestamp: DateTime.utc_now()}}
+          {:ok, %GenesisAddress{address: genesis, timestamp: DateTime.utc_now()}}
 
         _, %GetUnspentOutputs{}, _ ->
           {:ok, %UnspentOutputList{unspent_outputs: []}}
@@ -181,7 +183,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
 
   describe "add_mining_context/6" do
     test "should aggregate context and wait enough confirmed validation nodes context building",
-         %{tx: tx, sorting_seed: sorting_seed} do
+         %{tx: tx, genesis: genesis, sorting_seed: sorting_seed} do
       P2P.add_and_connect_node(%Node{
         ip: {80, 10, 20, 102},
         port: 3006,
@@ -229,7 +231,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           {:ok, %NotFound{}}
 
         _, %GetGenesisAddress{}, _ ->
-          {:ok, %GenesisAddress{address: "@Alice0", timestamp: DateTime.utc_now()}}
+          {:ok, %GenesisAddress{address: genesis, timestamp: DateTime.utc_now()}}
 
         _, %GetUnspentOutputs{}, _ ->
           {:ok, %UnspentOutputList{unspent_outputs: []}}
@@ -316,6 +318,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
 
     test "aggregate context and create validation stamp when enough context are retrieved", %{
       tx: tx,
+      genesis: genesis,
       sorting_seed: sorting_seed
     } do
       validation_nodes =
@@ -335,7 +338,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           {:ok, %NotFound{}}
 
         _, %GetGenesisAddress{}, _ ->
-          {:ok, %GenesisAddress{address: "@Alice0", timestamp: DateTime.utc_now()}}
+          {:ok, %GenesisAddress{address: genesis, timestamp: DateTime.utc_now()}}
 
         _, %GetUnspentOutputs{}, _ ->
           {:ok, %UnspentOutputList{unspent_outputs: []}}
@@ -427,7 +430,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
     end
 
     test "should evict validations nodes which didn't confirm by sending their context in time",
-         %{tx: tx, sorting_seed: sorting_seed} do
+         %{tx: tx, genesis: genesis, sorting_seed: sorting_seed} do
       {pub, _} = Crypto.generate_deterministic_keypair("seed3")
 
       P2P.add_and_connect_node(%Node{
@@ -462,7 +465,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           {:ok, %NotFound{}}
 
         _, %GetGenesisAddress{}, _ ->
-          {:ok, %GenesisAddress{address: "@Alice0", timestamp: DateTime.utc_now()}}
+          {:ok, %GenesisAddress{address: genesis, timestamp: DateTime.utc_now()}}
 
         _, %GetUnspentOutputs{}, _ ->
           {:ok, %UnspentOutputList{unspent_outputs: []}}
@@ -558,7 +561,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
 
   describe "cross_validate/2" do
     test "should cross validate the validation stamp and the replication tree and then notify other node about it",
-         %{tx: tx, sorting_seed: sorting_seed} do
+         %{tx: tx, genesis: genesis, sorting_seed: sorting_seed} do
       {pub, _} = Crypto.generate_deterministic_keypair("seed3")
 
       P2P.add_and_connect_node(%Node{
@@ -595,7 +598,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           {:ok, %NotFound{}}
 
         _, %GetGenesisAddress{}, _ ->
-          {:ok, %GenesisAddress{address: "@Alice0", timestamp: DateTime.utc_now()}}
+          {:ok, %GenesisAddress{address: genesis, timestamp: DateTime.utc_now()}}
 
         _, %GetUnspentOutputs{}, _ ->
           {:ok, %UnspentOutputList{unspent_outputs: []}}
@@ -767,6 +770,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
 
     test "should cross validate and start replication when all cross validations are received", %{
       tx: tx,
+      genesis: genesis,
       sorting_seed: sorting_seed
     } do
       validation_nodes =
@@ -837,7 +841,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           {:ok, %NotFound{}}
 
         _, %GetGenesisAddress{}, _ ->
-          {:ok, %GenesisAddress{address: "@Alice0", timestamp: DateTime.utc_now()}}
+          {:ok, %GenesisAddress{address: genesis, timestamp: DateTime.utc_now()}}
 
         _, %Ping{}, _ ->
           {:ok, %Ok{}}
@@ -1057,7 +1061,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       end
     end
 
-    test "should not replicate if there is a validation error", %{tx: tx} do
+    test "should not replicate if there is a validation error", %{tx: tx, genesis: genesis} do
       error = Error.new(:invalid_pending_transaction, "Transactiion already exists")
 
       validation_context = %ValidationContext{create_context(tx) | mining_error: error}
@@ -1077,7 +1081,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           {:ok, %UnspentOutputList{unspent_outputs: []}}
 
         _, %GetGenesisAddress{}, _ ->
-          {:ok, %GenesisAddress{address: "@Alice0", timestamp: DateTime.utc_now()}}
+          {:ok, %GenesisAddress{address: genesis, timestamp: DateTime.utc_now()}}
 
         _, %ValidationError{}, _ ->
           send(me, :validation_error)
@@ -1140,7 +1144,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       refute Process.alive?(coordinator_pid)
     end
 
-    test "should not replicate if there is a cross validation error", %{tx: tx} do
+    test "should not replicate if there is a cross validation error", %{tx: tx, genesis: genesis} do
       validation_context = create_context(tx)
 
       context =
@@ -1155,7 +1159,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           {:ok, %Ok{}}
 
         _, %GetGenesisAddress{}, _ ->
-          {:ok, %GenesisAddress{address: "@Alice0", timestamp: DateTime.utc_now()}}
+          {:ok, %GenesisAddress{address: genesis, timestamp: DateTime.utc_now()}}
 
         _, %GetUnspentOutputs{}, _ ->
           {:ok, %UnspentOutputList{unspent_outputs: []}}

--- a/test/archethic/mining/standalone_workflow_test.exs
+++ b/test/archethic/mining/standalone_workflow_test.exs
@@ -105,7 +105,8 @@ defmodule Archethic.Mining.StandaloneWorkflowTest do
         end
 
       _, %GetGenesisAddress{}, _ ->
-        {:ok, %GenesisAddress{address: "@Alice0", timestamp: DateTime.utc_now()}}
+        {:ok,
+         %GenesisAddress{address: Transaction.previous_address(tx), timestamp: DateTime.utc_now()}}
 
       _, %ValidateTransaction{transaction: tx}, _ ->
         Agent.update(agent_pid, fn _ -> tx end)


### PR DESCRIPTION
# Description

There are cases where we know for sure that we are querying data that exists, in these cases we add an acceptance_resolver to keep asking the data until we find it.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

unit test on the transaction_context 

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
