### PR TITLE
Add timestamp in node validation election

### DIFF
--- a/lib/archethic/election.ex
+++ b/lib/archethic/election.ex
@@ -23,13 +23,16 @@ defmodule Archethic.Election do
   """
   @spec validation_nodes_election_seed_sorting(Transaction.t(), DateTime.t()) :: binary()
   def validation_nodes_election_seed_sorting(tx = %Transaction{}, timestamp = %DateTime{}) do
-    tx_hash =
+    serialized_tx =
       tx
       |> Transaction.to_pending()
       |> Transaction.serialize()
+
+    sorting_hash =
+      <<serialized_tx::bitstring, DateTime.to_unix(timestamp, :millisecond)::64>>
       |> Crypto.hash()
 
-    Crypto.sign_with_daily_nonce_key(tx_hash, timestamp)
+    Crypto.sign_with_daily_nonce_key(sorting_hash, timestamp)
   end
 
   @doc """

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -80,11 +80,13 @@ defmodule Archethic.Mining do
   @doc """
   Elect validation nodes for a transaction
   """
-  def get_validation_nodes(tx = %Transaction{address: tx_address, validation_stamp: nil}) do
-    current_date = DateTime.utc_now()
-    sorting_seed = Election.validation_nodes_election_seed_sorting(tx, current_date)
+  def get_validation_nodes(
+        tx = %Transaction{address: tx_address, validation_stamp: nil},
+        ref_timestamp
+      ) do
+    sorting_seed = Election.validation_nodes_election_seed_sorting(tx, ref_timestamp)
 
-    node_list = P2P.authorized_and_available_nodes(current_date)
+    node_list = P2P.authorized_and_available_nodes(ref_timestamp)
 
     storage_nodes = Election.chain_storage_nodes(tx_address, node_list)
 
@@ -100,10 +102,11 @@ defmodule Archethic.Mining do
   @doc """
   Determines if the election of validation nodes performed by the welcome node is valid
   """
-  @spec valid_election?(Transaction.t(), list(Crypto.key())) :: boolean()
-  def valid_election?(tx, validation_node_public_keys)
+  @spec valid_election?(Transaction.t(), list(Crypto.key()), ref_timestamp :: DateTime.t()) ::
+          boolean()
+  def valid_election?(tx, validation_node_public_keys, ref_timestamp)
       when is_list(validation_node_public_keys) do
-    validation_nodes = get_validation_nodes(tx)
+    validation_nodes = get_validation_nodes(tx, ref_timestamp)
     validation_node_public_keys == Enum.map(validation_nodes, & &1.last_public_key)
   end
 

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -218,9 +218,9 @@ defmodule Archethic.Mining.DistributedWorkflow do
         :internal,
         {:start_mining, tx, welcome_node, validation_nodes, contract_context},
         :idle,
-        data = %{node_public_key: node_public_key}
+        data = %{ref_timestamp: ref_timestamp, node_public_key: node_public_key}
       ) do
-    validation_time = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+    validation_time = ref_timestamp |> DateTime.truncate(:millisecond)
 
     authorized_nodes = P2P.authorized_and_available_nodes(validation_time)
 

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -1161,8 +1161,7 @@ defmodule Archethic.Mining.ValidationContext do
   defp valid_timestamp(%ValidationStamp{timestamp: timestamp}, %__MODULE__{
          validation_time: validation_time
        }) do
-    diff = DateTime.diff(timestamp, validation_time)
-    diff <= 10 and diff > -10
+    DateTime.compare(timestamp, validation_time) == :eq
   end
 
   defp valid_stamp_signature(stamp = %ValidationStamp{}, %__MODULE__{

--- a/lib/archethic/p2p/message/start_mining.ex
+++ b/lib/archethic/p2p/message/start_mining.ex
@@ -64,7 +64,7 @@ defmodule Archethic.P2P.Message.StartMining do
       ) do
     with :ok <- check_ref_timestamp(ref_timestamp),
          :ok <- check_synchronization(network_chains_view_hash, p2p_view_hash),
-         :ok <- check_valid_election(tx, validation_nodes),
+         :ok <- check_valid_election(tx, validation_nodes, ref_timestamp),
          :ok <- check_current_node_is_elected(validation_nodes),
          :ok <- check_not_already_mining(tx.address),
          :ok <- Mining.request_chain_lock(tx) do
@@ -212,8 +212,8 @@ defmodule Archethic.P2P.Message.StartMining do
     end
   end
 
-  defp check_valid_election(tx, validation_nodes) do
-    if Mining.valid_election?(tx, validation_nodes) do
+  defp check_valid_election(tx, validation_nodes, ref_timestamp) do
+    if Mining.valid_election?(tx, validation_nodes, ref_timestamp) do
       :ok
     else
       {:error, :invalid_validation_nodes_election}

--- a/test/archethic/election_test.exs
+++ b/test/archethic/election_test.exs
@@ -16,123 +16,238 @@ defmodule Archethic.ElectionTest do
 
   doctest Election
 
-  describe "validation_nodes/4" do
-    test "should change for new transaction" do
-      authorized_nodes = [
-        %Node{
-          first_public_key: "Node0",
-          last_public_key: "Node0",
-          available?: true,
-          geo_patch: "AAA"
-        },
-        %Node{
-          first_public_key: "Node1",
-          last_public_key: "Node1",
-          available?: true,
-          geo_patch: "CCC"
-        },
-        %Node{
-          first_public_key: "Node2",
-          last_public_key: "Node2",
-          available?: true,
-          geo_patch: "CCC"
-        },
-        %Node{
-          first_public_key: "Node3",
-          last_public_key: "Node3",
-          available?: true,
-          geo_patch: "F24"
-        }
-      ]
-
-      storage_nodes = [
-        %Node{
-          first_public_key: "Node10",
-          last_public_key: "Node10",
-          available?: true,
-          geo_patch: "AAA"
-        },
-        %Node{
-          first_public_key: "Node11",
-          last_public_key: "Node11",
-          available?: true,
-          geo_patch: "CCC"
-        },
-        %Node{
-          first_public_key: "Node12",
-          last_public_key: "Node12",
-          available?: true,
-          geo_patch: "CCC"
-        },
-        %Node{
-          first_public_key: "Node13",
-          last_public_key: "Node13",
-          available?: true,
-          geo_patch: "F24"
-        }
-      ]
-
-      tx1 = %Transaction{
-        address:
-          <<0, 120, 195, 32, 77, 84, 215, 196, 116, 215, 56, 141, 40, 54, 226, 48, 66, 254, 119,
-            11, 73, 77, 243, 125, 62, 94, 133, 67, 9, 253, 45, 134, 89>>,
-        type: :transfer,
-        data: %TransactionData{},
-        previous_public_key:
-          <<0, 239, 240, 90, 182, 66, 190, 68, 20, 250, 131, 83, 190, 29, 184, 177, 52, 166, 207,
-            80, 193, 110, 57, 6, 199, 152, 184, 24, 178, 179, 11, 164, 150>>,
-        previous_signature:
-          <<200, 70, 0, 25, 105, 111, 15, 161, 146, 188, 100, 234, 147, 62, 127, 8, 152, 60, 66,
-            169, 113, 255, 51, 112, 59, 200, 61, 63, 128, 228, 111, 104, 47, 15, 81, 185, 179, 36,
-            59, 86, 171, 7, 138, 199, 203, 252, 50, 87, 160, 107, 119, 131, 121, 11, 239, 169, 99,
-            203, 76, 159, 158, 243, 133, 133>>,
-        origin_signature:
-          <<162, 223, 100, 72, 17, 56, 99, 212, 78, 132, 166, 81, 127, 91, 214, 143, 221, 32, 106,
-            189, 247, 64, 183, 27, 55, 142, 254, 72, 47, 215, 34, 108, 233, 55, 35, 94, 49, 165,
-            180, 248, 229, 160, 229, 220, 191, 35, 80, 127, 213, 240, 195, 185, 165, 89, 172, 97,
-            170, 217, 57, 254, 125, 127, 62, 169>>
+  setup do
+    authorized_nodes = [
+      %Node{
+        first_public_key: "Node0",
+        last_public_key: "Node0",
+        available?: true,
+        geo_patch: "AAA"
+      },
+      %Node{
+        first_public_key: "Node1",
+        last_public_key: "Node1",
+        available?: true,
+        geo_patch: "CCC"
+      },
+      %Node{
+        first_public_key: "Node2",
+        last_public_key: "Node2",
+        available?: true,
+        geo_patch: "CCC"
+      },
+      %Node{
+        first_public_key: "Node3",
+        last_public_key: "Node3",
+        available?: true,
+        geo_patch: "F24"
       }
+    ]
+
+    storage_nodes = [
+      %Node{
+        first_public_key: "Node10",
+        last_public_key: "Node10",
+        available?: true,
+        geo_patch: "AAA"
+      },
+      %Node{
+        first_public_key: "Node11",
+        last_public_key: "Node11",
+        available?: true,
+        geo_patch: "CCC"
+      },
+      %Node{
+        first_public_key: "Node12",
+        last_public_key: "Node12",
+        available?: true,
+        geo_patch: "CCC"
+      },
+      %Node{
+        first_public_key: "Node13",
+        last_public_key: "Node13",
+        available?: true,
+        geo_patch: "F24"
+      }
+    ]
+
+    tx1 = %Transaction{
+      address:
+        <<0, 120, 195, 32, 77, 84, 215, 196, 116, 215, 56, 141, 40, 54, 226, 48, 66, 254, 119, 11,
+          73, 77, 243, 125, 62, 94, 133, 67, 9, 253, 45, 134, 89>>,
+      type: :transfer,
+      data: %TransactionData{},
+      previous_public_key:
+        <<0, 239, 240, 90, 182, 66, 190, 68, 20, 250, 131, 83, 190, 29, 184, 177, 52, 166, 207,
+          80, 193, 110, 57, 6, 199, 152, 184, 24, 178, 179, 11, 164, 150>>,
+      previous_signature:
+        <<200, 70, 0, 25, 105, 111, 15, 161, 146, 188, 100, 234, 147, 62, 127, 8, 152, 60, 66,
+          169, 113, 255, 51, 112, 59, 200, 61, 63, 128, 228, 111, 104, 47, 15, 81, 185, 179, 36,
+          59, 86, 171, 7, 138, 199, 203, 252, 50, 87, 160, 107, 119, 131, 121, 11, 239, 169, 99,
+          203, 76, 159, 158, 243, 133, 133>>,
+      origin_signature:
+        <<162, 223, 100, 72, 17, 56, 99, 212, 78, 132, 166, 81, 127, 91, 214, 143, 221, 32, 106,
+          189, 247, 64, 183, 27, 55, 142, 254, 72, 47, 215, 34, 108, 233, 55, 35, 94, 49, 165,
+          180, 248, 229, 160, 229, 220, 191, 35, 80, 127, 213, 240, 195, 185, 165, 89, 172, 97,
+          170, 217, 57, 254, 125, 127, 62, 169>>
+    }
+
+    tx2 = %Transaction{
+      address:
+        <<0, 121, 194, 31, 76, 85, 216, 195, 115, 214, 57, 140, 41, 55, 225, 49, 67, 255, 118, 12,
+          72, 76, 242, 124, 63, 95, 132, 66, 8, 252, 46, 135, 88>>,
+      type: :transfer,
+      data: %TransactionData{},
+      previous_public_key:
+        <<0, 238, 241, 91, 183, 67, 191, 69, 21, 251, 130, 82, 191, 28, 185, 176, 53, 167, 206,
+          81, 192, 111, 56, 7, 198, 153, 185, 19, 179, 178, 10, 165, 151>>,
+      previous_signature:
+        <<199, 71, 1, 24, 104, 110, 14, 160, 147, 189, 101, 235, 146, 61, 126, 9, 153, 61, 67,
+          168, 112, 254, 52, 113, 58, 199, 60, 62, 129, 229, 110, 105, 46, 14, 80, 184, 178, 35,
+          58, 85, 172, 6, 139, 198, 202, 253, 51, 86, 161, 106, 118, 132, 120, 10, 238, 168, 98,
+          202, 75, 158, 159, 242, 132, 134>>,
+      origin_signature:
+        <<163, 222, 101, 73, 16, 57, 98, 213, 79, 133, 167, 82, 126, 90, 215, 142, 220, 31, 107,
+          188, 246, 65, 182, 26, 54, 143, 255, 71, 46, 214, 33, 109, 232, 56, 34, 93, 50, 164,
+          181, 249, 228, 161, 228, 221, 190, 34, 81, 126, 212, 241, 194, 184, 164, 88, 173, 96,
+          171, 216, 56, 253, 126, 126, 63, 168>>
+    }
+
+    %{
+      authorized_nodes: authorized_nodes,
+      storage_nodes: storage_nodes,
+      tx1: tx1,
+      tx2: tx2
+    }
+  end
+
+  describe "validation_nodes_election_seed_sorting/2" do
+    test "should change for different transactions", %{
+      tx1: tx1,
+      tx2: tx2
+    } do
+      timestamp = ~U[2024-11-04 13:41:18.280699Z]
+
+      assert Election.validation_nodes_election_seed_sorting(tx1, timestamp) !=
+               Election.validation_nodes_election_seed_sorting(tx2, timestamp)
+    end
+
+    test "should change for same transaction with different timestamps", %{
+      tx1: tx1
+    } do
+      # simulate two diffrenet transaction mining timestamps
+      ref_timestamp_first_attempt = ~U[2024-11-04 13:41:18.280699Z]
+
+      ref_timestamp_second_attempt = ~U[2024-11-04 13:41:50.280699Z]
+
+      assert Election.validation_nodes_election_seed_sorting(tx1, ref_timestamp_first_attempt) !=
+               Election.validation_nodes_election_seed_sorting(tx1, ref_timestamp_second_attempt)
+    end
+
+    test "should not change for same transaction with same timestamp", %{
+      tx1: tx1
+    } do
+      timestamp = ~U[2024-11-04 13:41:18.280699Z]
+
+      assert Election.validation_nodes_election_seed_sorting(tx1, timestamp) ==
+               Election.validation_nodes_election_seed_sorting(tx1, timestamp)
+    end
+  end
+
+  describe "validation_nodes/4" do
+    test "should change for new transaction",
+         %{
+           authorized_nodes: authorized_nodes,
+           storage_nodes: storage_nodes,
+           tx1: tx1,
+           tx2: tx2
+         } do
+      ref_timestamp = ~U[2024-11-04 13:41:18.280699Z]
 
       first_election =
         Election.validation_nodes(
           tx1,
-          "sorting_seed",
+          Election.validation_nodes_election_seed_sorting(tx1, ref_timestamp),
           authorized_nodes,
           storage_nodes,
           ValidationConstraints.new()
         )
 
-      tx2 = %Transaction{
-        address:
-          <<0, 120, 195, 32, 77, 84, 215, 196, 116, 215, 56, 141, 40, 54, 226, 48, 66, 254, 119,
-            11, 73, 77, 243, 125, 62, 94, 133, 67, 9, 253, 45, 134, 89>>,
-        type: :transfer,
-        data: %TransactionData{},
-        previous_public_key:
-          <<0, 239, 240, 90, 182, 66, 190, 68, 20, 250, 131, 83, 190, 29, 184, 177, 52, 166, 207,
-            80, 193, 110, 57, 6, 199, 152, 184, 24, 178, 179, 11, 164, 150>>,
-        previous_signature:
-          <<200, 70, 0, 25, 105, 111, 15, 161, 146, 188, 100, 234, 147, 62, 127, 8, 152, 60, 66,
-            169, 113, 255, 51, 112, 59, 200, 61, 63, 128, 228, 111, 104, 47, 15, 81, 185, 179, 36,
-            59, 86, 171, 7, 138, 199, 203, 252, 50, 87, 160, 107, 119, 131, 121, 11, 239, 169, 99,
-            203, 76, 159, 158, 243, 133, 133>>,
-        origin_signature:
-          <<162, 223, 100, 72, 17, 56, 99, 212, 78, 132, 166, 81, 127, 91, 214, 143, 221, 32, 106,
-            189, 247, 64, 183, 27, 55, 142, 254, 72, 47, 215, 34, 108, 233, 55, 35, 94, 49, 165,
-            180, 248, 229, 160, 229, 220, 191, 35, 80, 127, 213, 240, 195, 185, 165, 89, 172, 97,
-            170, 217, 57, 254, 125, 127, 62, 169>>
-      }
-
       second_election =
         Election.validation_nodes(
           tx2,
-          "daily_nonce_proof",
+          Election.validation_nodes_election_seed_sorting(tx2, ref_timestamp),
           authorized_nodes,
           storage_nodes,
           ValidationConstraints.new()
         )
 
       assert Enum.map(first_election, & &1.last_public_key) !=
+               Enum.map(second_election, & &1.last_public_key)
+    end
+
+    test "should change for same transaction with different timestamp", %{
+      authorized_nodes: authorized_nodes,
+      storage_nodes: storage_nodes,
+      tx1: tx1
+    } do
+      tx = tx1
+
+      # simulate two diffrenet transaction mining timestamps
+      ref_timestamp_first_attempt = ~U[2024-11-04 13:41:18.280699Z]
+
+      ref_timestamp_second_attempt = ~U[2024-11-04 13:41:50.280699Z]
+
+      first_election =
+        Election.validation_nodes(
+          tx,
+          Election.validation_nodes_election_seed_sorting(tx, ref_timestamp_first_attempt),
+          authorized_nodes,
+          storage_nodes,
+          ValidationConstraints.new()
+        )
+
+      second_election =
+        Election.validation_nodes(
+          tx,
+          Election.validation_nodes_election_seed_sorting(tx, ref_timestamp_second_attempt),
+          authorized_nodes,
+          storage_nodes,
+          ValidationConstraints.new()
+        )
+
+      assert Enum.map(first_election, & &1.last_public_key) !=
+               Enum.map(second_election, & &1.last_public_key)
+    end
+
+    test "should not change for same transaction with same timestamp", %{
+      authorized_nodes: authorized_nodes,
+      storage_nodes: storage_nodes,
+      tx1: tx1
+    } do
+      tx = tx1
+
+      ref_timestamp = ~U[2024-11-04 13:41:18.280699Z]
+
+      first_election =
+        Election.validation_nodes(
+          tx,
+          Election.validation_nodes_election_seed_sorting(tx, ref_timestamp),
+          authorized_nodes,
+          storage_nodes,
+          ValidationConstraints.new()
+        )
+
+      second_election =
+        Election.validation_nodes(
+          tx,
+          Election.validation_nodes_election_seed_sorting(tx, ref_timestamp),
+          authorized_nodes,
+          storage_nodes,
+          ValidationConstraints.new()
+        )
+
+      assert Enum.map(first_election, & &1.last_public_key) ==
                Enum.map(second_election, & &1.last_public_key)
     end
 
@@ -211,11 +326,13 @@ defmodule Archethic.ElectionTest do
             170, 217, 57, 254, 125, 127, 62, 169>>
       }
 
+      ref_timestamp = ~U[2024-11-04 13:41:18.280699Z]
+
       assert 3 ==
                length(
                  Election.validation_nodes(
                    tx1,
-                   "sorting_seed",
+                   Election.validation_nodes_election_seed_sorting(tx1, ref_timestamp),
                    authorized_nodes,
                    storage_nodes,
                    ValidationConstraints.new()

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -249,7 +249,7 @@ defmodule Archethic.Mining.ValidationContextTest do
         |> ValidationContext.cross_validate()
     end
 
-    test "should validate even if validation_time and cross_validation_time are in different oracle bucket" do
+    test "should not validate if validation_time and cross_validation_time are in different oracle bucket" do
       validation_context = create_context(~U[2023-12-11 09:00:01Z])
 
       validation_context2 = %ValidationContext{
@@ -267,7 +267,7 @@ defmodule Archethic.Mining.ValidationContextTest do
         end
       ) do
         assert %ValidationContext{
-                 cross_validation_stamps: [%CrossValidationStamp{inconsistencies: []}]
+                 cross_validation_stamps: [%CrossValidationStamp{inconsistencies: [:timestamp]}]
                } =
                  validation_context
                  |> ValidationContext.add_validation_stamp(
@@ -643,7 +643,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
       ledger_operations: ledger_operations,
       signature: :crypto.strong_rand_bytes(32),
       protocol_version: current_protocol_version()
@@ -675,7 +675,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       timestamp: timestamp,
       proof_of_work: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>,
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
       ledger_operations: ledger_operations,
       protocol_version: current_protocol_version()
     }
@@ -707,7 +707,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
       ledger_operations: ledger_operations,
       protocol_version: current_protocol_version()
     }
@@ -740,7 +740,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
       ledger_operations: ledger_operations,
       protocol_version: current_protocol_version()
     }
@@ -774,7 +774,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
       ledger_operations: ledger_operations,
       protocol_version: current_protocol_version()
     }
@@ -790,7 +790,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
       ledger_operations: %LedgerOperations{
         fee: Fee.calculate(tx, nil, 0.07, timestamp, nil, 0, current_protocol_version()),
         transaction_movements: Transaction.get_movements(tx),
@@ -833,7 +833,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
       ledger_operations: ledger_operations,
       error: :invalid_pending_transaction,
       protocol_version: current_protocol_version()
@@ -877,7 +877,7 @@ defmodule Archethic.Mining.ValidationContextTest do
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
       ledger_operations: ledger_operations,
       protocol_version: current_protocol_version()
     }

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -116,8 +116,7 @@ defmodule Archethic.TransactionFactory do
       %ValidationStamp{
         timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
-        proof_of_election:
-          Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+        proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
         proof_of_integrity: poi,
         ledger_operations: ledger_operations,
         protocol_version: protocol_version,
@@ -262,7 +261,7 @@ defmodule Archethic.TransactionFactory do
       timestamp: timestamp,
       proof_of_work: Crypto.origin_node_public_key(),
       proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+      proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
       ledger_operations: ledger_operations,
       signature: :crypto.strong_rand_bytes(32),
       protocol_version: protocol_version
@@ -303,8 +302,7 @@ defmodule Archethic.TransactionFactory do
       %ValidationStamp{
         timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
-        proof_of_election:
-          Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+        proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
         proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
         ledger_operations: ledger_operations,
         protocol_version: protocol_version
@@ -348,8 +346,7 @@ defmodule Archethic.TransactionFactory do
         timestamp: timestamp,
         proof_of_work: Crypto.origin_node_public_key(),
         proof_of_integrity: TransactionChain.proof_of_integrity([tx]),
-        proof_of_election:
-          Election.validation_nodes_election_seed_sorting(tx, DateTime.utc_now()),
+        proof_of_election: Election.validation_nodes_election_seed_sorting(tx, timestamp),
         ledger_operations: ledger_operations,
         protocol_version: protocol_version
       }


### PR DESCRIPTION
# Description

This pull request addresses an issue with the validation node election process. Currently, the election is based on transaction data and a daily nonce seed, which causes repeated selection of the same validation nodes for identical transactions throughout the day. If one of the validation nodes, especially the coordinator, has an incorrect state or is unable to retrieve required data, the transaction will fail validation for the entire day.

The solution implemented here introduces a timestamp into the election process to ensure that the elected nodes vary with each transaction attempt. The timestamp used is from the StartMining message, sent by the welcome node, which serves as a reference timestamp to diversify node election.

Fixes #1564

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The following tests were conducted to validate this change:

- Ensuring the seed sorting value changes with changing transactions, and/or ref_timestamp
- Ensuring the seed sorting value doesn't change for identical parameters (transaction, ref_timestamp)
- Ensuring that validation nodes election changes with changing transactions and/or ref_timestamp
- Ensuring that validation nodes election doesn't change for identical transactions and ref_timestamp

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
