### PR TITLE
Add the genesis address in the validation_stamp

### DIFF
--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -200,6 +200,7 @@ defmodule Archethic.Bootstrap.NetworkInit do
 
     validation_stamp =
       %ValidationStamp{
+        genesis_address: Transaction.previous_address(tx),
         protocol_version: 1,
         timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),

--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -51,6 +51,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
           |> read_transaction(column_names, size, 0)
           |> Enum.into(%{})
           |> decode_transaction_columns(version)
+          |> set_genesis_address(genesis_address)
 
         File.close(fd)
 
@@ -163,12 +164,13 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
     case File.open(filepath, [:binary, :read]) do
       {:ok, fd} ->
         Stream.resource(
-          fn -> process_get_chain(fd, fields, [], db_path) end,
+          fn -> process_get_chain(fd, genesis_address, fields, [], db_path) end,
           fn
             {transactions, true, paging_address} ->
               next_transactions =
                 process_get_chain(
                   fd,
+                  genesis_address,
                   fields,
                   [paging_address: paging_address],
                   db_path
@@ -273,14 +275,17 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
               _ -> opts
             end
 
-          process_get_chain(fd, fields, opts, db_path)
+          process_get_chain(fd, genesis_address, fields, opts, db_path)
 
         :desc ->
           # if the paging_address=genesis_address,
           # we return empty
           case Keyword.get(opts, :paging_address) do
-            ^genesis_address -> {[], false, nil}
-            _ -> process_get_chain_desc(fd, genesis_address, fields, opts, db_path)
+            ^genesis_address ->
+              {[], false, nil}
+
+            _ ->
+              process_get_chain_desc(fd, genesis_address, fields, opts, db_path)
           end
       end
 
@@ -288,18 +293,18 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
     {transactions, more?, paging_address}
   end
 
-  defp process_get_chain(fd, fields, opts, db_path) do
+  defp process_get_chain(fd, genesis_address, fields, opts, db_path) do
     # Set the file cursor position to the paging state
     case Keyword.get(opts, :paging_address) do
       nil ->
         :file.position(fd, 0)
-        do_process_get_chain(fd, fields)
+        do_process_get_chain(fd, genesis_address, fields)
 
       paging_address ->
         case ChainIndex.get_tx_entry(paging_address, db_path) do
           {:ok, %{offset: offset, size: size}} ->
             :file.position(fd, offset + size)
-            do_process_get_chain(fd, fields)
+            do_process_get_chain(fd, genesis_address, fields)
 
           {:error, :not_exists} ->
             {[], false, nil}
@@ -307,7 +312,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
     end
   end
 
-  defp do_process_get_chain(fd, fields) do
+  defp do_process_get_chain(fd, genesis_address, fields) do
     # Always return transaction address
     fields = if Enum.empty?(fields), do: fields, else: Enum.uniq([:address | fields])
 
@@ -328,7 +333,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
       end
 
     # Read the transactions until the nb of transactions to fullfil the page (ie. 10 transactions)
-    {transactions, more?, paging_address} = get_paginated_chain(fd, column_names)
+    {transactions, more?, paging_address} = get_paginated_chain(fd, genesis_address, column_names)
 
     {transactions, more?, paging_address}
   end
@@ -376,14 +381,14 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
 
     # call the ASC function and ignore the more? and paging_address
     {transactions, _more?, _paging_address} =
-      process_get_chain(fd, fields, [paging_address: paging_address], db_path)
+      process_get_chain(fd, genesis_address, fields, [paging_address: paging_address], db_path)
 
     transactions = Enum.take(transactions, nb_to_take)
 
     {Enum.reverse(transactions), more?, new_paging_address}
   end
 
-  defp get_paginated_chain(fd, fields, acc \\ []) do
+  defp get_paginated_chain(fd, genesis_address, fields, acc \\ []) do
     case :file.read(fd, 8) do
       {:ok, <<size::32, version::32>>} ->
         if length(acc) == @page_size do
@@ -394,8 +399,9 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
             fd
             |> read_transaction(fields, size, 0)
             |> decode_transaction_columns(version)
+            |> set_genesis_address(genesis_address)
 
-          get_paginated_chain(fd, fields, [tx | acc])
+          get_paginated_chain(fd, genesis_address, fields, [tx | acc])
         end
 
       :eof ->
@@ -552,5 +558,9 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
     )
     |> Utils.atomize_keys()
     |> Transaction.cast()
+  end
+
+  defp set_genesis_address(tx = %Transaction{}, genesis_address) do
+    put_in(tx, [Access.key!(:validation_stamp), Access.key!(:genesis_address)], genesis_address)
   end
 end

--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -50,7 +50,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
           fd
           |> read_transaction(column_names, size, 0)
           |> Enum.into(%{})
-          |> set_genesis_address(genesis_address)
+          |> set_genesis_address(column_names, genesis_address)
           |> decode_transaction_columns(version)
 
         File.close(fd)
@@ -398,7 +398,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
           tx =
             fd
             |> read_transaction(fields, size, 0)
-            |> set_genesis_address(genesis_address)
+            |> set_genesis_address(fields, genesis_address)
             |> decode_transaction_columns(version)
 
           get_paginated_chain(fd, genesis_address, fields, [tx | acc])
@@ -560,7 +560,14 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
     |> Transaction.cast()
   end
 
-  defp set_genesis_address(column_values, genesis_address) do
-    Map.put(column_values, "validation_stamp.genesis_address", genesis_address)
+  defp set_genesis_address(column_values, [], genesis_address),
+    do: Map.put(column_values, "validation_stamp.genesis_address", genesis_address)
+
+  defp set_genesis_address(column_values, fields, genesis_address) do
+    genesis_field_name = "validation_stamp.genesis_address"
+
+    if Enum.member?(fields, genesis_field_name),
+      do: Map.put(column_values, genesis_field_name, genesis_address),
+      else: column_values
   end
 end

--- a/lib/archethic/db/embedded_impl/chain_reader.ex
+++ b/lib/archethic/db/embedded_impl/chain_reader.ex
@@ -50,8 +50,8 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
           fd
           |> read_transaction(column_names, size, 0)
           |> Enum.into(%{})
-          |> decode_transaction_columns(version)
           |> set_genesis_address(genesis_address)
+          |> decode_transaction_columns(version)
 
         File.close(fd)
 
@@ -398,8 +398,8 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
           tx =
             fd
             |> read_transaction(fields, size, 0)
-            |> decode_transaction_columns(version)
             |> set_genesis_address(genesis_address)
+            |> decode_transaction_columns(version)
 
           get_paginated_chain(fd, genesis_address, fields, [tx | acc])
         end
@@ -560,7 +560,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainReader do
     |> Transaction.cast()
   end
 
-  defp set_genesis_address(tx = %Transaction{}, genesis_address) do
-    put_in(tx, [Access.key!(:validation_stamp), Access.key!(:genesis_address)], genesis_address)
+  defp set_genesis_address(column_values, genesis_address) do
+    Map.put(column_values, "validation_stamp.genesis_address", genesis_address)
   end
 end

--- a/lib/archethic/db/embedded_impl/chain_writer.ex
+++ b/lib/archethic/db/embedded_impl/chain_writer.ex
@@ -40,7 +40,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
 
     filename = io_path(db_path, address)
 
-    data = Encoding.encode(tx)
+    data = Encoding.encode(tx, storage_type: :io)
 
     File.write!(
       filename,

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -34,7 +34,8 @@ defmodule Archethic.Mining do
   # version 5->6 the POI changed and is now done with tx.data.recipients.args serialized with :extended mode
   # version 6->7 add Add consumed inputs in tx.validation_stamp.ledger_operations
   # version 7->8 movement resolved address are now the genesis address of the destination
-  @protocol_version 8
+  # version 8->9 genesis in the validation stamp
+  @protocol_version 9
 
   @lock_threshold 0.75
 

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -1025,13 +1025,18 @@ defmodule Archethic.Mining.DistributedWorkflow do
   def code_change(2, state, data, _extra) do
     {:ok, state,
      case Map.get(data, :context) do
-       %{context: %ValidationContext{genesis_address: genesis_address, validation_stamp: stamp}}
+       ctx = %Archethic.Mining.ValidationContext{
+         genesis_address: genesis_address,
+         validation_stamp: stamp
+       }
        when not is_nil(genesis_address) and not is_nil(stamp) ->
-         update_in(
-           data,
-           [:context, Access.key!(:validation_stamp), Access.key!(:genesis_address)],
-           genesis_address
-         )
+         %{
+           data
+           | context: %Archethic.Mining.ValidationContext{
+               ctx
+               | validation_stamp: Map.put(stamp, :genesis_address, genesis_address)
+             }
+         }
 
        _ ->
          data

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -56,7 +56,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
   require Logger
 
   use GenStateMachine, callback_mode: [:handle_event_function, :state_enter], restart: :temporary
-  @vsn 2
+  @vsn 3
 
   @mining_timeout Application.compile_env!(:archethic, [__MODULE__, :global_timeout])
   @coordinator_timeout_supplement Application.compile_env!(:archethic, [
@@ -1020,6 +1020,22 @@ defmodule Archethic.Mining.DistributedWorkflow do
     )
 
     {:keep_state_and_data, :postpone}
+  end
+
+  def code_change(2, state, data, _extra) do
+    {:ok, state,
+     case Map.get(data, :context) do
+       %{context: %ValidationContext{genesis_address: genesis_address, validation_stamp: stamp}}
+       when not is_nil(genesis_address) and not is_nil(stamp) ->
+         update_in(
+           data,
+           [:context, Access.key!(:validation_stamp), Access.key!(:genesis_address)],
+           genesis_address
+         )
+
+       _ ->
+         data
+     end}
   end
 
   def code_change(_old_vsn, state, data, _extra), do: {:ok, state, data}

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -703,6 +703,7 @@ defmodule Archethic.Mining.ValidationContext do
   @spec create_validation_stamp(t()) :: t()
   def create_validation_stamp(
         context = %__MODULE__{
+          genesis_address: genesis_address,
           transaction: tx = %Transaction{data: %TransactionData{recipients: recipients}},
           previous_transaction: prev_tx,
           validation_time: validation_time,
@@ -728,6 +729,7 @@ defmodule Archethic.Mining.ValidationContext do
       get_ledger_operations(context, fee, validation_time, encoded_state)
 
     validation_stamp = %ValidationStamp{
+      genesis_address: genesis_address,
       protocol_version: Mining.protocol_version(),
       timestamp: validation_time,
       proof_of_work: do_proof_of_work(tx),
@@ -1146,7 +1148,8 @@ defmodule Archethic.Mining.ValidationContext do
       consumed_inputs: fn -> valid_consumed_inputs?(stamp, ledger_operations) end,
       unspent_outputs: fn -> valid_stamp_unspent_outputs?(stamp, ledger_operations) end,
       error: fn -> valid_stamp_error?(stamp, context) end,
-      protocol_version: fn -> valid_protocol_version?(stamp) end
+      protocol_version: fn -> valid_protocol_version?(stamp) end,
+      genesis_address: fn -> valid_genesis_address?(stamp, context) end
     ]
 
     subsets_verifications
@@ -1260,6 +1263,11 @@ defmodule Archethic.Mining.ValidationContext do
 
   defp valid_protocol_version?(%ValidationStamp{protocol_version: version}),
     do: Mining.protocol_version() == version
+
+  defp valid_genesis_address?(%ValidationStamp{genesis_address: genesis_address}, %__MODULE__{
+         genesis_address: ctx_genesis_address
+       }),
+       do: genesis_address == ctx_genesis_address
 
   @doc """
   Get the chain storage node position

--- a/lib/archethic/transaction_chain/transaction/validation_stamp.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp.ex
@@ -44,7 +44,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
   - Signature: generated from the coordinator private key to avoid non-repudiation of the stamp
   - Error: Error returned by the pending transaction validation or after mining context
   - Protocol version: Version of the protocol
-  - Genesis address: Genesis of the chain. **It is not present in the serialization**
+  - Genesis address: Genesis of the chain. Added in protocol_version=9
   """
   @type t :: %__MODULE__{
           timestamp: DateTime.t(),
@@ -153,11 +153,11 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
 
   @doc """
   Deserialize an encoded validation stamp
-  Opts:
-    deserialize_genesis?: true | false
+
+  Never used after a serialize(serialize_genesis?: false)
   """
-  @spec deserialize(bin :: bitstring(), Keyword.t()) :: {t(), bitstring()}
-  def deserialize(<<version::32, timestamp::64, rest::bitstring>>, opts \\ []) do
+  @spec deserialize(bin :: bitstring()) :: {t(), bitstring()}
+  def deserialize(<<version::32, timestamp::64, rest::bitstring>>) do
     <<pow_curve_id::8, pow_origin_id::8, rest::bitstring>> = rest
     pow_key_size = Crypto.key_size(pow_curve_id)
     <<pow_key::binary-size(pow_key_size), rest::bitstring>> = rest
@@ -178,12 +178,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
 
     <<signature_size::8, signature::binary-size(signature_size), rest::bitstring>> = rest
 
-    {genesis_address, rest} =
-      if Keyword.get(opts, :deserialize_genesis?, true) do
-        Utils.deserialize_address(rest)
-      else
-        {nil, rest}
-      end
+    {genesis_address, rest} = Utils.deserialize_address(rest)
 
     {
       %__MODULE__{

--- a/lib/archethic/transaction_chain/transaction/validation_stamp.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp.ex
@@ -12,6 +12,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
 
   defstruct [
     :protocol_version,
+    :genesis_address,
     :timestamp,
     :signature,
     :proof_of_work,
@@ -43,6 +44,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
   - Signature: generated from the coordinator private key to avoid non-repudiation of the stamp
   - Error: Error returned by the pending transaction validation or after mining context
   - Protocol version: Version of the protocol
+  - Genesis address: Genesis of the chain. **It is not present in the serialization**
   """
   @type t :: %__MODULE__{
           timestamp: DateTime.t(),
@@ -51,17 +53,18 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
           proof_of_integrity: Crypto.versioned_hash(),
           proof_of_election: binary(),
           ledger_operations: LedgerOperations.t(),
-          recipients: list(Crypto.versioned_hash()),
+          recipients: list(Crypto.prepended_hash()),
+          genesis_address: Crypto.prepended_hash(),
           error: error() | nil,
           protocol_version: non_neg_integer()
         }
 
   @spec sign(__MODULE__.t()) :: __MODULE__.t()
-  def sign(stamp = %__MODULE__{}) do
+  def sign(stamp = %__MODULE__{protocol_version: protocol_version}) do
     raw_stamp =
       stamp
       |> extract_for_signature()
-      |> serialize()
+      |> serialize(serialize_genesis?: protocol_version >= 9)
 
     sig = Crypto.sign_with_last_node_key(raw_stamp)
 
@@ -80,7 +83,8 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
         ledger_operations: ops,
         recipients: recipients,
         error: error,
-        protocol_version: version
+        protocol_version: version,
+        genesis_address: genesis_address
       }) do
     %__MODULE__{
       timestamp: timestamp,
@@ -90,25 +94,35 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
       ledger_operations: ops,
       recipients: recipients,
       error: error,
-      protocol_version: version
+      protocol_version: version,
+      genesis_address: genesis_address
     }
   end
 
   @doc """
   Serialize a validation stamp info binary format
+
+  Opts:
+    serialize_genesis?: true | false
   """
   @spec serialize(t()) :: bitstring()
-  def serialize(%__MODULE__{
-        timestamp: timestamp,
-        proof_of_work: pow,
-        proof_of_integrity: poi,
-        proof_of_election: poe,
-        ledger_operations: ledger_operations,
-        recipients: recipients,
-        error: error,
-        signature: nil,
-        protocol_version: version
-      }) do
+  def serialize(stamp, opts \\ [])
+
+  def serialize(
+        %__MODULE__{
+          timestamp: timestamp,
+          proof_of_work: pow,
+          proof_of_integrity: poi,
+          proof_of_election: poe,
+          ledger_operations: ledger_operations,
+          recipients: recipients,
+          error: error,
+          signature: signature,
+          protocol_version: version,
+          genesis_address: genesis_address
+        },
+        opts
+      ) do
     pow =
       if pow == "" do
         # Empty public key if the no public key matching the origin signature
@@ -123,40 +137,27 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
       poe::binary, LedgerOperations.serialize(ledger_operations, version)::bitstring,
       encoded_recipients_len::binary, :erlang.list_to_binary(recipients)::binary,
       serialize_error(error)::8>>
+    |> maybe_add_signature(signature)
+    |> maybe_add_genesis(genesis_address, Keyword.get(opts, :serialize_genesis?, true))
   end
 
-  def serialize(%__MODULE__{
-        timestamp: timestamp,
-        proof_of_work: pow,
-        proof_of_integrity: poi,
-        proof_of_election: poe,
-        ledger_operations: ledger_operations,
-        recipients: recipients,
-        error: error,
-        signature: signature,
-        protocol_version: version
-      }) do
-    pow =
-      if pow == "" do
-        # Empty public key if the no public key matching the origin signature
-        <<0::8, 0::8, 0::256>>
-      else
-        pow
-      end
+  defp maybe_add_signature(bin, nil), do: bin
 
-    encoded_recipients_len = length(recipients) |> VarInt.from_value()
+  defp maybe_add_signature(bin, signature),
+    do: <<bin::bitstring, byte_size(signature)::8, signature::binary>>
 
-    <<version::32, DateTime.to_unix(timestamp, :millisecond)::64, pow::binary, poi::binary,
-      poe::binary, LedgerOperations.serialize(ledger_operations, version)::bitstring,
-      encoded_recipients_len::binary, :erlang.list_to_binary(recipients)::binary,
-      serialize_error(error)::8, byte_size(signature)::8, signature::binary>>
-  end
+  defp maybe_add_genesis(bin, _genesis_address, false), do: bin
+
+  defp maybe_add_genesis(bin, genesis_address, true),
+    do: <<bin::bitstring, genesis_address::binary>>
 
   @doc """
   Deserialize an encoded validation stamp
+  Opts:
+    deserialize_genesis?: true | false
   """
-  @spec deserialize(bitstring()) :: {t(), bitstring()}
-  def deserialize(<<version::32, timestamp::64, rest::bitstring>>) do
+  @spec deserialize(bin :: bitstring(), Keyword.t()) :: {t(), bitstring()}
+  def deserialize(<<version::32, timestamp::64, rest::bitstring>>, opts \\ []) do
     <<pow_curve_id::8, pow_origin_id::8, rest::bitstring>> = rest
     pow_key_size = Crypto.key_size(pow_curve_id)
     <<pow_key::binary-size(pow_key_size), rest::bitstring>> = rest
@@ -177,8 +178,16 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
 
     <<signature_size::8, signature::binary-size(signature_size), rest::bitstring>> = rest
 
+    {genesis_address, rest} =
+      if Keyword.get(opts, :deserialize_genesis?, true) do
+        Utils.deserialize_address(rest)
+      else
+        {nil, rest}
+      end
+
     {
       %__MODULE__{
+        genesis_address: genesis_address,
         timestamp: DateTime.from_unix!(timestamp, :millisecond),
         proof_of_work: pow,
         proof_of_integrity: <<poi_hash_id::8, poi_hash::binary>>,
@@ -205,6 +214,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
       recipients: Map.get(stamp, :recipients, []),
       signature: Map.get(stamp, :signature),
       error: Map.get(stamp, :error),
+      genesis_address: Map.get(stamp, :genesis_address),
       protocol_version: Map.get(stamp, :protocol_version)
     }
   end
@@ -220,7 +230,8 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
         ledger_operations: ledger_operations,
         recipients: recipients,
         signature: signature,
-        error: error
+        error: error,
+        genesis_address: genesis_address
       }) do
     %{
       timestamp: timestamp,
@@ -230,7 +241,8 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
       ledger_operations: LedgerOperations.to_map(ledger_operations),
       recipients: recipients,
       signature: signature,
-      error: error
+      error: error,
+      genesis_address: genesis_address
     }
   end
 
@@ -243,14 +255,14 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
   def valid_signature?(%__MODULE__{signature: nil}, _public_key), do: false
 
   def valid_signature?(
-        stamp = %__MODULE__{signature: signature},
+        stamp = %__MODULE__{signature: signature, protocol_version: protocol_version},
         public_key
       )
       when is_binary(signature) do
     raw_stamp =
       stamp
-      |> extract_for_signature
-      |> serialize
+      |> extract_for_signature()
+      |> serialize(serialize_genesis?: protocol_version >= 9)
 
     Crypto.verify?(signature, raw_stamp, public_key)
   end
@@ -263,6 +275,8 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
   def generate_dummy(opts \\ []) do
     %__MODULE__{
       timestamp: Keyword.get(opts, :timestamp, DateTime.utc_now()),
+      genesis_address:
+        Keyword.get(opts, :genesis_address, <<0::16, :crypto.strong_rand_bytes(32)::binary>>),
       protocol_version: 1,
       proof_of_work: :crypto.strong_rand_bytes(32),
       proof_of_election: :crypto.strong_rand_bytes(32),

--- a/lib/archethic_web/api/graphql/schema/transaction_type.ex
+++ b/lib/archethic_web/api/graphql/schema/transaction_type.ex
@@ -146,6 +146,7 @@ defmodule ArchethicWeb.API.GraphQL.Schema.TransactionType do
     field(:ledger_operations, :ledger_operations)
     field(:signature, :hex)
     field(:protocol_version, :integer)
+    field(:genesis_address, :hex)
   end
 
   @desc """

--- a/lib/archethic_web/api/graphql/schema/transaction_type.ex
+++ b/lib/archethic_web/api/graphql/schema/transaction_type.ex
@@ -138,6 +138,7 @@ defmodule ArchethicWeb.API.GraphQL.Schema.TransactionType do
   - Ledger operations: All the operations performed by the transaction
   - Signature: Coordinator signature of the stamp
   - Protocol version: Version of the transaction validation protocol
+  - Genesis address: Genesis address of the chain
   """
   object :validation_stamp do
     field(:timestamp, :timestamp)

--- a/lib/archethic_web/explorer/components/transactions_list.ex
+++ b/lib/archethic_web/explorer/components/transactions_list.ex
@@ -52,7 +52,7 @@ defmodule ArchethicWeb.Explorer.Components.TransactionsList do
       <ul>
         <li class="columns is-mobile th">
           <div class="column is-3-tablet is-6-mobile">Address</div>
-          <div class="column is-3-tablet is-6-mobile">Genesis</div>
+          <div class="column is-3-tablet is-hidden-mobile">Genesis</div>
           <div class="column is-6-mobile">Type</div>
           <div class="column is-hidden-mobile">Date (UTC)</div>
           <div class="column is-hidden-mobile">Fee</div>
@@ -70,7 +70,7 @@ defmodule ArchethicWeb.Explorer.Components.TransactionsList do
                   )
               ) %>
             </div>
-            <div class="column is-3-tablet is-6-mobile">
+            <div class="column is-3-tablet is-hidden-mobile">
               <%= link(short_address(get_genesis(tx)),
                 to:
                   Routes.live_path(

--- a/lib/archethic_web/explorer/components/transactions_list.ex
+++ b/lib/archethic_web/explorer/components/transactions_list.ex
@@ -52,6 +52,7 @@ defmodule ArchethicWeb.Explorer.Components.TransactionsList do
       <ul>
         <li class="columns is-mobile th">
           <div class="column is-3-tablet is-6-mobile">Address</div>
+          <div class="column is-3-tablet is-6-mobile">Genesis</div>
           <div class="column is-6-mobile">Type</div>
           <div class="column is-hidden-mobile">Date (UTC)</div>
           <div class="column is-hidden-mobile">Fee</div>
@@ -66,6 +67,16 @@ defmodule ArchethicWeb.Explorer.Components.TransactionsList do
                     @socket,
                     ArchethicWeb.Explorer.TransactionDetailsLive,
                     Base.encode16(tx.address)
+                  )
+              ) %>
+            </div>
+            <div class="column is-3-tablet is-6-mobile">
+              <%= link(short_address(get_genesis(tx)),
+                to:
+                  Routes.live_path(
+                    @socket,
+                    ArchethicWeb.Explorer.TransactionChainLive,
+                    address: Base.encode16(get_genesis(tx))
                   )
               ) %>
             </div>
@@ -87,16 +98,28 @@ defmodule ArchethicWeb.Explorer.Components.TransactionsList do
     """
   end
 
-  # reward/nss/home...
+  # beacon
   defp get_timestamp(%TransactionSummary{timestamp: timestamp}), do: timestamp
 
   # chain page
   defp get_timestamp(%Transaction{validation_stamp: %ValidationStamp{timestamp: timestamp}}),
     do: timestamp
 
-  # oracle/origin page
+  # nss/reward/oracle/origin page
   defp get_timestamp(map) do
     Map.get(map, :timestamp)
+  end
+
+  defp get_genesis(%Transaction{
+         validation_stamp: %ValidationStamp{genesis_address: genesis_address}
+       }),
+       do: genesis_address
+
+  defp get_genesis(%TransactionSummary{genesis_address: genesis_address}),
+    do: genesis_address
+
+  defp get_genesis(map) do
+    Map.get(map, :genesis_address)
   end
 
   # reward/nss/home...

--- a/lib/archethic_web/explorer/live/chains/node_shared_secrets_chain_live.ex
+++ b/lib/archethic_web/explorer/live/chains/node_shared_secrets_chain_live.ex
@@ -3,6 +3,7 @@ defmodule ArchethicWeb.Explorer.NodeSharedSecretsChainLive do
 
   use ArchethicWeb.Explorer, :live_view
 
+  alias Archethic.Crypto
   alias Archethic.OracleChain
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction

--- a/lib/archethic_web/explorer/live/chains/node_shared_secrets_chain_live.ex
+++ b/lib/archethic_web/explorer/live/chains/node_shared_secrets_chain_live.ex
@@ -110,7 +110,15 @@ defmodule ArchethicWeb.Explorer.NodeSharedSecretsChainLive do
           |> update(
             :transactions,
             fn tx_list ->
-              [display_data(address, nb_auth_nodes, timestamp) | tx_list]
+              [
+                display_data(
+                  SharedSecrets.genesis_address(@txn_type),
+                  address,
+                  nb_auth_nodes,
+                  timestamp
+                )
+                | tx_list
+              ]
               |> Enum.take(@display_limit)
             end
           )
@@ -135,8 +143,8 @@ defmodule ArchethicWeb.Explorer.NodeSharedSecretsChainLive do
       if nb_drops < 0, do: {0, @display_limit + nb_drops}, else: {nb_drops, @display_limit}
 
     case SharedSecrets.genesis_address(@txn_type) do
-      address when is_binary(address) ->
-        address
+      genesis_address when is_binary(genesis_address) ->
+        genesis_address
         |> TransactionChain.list_chain_addresses()
         |> Stream.drop(nb_drops)
         |> Stream.take(display_limit)
@@ -144,6 +152,7 @@ defmodule ArchethicWeb.Explorer.NodeSharedSecretsChainLive do
           nb_authorized_nodes = nb_of_authorized_keys(addr)
 
           display_data(
+            genesis_address,
             addr,
             nb_authorized_nodes,
             timestamp
@@ -168,13 +177,15 @@ defmodule ArchethicWeb.Explorer.NodeSharedSecretsChainLive do
   end
 
   @spec display_data(
-          address :: binary(),
+          genesis_address :: Crypto.prepended_hash(),
+          address :: Crypto.prepended_hash(),
           nb_authorized_nodes :: non_neg_integer(),
           timestamp :: DateTime.t()
         ) ::
           map()
-  defp display_data(address, nb_authorized_nodes, timestamp) do
+  defp display_data(genesis_address, address, nb_authorized_nodes, timestamp) do
     %{
+      genesis_address: genesis_address,
       address: address,
       type: @txn_type,
       timestamp: timestamp,

--- a/lib/archethic_web/explorer/live/chains/oracle_chain_live.ex
+++ b/lib/archethic_web/explorer/live/chains/oracle_chain_live.ex
@@ -153,17 +153,24 @@ defmodule ArchethicWeb.Explorer.OracleChainLive do
     |> TransactionChain.get([
       :address,
       :type,
-      validation_stamp: [:timestamp, ledger_operations: [:fee]]
+      validation_stamp: [:genesis_address, :timestamp, ledger_operations: [:fee]]
     ])
     |> Enum.map(fn %Transaction{
                      address: address,
                      type: type,
                      validation_stamp: %ValidationStamp{
+                       genesis_address: genesis_address,
                        timestamp: timestamp,
                        ledger_operations: %LedgerOperations{fee: fee}
                      }
                    } ->
-      %{address: address, type: type, timestamp: timestamp, fee: fee}
+      %{
+        address: address,
+        type: type,
+        timestamp: timestamp,
+        fee: fee,
+        genesis_address: genesis_address
+      }
     end)
     |> Enum.reverse()
   end

--- a/lib/archethic_web/explorer/live/chains/origin_chain_live.ex
+++ b/lib/archethic_web/explorer/live/chains/origin_chain_live.ex
@@ -128,11 +128,14 @@ defmodule ArchethicWeb.Explorer.OriginChainLive do
     with {:ok,
           %Transaction{
             data: %TransactionData{content: content},
-            validation_stamp: %ValidationStamp{timestamp: timestamp}
+            validation_stamp: %ValidationStamp{
+              timestamp: timestamp,
+              genesis_address: genesis_address
+            }
           }} <-
            TransactionChain.get_transaction(address,
              data: [:content],
-             validation_stamp: [:timestamp]
+             validation_stamp: [:timestamp, :genesis_address]
            ),
          {pb_key, _} <- Utils.deserialize_public_key(content),
          family_id <- SharedSecrets.origin_family_from_public_key(pb_key) do
@@ -140,7 +143,8 @@ defmodule ArchethicWeb.Explorer.OriginChainLive do
         address: address,
         type: @txn_type,
         timestamp: timestamp,
-        family_of_origin: family_id
+        family_of_origin: family_id,
+        genesis_address: genesis_address
       }
     else
       _ -> []

--- a/lib/archethic_web/explorer/live/chains/reward_chain_live.ex
+++ b/lib/archethic_web/explorer/live/chains/reward_chain_live.ex
@@ -95,7 +95,7 @@ defmodule ArchethicWeb.Explorer.RewardChainLive do
       1 ->
         socket
         |> update(:transactions, fn tx_list ->
-          [display_data(address, type, timestamp) | tx_list]
+          [display_data(Reward.genesis_address(), address, type, timestamp) | tx_list]
           |> Enum.take(@display_limit)
         end)
         |> assign(:tx_count, tx_count + 1)
@@ -115,13 +115,14 @@ defmodule ArchethicWeb.Explorer.RewardChainLive do
       if nb_drops < 0, do: {0, @display_limit + nb_drops}, else: {nb_drops, @display_limit}
 
     case Reward.genesis_address() do
-      address when is_binary(address) ->
-        address
+      genesis_address when is_binary(genesis_address) ->
+        genesis_address
         |> TransactionChain.list_chain_addresses()
         |> Stream.drop(nb_drops)
         |> Stream.take(display_limit)
         |> Stream.map(fn {addr, timestamp} ->
           display_data(
+            genesis_address,
             addr,
             (TransactionChain.get_transaction(addr, [:type]) |> elem(1)).type,
             timestamp
@@ -135,12 +136,13 @@ defmodule ArchethicWeb.Explorer.RewardChainLive do
   end
 
   @spec display_data(
-          address :: binary(),
+          genesis_address :: Crypto.prepended_hash(),
+          address :: Crypto.prepended_hash(),
           type :: :node_rewards | :mint_rewards,
           timestamp :: DateTime.t()
         ) ::
           map()
-  defp display_data(address, type, timestamp) do
-    %{address: address, type: type, timestamp: timestamp}
+  defp display_data(genesis_address, address, type, timestamp) do
+    %{genesis_address: genesis_address, address: address, type: type, timestamp: timestamp}
   end
 end

--- a/lib/archethic_web/explorer/live/chains/reward_chain_live.ex
+++ b/lib/archethic_web/explorer/live/chains/reward_chain_live.ex
@@ -3,6 +3,7 @@ defmodule ArchethicWeb.Explorer.RewardChainLive do
 
   use ArchethicWeb.Explorer, :live_view
 
+  alias Archethic.Crypto
   alias Archethic.OracleChain
   alias Archethic.TransactionChain
   alias Archethic.PubSub

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -19,7 +19,7 @@
           <% end %>
         </div>
       <% end %>
-      <%= if @address != burning_address() do %>
+      <%= if @address != burning_address() && not is_nil(@transaction) do %>
         <div class="level-item">
           <%= link class: "simple-button", to: Routes.live_path(@socket, ArchethicWeb.Explorer.TransactionChainLive, address: Base.encode16(@transaction.validation_stamp.genesis_address)) do %>
             <span>Explore chain</span>

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -21,7 +21,7 @@
       <% end %>
       <%= if @address != burning_address() do %>
         <div class="level-item">
-          <%= link class: "simple-button", to: Routes.live_path(@socket, ArchethicWeb.Explorer.TransactionChainLive, address: Base.encode16(@address)) do %>
+          <%= link class: "simple-button", to: Routes.live_path(@socket, ArchethicWeb.Explorer.TransactionChainLive, address: Base.encode16(@transaction.validation_stamp.genesis_address)) do %>
             <span>Explore chain</span>
           <% end %>
         </div>
@@ -64,6 +64,21 @@
       <% true -> %>
         <div class="is-2">
           <div>
+            <%!-------------------------------- GENESIS --------------------------------%>
+            <div class="columns">
+              <div class="column ae-left-heading is-2">Genesis</div>
+              <div class="column">
+                <%= link(short_address(@transaction.validation_stamp.genesis_address),
+                  to:
+                    Routes.live_path(
+                      @socket,
+                      ArchethicWeb.Explorer.TransactionChainLive,
+                      address: Base.encode16(@transaction.validation_stamp.genesis_address)
+                    )
+                ) %>
+              </div>
+            </div>
+
             <%!-------------------------------- TYPE --------------------------------%>
             <div class="columns">
               <div class="column ae-left-heading is-2">Type</div>
@@ -185,7 +200,7 @@
                     x-show="show"
                     class="language-json"
                     phx-hook="CodeViewer"
-                  > 
+                  >
                     <%= print_state(state_utxo) %>
                   </pre>
                 <% end %>

--- a/priv/migration_tasks/prod/1.6.0@genesis.exs
+++ b/priv/migration_tasks/prod/1.6.0@genesis.exs
@@ -1,0 +1,33 @@
+defmodule Migration_1_6_0 do
+  @moduledoc false
+
+  alias Archethic.DB
+  alias Archethic.DB.EmbeddedImpl.ChainWriter
+  alias Archethic.Election
+  alias Archethic.P2P
+  alias Archethic.TransactionChain
+
+  require Logger
+
+  def run() do
+    nodes = P2P.authorized_and_available_nodes()
+    db_path = :persistent_term.get(:archethic_db_path)
+
+    DB.list_io_transactions([])
+    |> Stream.each(fn transaction ->
+      if is_nil(transaction.validation_stamp.genesis_address) do
+        # query for genesis
+        storage_nodes = Election.storage_nodes(transaction.address, nodes)
+        {:ok, genesis_address} = TransactionChain.fetch_genesis_address(transaction.address, storage_nodes)
+
+        # update in memory
+        transaction = put_in(transaction, [Access.key!(:validation_stamp), Access.key!(:genesis_address)], genesis_address)
+
+        # update on disk
+        File.rm!(ChainWriter.io_path(db_path, transaction.address))
+        ChainWriter.write_io_transaction(transaction, db_path)
+      end
+    end)
+    |> Stream.run()
+  end
+end

--- a/test/archethic/db/embedded_impl_test.exs
+++ b/test/archethic/db/embedded_impl_test.exs
@@ -86,7 +86,7 @@ defmodule Archethic.DB.EmbeddedTest do
 
       contents = File.read!(filename)
 
-      assert contents == Encoding.encode(tx1)
+      assert contents == Encoding.encode(tx1, storage_type: :io)
     end
 
     test "should delete transaction in io storage after writing it in chain storage", %{
@@ -295,7 +295,7 @@ defmodule Archethic.DB.EmbeddedTest do
 
     test "should return a page and its paging state" do
       transactions =
-        Enum.map(1..20, fn i ->
+        Enum.map(0..19, fn i ->
           tx =
             TransactionFactory.create_valid_transaction([],
               index: i,
@@ -325,7 +325,7 @@ defmodule Archethic.DB.EmbeddedTest do
 
     test "should return an empty list when the Paging Address is not found" do
       transactions =
-        Enum.map(1..15, fn i ->
+        Enum.map(0..14, fn i ->
           tx =
             TransactionFactory.create_valid_transaction([],
               index: i,
@@ -352,7 +352,7 @@ defmodule Archethic.DB.EmbeddedTest do
 
     test "should return entire chain if paging_address is the genesis (asc)" do
       transactions =
-        Enum.map(1..5, fn i ->
+        Enum.map(0..4, fn i ->
           tx =
             TransactionFactory.create_valid_transaction([],
               index: i,
@@ -379,7 +379,7 @@ defmodule Archethic.DB.EmbeddedTest do
 
     test "should return empty if paging_address is the genesis (desc)" do
       transactions =
-        Enum.map(1..5, fn i ->
+        Enum.map(0..4, fn i ->
           tx =
             TransactionFactory.create_valid_transaction([],
               index: i,
@@ -414,7 +414,7 @@ defmodule Archethic.DB.EmbeddedTest do
 
     test "should return all transactions if there are less than one page (10)" do
       transactions =
-        Enum.map(1..9, fn i ->
+        Enum.map(0..8, fn i ->
           tx =
             TransactionFactory.create_valid_transaction([],
               index: i,
@@ -435,7 +435,7 @@ defmodule Archethic.DB.EmbeddedTest do
 
     test "should return transactions paginated if there are more than one page (10)" do
       transactions =
-        Enum.map(1..28, fn i ->
+        Enum.map(0..27, fn i ->
           tx =
             TransactionFactory.create_valid_transaction([],
               index: i,
@@ -474,7 +474,7 @@ defmodule Archethic.DB.EmbeddedTest do
 
     test "should be able to load the last page if there are 10 transactions (for a page_size=10)" do
       transactions =
-        Enum.map(1..30, fn i ->
+        Enum.map(0..29, fn i ->
           tx =
             TransactionFactory.create_valid_transaction([],
               index: i,
@@ -519,7 +519,7 @@ defmodule Archethic.DB.EmbeddedTest do
 
     test "should return the number of transaction in a chain" do
       transactions =
-        Enum.map(1..20, fn i ->
+        Enum.map(0..19, fn i ->
           tx =
             TransactionFactory.create_valid_transaction([],
               index: i,

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -1322,6 +1322,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
     Enum.each(previous_storage_nodes, &P2P.add_and_connect_node(&1))
 
     %ValidationContext{
+      genesis_address: Transaction.previous_address(tx),
       transaction: tx,
       previous_storage_nodes: previous_storage_nodes,
       unspent_outputs: [
@@ -1344,6 +1345,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
   end
 
   defp create_validation_stamp(%ValidationContext{
+         genesis_address: genesis_address,
          transaction: tx,
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
@@ -1366,6 +1368,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
+      genesis_address: genesis_address,
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -606,6 +606,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       tx |> Transaction.get_movements() |> Enum.map(&{&1.to, &1.to}) |> Map.new()
 
     %ValidationContext{
+      genesis_address: Transaction.previous_address(tx),
       transaction: tx,
       previous_storage_nodes: previous_storage_nodes,
       unspent_outputs: unspent_outputs,
@@ -619,6 +620,7 @@ defmodule Archethic.Mining.ValidationContextTest do
   end
 
   defp create_validation_stamp_with_invalid_signature(%ValidationContext{
+         genesis_address: genesis_address,
          transaction: tx,
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
@@ -640,6 +642,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
+      genesis_address: genesis_address,
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -651,6 +654,7 @@ defmodule Archethic.Mining.ValidationContextTest do
   end
 
   defp create_validation_stamp_with_invalid_proof_of_work(%ValidationContext{
+         genesis_address: genesis_address,
          transaction: tx,
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
@@ -672,6 +676,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
+      genesis_address: genesis_address,
       timestamp: timestamp,
       proof_of_work: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -683,6 +688,7 @@ defmodule Archethic.Mining.ValidationContextTest do
   end
 
   defp create_validation_stamp(%ValidationContext{
+         genesis_address: genesis_address,
          transaction: tx,
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
@@ -704,6 +710,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
+      genesis_address: genesis_address,
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -716,6 +723,7 @@ defmodule Archethic.Mining.ValidationContextTest do
 
   defp create_validation_stamp_with_invalid_transaction_fee(
          %ValidationContext{
+           genesis_address: genesis_address,
            transaction: tx,
            unspent_outputs: unspent_outputs,
            validation_time: timestamp
@@ -737,6 +745,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
+      genesis_address: genesis_address,
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -748,6 +757,7 @@ defmodule Archethic.Mining.ValidationContextTest do
   end
 
   defp create_validation_stamp_with_invalid_transaction_movements(%ValidationContext{
+         genesis_address: genesis_address,
          transaction: tx,
          validation_time: timestamp,
          unspent_outputs: unspent_outputs
@@ -771,6 +781,7 @@ defmodule Archethic.Mining.ValidationContextTest do
     }
 
     %ValidationStamp{
+      genesis_address: genesis_address,
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -782,11 +793,13 @@ defmodule Archethic.Mining.ValidationContextTest do
   end
 
   defp create_validation_stamp_with_invalid_unspent_outputs(%ValidationContext{
+         genesis_address: genesis_address,
          transaction: tx,
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
        }) do
     %ValidationStamp{
+      genesis_address: genesis_address,
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -810,6 +823,7 @@ defmodule Archethic.Mining.ValidationContextTest do
   end
 
   defp create_validation_stamp_with_invalid_errors(%ValidationContext{
+         genesis_address: genesis_address,
          transaction: tx,
          unspent_outputs: unspent_outputs,
          validation_time: timestamp
@@ -830,6 +844,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
+      genesis_address: genesis_address,
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -842,6 +857,7 @@ defmodule Archethic.Mining.ValidationContextTest do
   end
 
   defp create_validation_stamp_with_invalid_consumed_inputs(%ValidationContext{
+         genesis_address: genesis_address,
          transaction: tx,
          validation_time: timestamp,
          unspent_outputs: unspent_outputs
@@ -874,6 +890,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       )
 
     %ValidationStamp{
+      genesis_address: genesis_address,
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -240,6 +240,7 @@ defmodule Archethic.P2P.MessageTest do
           <<0, 0, 227, 129, 244, 35, 48, 113, 14, 75, 1, 127, 107, 32, 29, 93, 232, 119, 254, 1,
             65, 32, 47, 129, 164, 142, 240, 43, 22, 81, 188, 212, 56, 238>>,
         validation_stamp: %ValidationStamp{
+          genesis_address: random_address(),
           timestamp: ~U[2020-06-26 06:37:04.000Z],
           proof_of_work:
             <<0, 0, 206, 159, 122, 114, 106, 65, 116, 18, 224, 214, 2, 26, 213, 36, 82, 175, 176,
@@ -296,6 +297,7 @@ defmodule Archethic.P2P.MessageTest do
           <<0, 0, 227, 129, 244, 35, 48, 113, 14, 75, 1, 127, 107, 32, 29, 93, 232, 119, 254, 1,
             65, 32, 47, 129, 164, 142, 240, 43, 22, 81, 188, 212, 56, 238>>,
         validation_stamp: %ValidationStamp{
+          genesis_address: random_address(),
           timestamp: ~U[2020-06-26 06:37:04.000Z],
           proof_of_work:
             <<0, 0, 206, 159, 122, 114, 106, 65, 116, 18, 224, 214, 2, 26, 213, 36, 82, 175, 176,
@@ -484,6 +486,7 @@ defmodule Archethic.P2P.MessageTest do
                 175, 135, 180, 179, 28, 57, 84, 35, 156, 173, 212, 235, 155, 226, 41, 148, 171,
                 132, 196, 120, 51, 136, 4, 78, 123, 70, 44, 76, 162>>,
             validation_stamp: %ValidationStamp{
+              genesis_address: random_address(),
               timestamp: ~U[2020-06-26 06:37:04.000Z],
               proof_of_work:
                 <<0, 0, 206, 159, 122, 114, 106, 65, 116, 18, 224, 214, 2, 26, 213, 36, 82, 175,

--- a/test/archethic/transaction_chain/transaction/cross_validation_stamp_test.exs
+++ b/test/archethic/transaction_chain/transaction/cross_validation_stamp_test.exs
@@ -1,6 +1,7 @@
 defmodule Archethic.TransactionChain.Transaction.CrossValidationStampTest do
   use ArchethicCase
   use ExUnitProperties
+  import ArchethicCase
 
   alias Archethic.Crypto
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
@@ -15,18 +16,20 @@ defmodule Archethic.TransactionChain.Transaction.CrossValidationStampTest do
             pow <- StreamData.binary(length: 32),
             poi <- StreamData.binary(length: 33),
             poe <- StreamData.binary(length: 64),
-            signature <- StreamData.binary(length: 64)
+            signature <- StreamData.binary(length: 64),
+            protocol_version <- StreamData.integer(1..Archethic.Mining.protocol_version())
           ) do
       pub = Crypto.last_node_public_key()
 
       validation_stamp = %ValidationStamp{
+        genesis_address: random_address(),
         timestamp: DateTime.utc_now(),
         proof_of_work: <<0::8, 0::8, pow::binary>>,
         proof_of_integrity: poi,
         proof_of_election: poe,
         ledger_operations: %LedgerOperations{},
         signature: signature,
-        protocol_version: ArchethicCase.current_protocol_version()
+        protocol_version: protocol_version
       }
 
       cross_stamp =

--- a/test/archethic/transaction_chain/transaction/validation_stamp_test.exs
+++ b/test/archethic/transaction_chain/transaction/validation_stamp_test.exs
@@ -1,7 +1,7 @@
 defmodule Archethic.TransactionChain.Transaction.ValidationStampTest do
   use ArchethicCase
 
-  import ArchethicCase, only: [current_protocol_version: 0]
+  import ArchethicCase
   use ExUnitProperties
 
   alias Archethic.Crypto
@@ -22,17 +22,21 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStampTest do
             proof_of_work <- StreamData.binary(length: 33),
             proof_of_integrity <- StreamData.binary(length: 33),
             proof_of_election <- StreamData.binary(length: 32),
-            ledger_operations <- gen_ledger_operations()
+            genesis_address <-
+              StreamData.binary(length: 32) |> StreamData.map(&<<0::16, &1::binary>>),
+            ledger_operations <- gen_ledger_operations(),
+            protocol_version <- StreamData.integer(1..Archethic.Mining.protocol_version())
           ) do
       pub = Crypto.last_node_public_key()
 
       assert %ValidationStamp{
+               genesis_address: genesis_address,
                timestamp: DateTime.utc_now(),
                proof_of_work: proof_of_work,
                proof_of_integrity: proof_of_integrity,
                proof_of_election: proof_of_election,
                ledger_operations: ledger_operations,
-               protocol_version: current_protocol_version()
+               protocol_version: protocol_version
              }
              |> ValidationStamp.sign()
              |> ValidationStamp.valid_signature?(pub)
@@ -91,6 +95,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStampTest do
   describe "symmetric serialization" do
     test "should support latest version" do
       stamp = %ValidationStamp{
+        genesis_address: random_address(),
         timestamp: ~U[2021-05-07 13:11:19.000Z],
         proof_of_work:
           <<0, 0, 34, 248, 200, 166, 69, 102, 246, 46, 84, 7, 6, 84, 66, 27, 8, 78, 103, 37, 155,
@@ -133,5 +138,50 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStampTest do
                |> ValidationStamp.deserialize()
                |> elem(0)
     end
+  end
+
+  test "should support serialize_genesis? flag" do
+    stamp = %ValidationStamp{
+      timestamp: ~U[2021-05-07 13:11:19.000Z],
+      proof_of_work:
+        <<0, 0, 34, 248, 200, 166, 69, 102, 246, 46, 84, 7, 6, 84, 66, 27, 8, 78, 103, 37, 155,
+          114, 208, 205, 40, 44, 6, 159, 178, 5, 186, 168, 237, 206>>,
+      proof_of_integrity:
+        <<0, 49, 174, 251, 208, 41, 135, 147, 199, 114, 232, 140, 254, 103, 186, 138, 175, 28,
+          156, 201, 30, 100, 75, 172, 95, 135, 167, 180, 242, 16, 74, 87, 170>>,
+      proof_of_election:
+        <<195, 51, 61, 55, 140, 12, 138, 246, 249, 106, 198, 175, 145, 9, 255, 133, 67, 240, 175,
+          53, 236, 65, 151, 191, 128, 11, 58, 103, 82, 6, 218, 31, 220, 114, 65, 3, 151, 209, 9,
+          84, 209, 105, 191, 180, 156, 157, 95, 25, 202, 2, 169, 112, 109, 54, 99, 40, 47, 96, 93,
+          33, 82, 40, 100, 13>>,
+      ledger_operations: %LedgerOperations{
+        fee: 10_000_000,
+        transaction_movements: [],
+        unspent_outputs: [],
+        consumed_inputs: [
+          %UnspentOutput{
+            from:
+              <<0, 0, 173, 169, 83, 136, 99, 24, 144, 188, 36, 180, 147, 166, 126, 118, 48, 185,
+                248, 65, 34, 85, 12, 87, 197, 69, 121, 0, 21, 5, 152, 20, 7, 197>>,
+            amount: 100_000_000,
+            type: :UCO,
+            timestamp: ~U[2021-05-05 13:11:19.000Z]
+          }
+          |> VersionedUnspentOutput.wrap_unspent_output(current_protocol_version())
+        ]
+      },
+      signature:
+        <<67, 12, 4, 246, 155, 34, 32, 108, 195, 54, 139, 8, 77, 152, 5, 55, 233, 217, 126, 181,
+          204, 195, 215, 239, 124, 186, 99, 187, 251, 243, 201, 6, 122, 65, 238, 221, 14, 89, 120,
+          225, 39, 33, 95, 95, 225, 113, 143, 200, 47, 96, 239, 66, 182, 168, 35, 129, 240, 35,
+          183, 47, 69, 154, 37, 172>>,
+      protocol_version: current_protocol_version()
+    }
+
+    assert stamp ==
+             stamp
+             |> ValidationStamp.serialize(serialize_genesis?: false)
+             |> ValidationStamp.deserialize(deserialize_genesis?: false)
+             |> elem(0)
   end
 end

--- a/test/archethic/transaction_chain/transaction/validation_stamp_test.exs
+++ b/test/archethic/transaction_chain/transaction/validation_stamp_test.exs
@@ -142,6 +142,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStampTest do
 
   test "should support serialize_genesis? flag" do
     stamp = %ValidationStamp{
+      genesis_address: random_address(),
       timestamp: ~U[2021-05-07 13:11:19.000Z],
       proof_of_work:
         <<0, 0, 34, 248, 200, 166, 69, 102, 246, 46, 84, 7, 6, 84, 66, 27, 8, 78, 103, 37, 155,
@@ -178,10 +179,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStampTest do
       protocol_version: current_protocol_version()
     }
 
-    assert stamp ==
-             stamp
-             |> ValidationStamp.serialize(serialize_genesis?: false)
-             |> ValidationStamp.deserialize(deserialize_genesis?: false)
-             |> elem(0)
+    refute ValidationStamp.serialize(stamp) ==
+             ValidationStamp.serialize(stamp, serialize_genesis?: false)
   end
 end

--- a/test/archethic/transaction_chain/transaction_test.exs
+++ b/test/archethic/transaction_chain/transaction_test.exs
@@ -534,6 +534,7 @@ defmodule Archethic.TransactionChain.TransactionTest do
             13, 122, 125, 219, 122, 131, 73, 6>>,
         type: :oracle,
         validation_stamp: %Archethic.TransactionChain.Transaction.ValidationStamp{
+          genesis_address: random_address(),
           ledger_operations:
             %Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations{
               fee: 0,

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -114,6 +114,7 @@ defmodule Archethic.TransactionFactory do
 
     validation_stamp =
       %ValidationStamp{
+        genesis_address: seed |> Crypto.derive_keypair(0) |> elem(0) |> Crypto.derive_address(),
         timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
@@ -166,6 +167,7 @@ defmodule Archethic.TransactionFactory do
 
     validation_stamp =
       %ValidationStamp{
+        genesis_address: "seed" |> Crypto.derive_keypair(0) |> elem(0) |> Crypto.derive_address(),
         timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -210,6 +212,7 @@ defmodule Archethic.TransactionFactory do
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp = %ValidationStamp{
+      genesis_address: "seed" |> Crypto.derive_keypair(0) |> elem(0) |> Crypto.derive_address(),
       timestamp: timestamp,
       proof_of_work: <<0, 0, :crypto.strong_rand_bytes(32)::binary>>,
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -258,6 +261,7 @@ defmodule Archethic.TransactionFactory do
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp = %ValidationStamp{
+      genesis_address: seed |> Crypto.derive_keypair(0) |> elem(0) |> Crypto.derive_address(),
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -300,6 +304,7 @@ defmodule Archethic.TransactionFactory do
 
     validation_stamp =
       %ValidationStamp{
+        genesis_address: "seed" |> Crypto.derive_keypair(0) |> elem(0) |> Crypto.derive_address(),
         timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
@@ -343,6 +348,7 @@ defmodule Archethic.TransactionFactory do
 
     validation_stamp =
       %ValidationStamp{
+        genesis_address: "seed" |> Crypto.derive_keypair(0) |> elem(0) |> Crypto.derive_address(),
         timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
@@ -403,6 +409,7 @@ defmodule Archethic.TransactionFactory do
 
     validation_stamp =
       %ValidationStamp{
+        genesis_address: seed |> Crypto.derive_keypair(0) |> elem(0) |> Crypto.derive_address(),
         timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),


### PR DESCRIPTION
# Description

Added the genesis_address in the validation_stamp. It's written on disk only on IO transaction, because the chain storage is written in a file named by the genesis, so there's no point to duplicate the data there.
There's a migration script to run on all legacy IOs

- [ ] Update migration version when decided which version it'll be

Fixes #1562

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Updated the code to store every tx also as IO then run a release upgrade on 4 nodes.
Chain & IO storage both returned the genesis address on legacy and new transactions

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
