### PR TITLE
Consume the MUCO correctly

### DIFF
--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -190,12 +190,12 @@ defmodule Archethic.Bootstrap.NetworkInit do
     resolved_addresses = Enum.map(movements, &{&1.to, &1.to}) |> Map.new()
 
     operations =
-      %LedgerValidation{fee: fee}
+      %LedgerValidation{fee: fee, transaction_movements: movements}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, nil)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, 1)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx_type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(address, timestamp)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx_type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =

--- a/lib/archethic/bootstrap/network_init.ex
+++ b/lib/archethic/bootstrap/network_init.ex
@@ -190,12 +190,12 @@ defmodule Archethic.Bootstrap.NetworkInit do
     resolved_addresses = Enum.map(movements, &{&1.to, &1.to}) |> Map.new()
 
     operations =
-      %LedgerValidation{fee: fee, transaction_movements: movements}
+      %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, nil)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, 1)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(address, timestamp)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx_type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx_type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =

--- a/lib/archethic/mining/ledger_validation.ex
+++ b/lib/archethic/mining/ledger_validation.ex
@@ -5,7 +5,8 @@ defmodule Archethic.Mining.LedgerValidation do
 
   @unit_uco 100_000_000
 
-  defstruct transaction_movements: nil,
+  defstruct state: :init,
+            transaction_movements: [],
             unspent_outputs: [],
             fee: 0,
             consumed_inputs: [],
@@ -32,13 +33,33 @@ defmodule Archethic.Mining.LedgerValidation do
   alias Archethic.TransactionChain.TransactionData
 
   @typedoc """
+  LedgerValidation should execute functions in a specific order.
+  To avoid miss order, state is updated to ensure order is respected
+  State is updated following
+  - :init
+  - :filtered_inputs
+  - :utxos_minted
+  - :sufficient_funds_validated
+  - :inputs_consumed
+  - :movements_resolved
+  """
+  @type state() ::
+          :init
+          | :filtered_inputs
+          | :utxos_minted
+          | :sufficient_funds_validated
+          | :inputs_consumed
+          | :movements_resolved
+
+  @typedoc """
   - Transaction movements: represents the pending transaction ledger movements
   - Unspent outputs: represents the new unspent outputs
   - fee: represents the transaction fee
   - Consumed inputs: represents the list of inputs consumed to produce the unspent outputs
   """
   @type t() :: %__MODULE__{
-          transaction_movements: nil | list(TransactionMovement.t()),
+          state: state(),
+          transaction_movements: list(TransactionMovement.t()),
           unspent_outputs: list(UnspentOutput.t()),
           fee: non_neg_integer(),
           consumed_inputs: list(VersionedUnspentOutput.t()),
@@ -65,10 +86,13 @@ defmodule Archethic.Mining.LedgerValidation do
           inputs :: list(VersionedUnspentOutput.t()),
           contract_context :: ContractContext.t() | nil
         ) :: t()
-  def filter_usable_inputs(ops, inputs, nil), do: %__MODULE__{ops | inputs: inputs}
+  def filter_usable_inputs(ops = %__MODULE__{state: :init}, inputs, nil),
+    do: %__MODULE__{ops | inputs: inputs} |> next_state()
 
-  def filter_usable_inputs(ops, inputs, contract_context),
-    do: %__MODULE__{ops | inputs: ContractContext.ledger_inputs(contract_context, inputs)}
+  def filter_usable_inputs(ops = %__MODULE__{state: :init}, inputs, contract_context) do
+    %__MODULE__{ops | inputs: ContractContext.ledger_inputs(contract_context, inputs)}
+    |> next_state()
+  end
 
   @doc """
   Build some ledger operations from a specific transaction
@@ -80,27 +104,30 @@ defmodule Archethic.Mining.LedgerValidation do
           protocol_version :: non_neg_integer()
         ) :: t()
   def mint_token_utxos(
-        ops,
+        ops = %__MODULE__{state: :filtered_inputs},
         %Transaction{address: address, type: type, data: %TransactionData{content: content}},
         timestamp,
         protocol_version
       )
       when type in [:token, :mint_rewards] and not is_nil(timestamp) do
-    case Jason.decode(content) do
-      {:ok, json} ->
-        minted_utxos =
-          json
-          |> create_token_utxos(address, timestamp)
-          |> VersionedUnspentOutput.wrap_unspent_outputs(protocol_version)
+    new_ops =
+      case Jason.decode(content) do
+        {:ok, json} ->
+          minted_utxos =
+            json
+            |> create_token_utxos(address, timestamp)
+            |> VersionedUnspentOutput.wrap_unspent_outputs(protocol_version)
 
-        %__MODULE__{ops | minted_utxos: minted_utxos}
+          %__MODULE__{ops | minted_utxos: minted_utxos}
 
-      _ ->
-        ops
-    end
+        _ ->
+          ops
+      end
+
+    next_state(new_ops)
   end
 
-  def mint_token_utxos(ops, _, _, _), do: ops
+  def mint_token_utxos(ops = %__MODULE__{state: :filtered_inputs}, _, _, _), do: next_state(ops)
 
   defp create_token_utxos(
          %{"token_reference" => token_ref, "supply" => supply},
@@ -196,20 +223,19 @@ defmodule Archethic.Mining.LedgerValidation do
         ) :: t()
   def build_resolved_movements(
         ops = %__MODULE__{
-          transaction_movements: unresolved_movements
+          state: :inputs_consumed,
+          transaction_movements: movements
         },
         resolved_addresses,
         tx_type
-      )
-      when is_list(unresolved_movements) do
-    %__MODULE__{
-      ops
-      | transaction_movements:
-          unresolved_movements
-          |> TransactionMovement.resolve_addresses(resolved_addresses)
-          |> Enum.map(&TransactionMovement.maybe_convert_reward(&1, tx_type))
-          |> TransactionMovement.aggregate()
-    }
+      ) do
+    resolved_movements =
+      movements
+      |> TransactionMovement.resolve_addresses(resolved_addresses)
+      |> Enum.map(&TransactionMovement.maybe_convert_reward(&1, tx_type))
+      |> TransactionMovement.aggregate()
+
+    %__MODULE__{ops | transaction_movements: resolved_movements} |> next_state()
   end
 
   @doc """
@@ -218,10 +244,10 @@ defmodule Archethic.Mining.LedgerValidation do
   @spec validate_sufficient_funds(ops :: t(), list(TransactionMovement.t())) :: t()
   def validate_sufficient_funds(
         ops = %__MODULE__{
+          state: :utxos_minted,
           fee: fee,
           inputs: inputs,
-          minted_utxos: minted_utxos,
-          transaction_movements: nil
+          minted_utxos: minted_utxos
         },
         movements
       ) do
@@ -239,6 +265,7 @@ defmodule Archethic.Mining.LedgerValidation do
         amount_to_spend: amount_to_spend,
         transaction_movements: movements
     }
+    |> next_state()
   end
 
   defp total_to_spend(fee, movements) do
@@ -298,6 +325,7 @@ defmodule Archethic.Mining.LedgerValidation do
   """
   @spec to_ledger_operations(ops :: t()) :: LedgerOperations.t()
   def to_ledger_operations(%__MODULE__{
+        state: :movements_resolved,
         transaction_movements: movements,
         unspent_outputs: utxos,
         fee: fee,
@@ -323,10 +351,26 @@ defmodule Archethic.Mining.LedgerValidation do
           encoded_state :: State.encoded() | nil,
           contract_context :: ContractContext.t() | nil
         ) :: t()
-  def consumed_inputs(ops = %__MODULE__{sufficient_funds?: false}), do: ops
+  def consume_inputs(
+        ops,
+        change_address,
+        timestamp,
+        encoded_state \\ nil,
+        contract_context \\ nil
+      )
+
+  def consume_inputs(
+        ops = %__MODULE__{state: :sufficient_funds_validated, sufficient_funds?: false},
+        _,
+        _,
+        _,
+        _
+      ),
+      do: next_state(ops)
 
   def consume_inputs(
         ops = %__MODULE__{
+          state: :sufficient_funds_validated,
           inputs: inputs,
           minted_utxos: minted_utxos,
           balances: %{uco: uco_balance, token: tokens_balance},
@@ -334,8 +378,8 @@ defmodule Archethic.Mining.LedgerValidation do
         },
         change_address,
         timestamp = %DateTime{},
-        encoded_state \\ nil,
-        contract_context \\ nil
+        encoded_state,
+        contract_context
       ) do
     # Since AEIP-19 we can consume from minted tokens
     # Sort inputs, to have consistent results across all nodes
@@ -380,6 +424,7 @@ defmodule Archethic.Mining.LedgerValidation do
       | unspent_outputs: new_unspent_outputs,
         consumed_inputs: versioned_consumed_utxos
     }
+    |> next_state()
   end
 
   defp tokens_utxos(
@@ -522,4 +567,20 @@ defmodule Archethic.Mining.LedgerValidation do
 
     [new_utxo | utxos]
   end
+
+  defp next_state(ops = %__MODULE__{state: :init}), do: %__MODULE__{ops | state: :filtered_inputs}
+
+  defp next_state(ops = %__MODULE__{state: :filtered_inputs}),
+    do: %__MODULE__{ops | state: :utxos_minted}
+
+  defp next_state(ops = %__MODULE__{state: :utxos_minted}),
+    do: %__MODULE__{ops | state: :sufficient_funds_validated}
+
+  defp next_state(ops = %__MODULE__{state: :sufficient_funds_validated}),
+    do: %__MODULE__{ops | state: :inputs_consumed}
+
+  defp next_state(ops = %__MODULE__{state: :inputs_consumed}),
+    do: %__MODULE__{ops | state: :movements_resolved}
+
+  defp next_state(ops = %__MODULE__{state: :movements_resolved}), do: ops
 end

--- a/lib/archethic/mining/ledger_validation.ex
+++ b/lib/archethic/mining/ledger_validation.ex
@@ -58,7 +58,7 @@ defmodule Archethic.Mining.LedgerValidation do
   def burning_address, do: @burning_address
 
   @doc """
-  Filter inputs that can be used in this transaction 
+  Filter inputs that can be used in this transaction
   """
   @spec filter_usable_inputs(
           ops :: t(),
@@ -186,6 +186,8 @@ defmodule Archethic.Mining.LedgerValidation do
   @doc """
   Build the resolved view of the movement, with the resolved address
   and convert MUCO movement to UCO movement
+
+  **MUST** be done after sufficient_funds? and consume_inputs
   """
   @spec build_resolved_movements(
           ops :: t(),

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -800,17 +800,17 @@ defmodule Archethic.Mining.ValidationContext do
     protocol_version = Mining.protocol_version()
 
     ops =
-      %LedgerValidation{fee: fee, transaction_movements: movements}
+      %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, validation_time, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(
         address,
         validation_time,
         encoded_state,
         contract_context
       )
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx_type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx_type)
 
     case ops do
       %LedgerValidation{sufficient_funds?: false} ->
@@ -1245,8 +1245,8 @@ defmodule Archethic.Mining.ValidationContext do
     movements = Transaction.get_movements(tx)
 
     %LedgerOperations{transaction_movements: resolved_movements} =
-      %LedgerValidation{}
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx_type)
+      %LedgerValidation{transaction_movements: movements}
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx_type)
       |> LedgerValidation.to_ledger_operations()
 
     length(resolved_movements) == length(transaction_movements) and

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -800,10 +800,9 @@ defmodule Archethic.Mining.ValidationContext do
     protocol_version = Mining.protocol_version()
 
     ops =
-      %LedgerValidation{fee: fee}
+      %LedgerValidation{fee: fee, transaction_movements: movements}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, validation_time, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx_type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(
         address,
@@ -811,6 +810,7 @@ defmodule Archethic.Mining.ValidationContext do
         encoded_state,
         contract_context
       )
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx_type)
 
     case ops do
       %LedgerValidation{sufficient_funds?: false} ->

--- a/lib/archethic/p2p/message/validate_smart_contract_call.ex
+++ b/lib/archethic/p2p/message/validate_smart_contract_call.ex
@@ -270,19 +270,17 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCall do
   defp calculate_fee(_, _), do: 0
 
   defp enough_funds_to_send?(
-         %ActionWithTransaction{next_tx: tx = %Transaction{type: tx_type}},
+         %ActionWithTransaction{next_tx: tx},
          inputs,
          timestamp
        ) do
     movements = Transaction.get_movements(tx)
     protocol_version = Mining.protocol_version()
-    resolved_addresses = Enum.map(movements, &{&1.to, &1.to}) |> Map.new()
 
     %LedgerValidation{sufficient_funds?: sufficient_funds?} =
-      %LedgerValidation{fee: 0}
+      %LedgerValidation{fee: 0, transaction_movements: movements}
       |> LedgerValidation.filter_usable_inputs(inputs, nil)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx_type)
       |> LedgerValidation.validate_sufficient_funds()
 
     sufficient_funds?

--- a/lib/archethic/p2p/message/validate_smart_contract_call.ex
+++ b/lib/archethic/p2p/message/validate_smart_contract_call.ex
@@ -278,10 +278,10 @@ defmodule Archethic.P2P.Message.ValidateSmartContractCall do
     protocol_version = Mining.protocol_version()
 
     %LedgerValidation{sufficient_funds?: sufficient_funds?} =
-      %LedgerValidation{fee: 0, transaction_movements: movements}
+      %LedgerValidation{}
       |> LedgerValidation.filter_usable_inputs(inputs, nil)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
 
     sufficient_funds?
   end

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -1360,9 +1360,9 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -1360,9 +1360,9 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{

--- a/test/archethic/mining/ledger_validation_test.exs
+++ b/test/archethic/mining/ledger_validation_test.exs
@@ -348,10 +348,10 @@ defmodule Archethic.Mining.LedgerValidationTest do
     end
   end
 
-  describe "validate_sufficient_funds/1" do
+  describe "validate_sufficient_funds/2" do
     test "should return insufficient funds when not enough uco" do
       assert %LedgerValidation{sufficient_funds?: false} =
-               %LedgerValidation{fee: 1_000} |> LedgerValidation.validate_sufficient_funds()
+               %LedgerValidation{fee: 1_000} |> LedgerValidation.validate_sufficient_funds([])
     end
 
     test "should return insufficient funds when not enough tokens" do
@@ -374,8 +374,8 @@ defmodule Archethic.Mining.LedgerValidationTest do
       ]
 
       assert %LedgerValidation{sufficient_funds?: false} =
-               %LedgerValidation{fee: 1_000, transaction_movements: movements, inputs: inputs}
-               |> LedgerValidation.validate_sufficient_funds()
+               %LedgerValidation{fee: 1_000, inputs: inputs}
+               |> LedgerValidation.validate_sufficient_funds(movements)
     end
 
     test "should not be able to pay with the same non-fungible token twice" do
@@ -415,11 +415,10 @@ defmodule Archethic.Mining.LedgerValidationTest do
       assert %LedgerValidation{sufficient_funds?: false} =
                %LedgerValidation{
                  fee: 1_000,
-                 transaction_movements: movements,
                  inputs: inputs,
                  minted_utxos: minted_utxos
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
     end
 
     test "should return available balance and amount to spend and return sufficient_funds to true" do
@@ -491,11 +490,10 @@ defmodule Archethic.Mining.LedgerValidationTest do
              } =
                %LedgerValidation{
                  fee: 1_000,
-                 transaction_movements: movements,
                  inputs: inputs,
                  minted_utxos: minted_utxos
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
     end
   end
 
@@ -542,10 +540,9 @@ defmodule Archethic.Mining.LedgerValidationTest do
              } =
                %LedgerValidation{
                  fee: 40_000_000,
-                 transaction_movements: movements,
                  inputs: inputs
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(tx_address, timestamp)
     end
 
@@ -630,10 +627,9 @@ defmodule Archethic.Mining.LedgerValidationTest do
              } =
                %LedgerValidation{
                  fee: 40_000_000,
-                 transaction_movements: movements,
                  inputs: inputs
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(tx_address, timestamp)
     end
 
@@ -703,10 +699,9 @@ defmodule Archethic.Mining.LedgerValidationTest do
              } =
                %LedgerValidation{
                  fee: 40_000_000,
-                 transaction_movements: movements,
                  inputs: inputs
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(tx_address, timestamp)
     end
 
@@ -800,10 +795,9 @@ defmodule Archethic.Mining.LedgerValidationTest do
              } =
                %LedgerValidation{
                  fee: 40_000_000,
-                 transaction_movements: movements,
                  inputs: inputs
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(tx_address, timestamp)
     end
 
@@ -879,10 +873,9 @@ defmodule Archethic.Mining.LedgerValidationTest do
              } =
                %LedgerValidation{
                  fee: 40_000_000,
-                 transaction_movements: movements,
                  inputs: inputs
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(tx_address, timestamp)
     end
 
@@ -921,11 +914,10 @@ defmodule Archethic.Mining.LedgerValidationTest do
       assert ops_result =
                %LedgerValidation{
                  fee: 1_000,
-                 transaction_movements: movements,
                  inputs: inputs,
                  minted_utxos: minted_utxos
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(tx_address, now)
 
       assert [
@@ -990,11 +982,10 @@ defmodule Archethic.Mining.LedgerValidationTest do
       assert ops_result =
                %LedgerValidation{
                  fee: 1_000,
-                 transaction_movements: movements,
                  inputs: inputs,
                  minted_utxos: minted_utxos
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(tx_address, now)
 
       assert [] = ops_result.unspent_outputs
@@ -1059,11 +1050,10 @@ defmodule Archethic.Mining.LedgerValidationTest do
       assert ops_result =
                %LedgerValidation{
                  fee: 1_000,
-                 transaction_movements: movements,
                  inputs: inputs,
                  minted_utxos: minted_utxos
                }
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(tx_address, now)
 
       assert [
@@ -1166,7 +1156,7 @@ defmodule Archethic.Mining.LedgerValidationTest do
                fee: 40_000_000
              } =
                %LedgerValidation{fee: 40_000_000, inputs: inputs}
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds([])
                |> LedgerValidation.consume_inputs(transaction_address, transaction_timestamp)
 
       tx_address = "@Alice2"
@@ -1210,8 +1200,8 @@ defmodule Archethic.Mining.LedgerValidationTest do
                  %VersionedUnspentOutput{unspent_output: %UnspentOutput{from: "@Tom5"}}
                ]
              } =
-               %LedgerValidation{inputs: inputs, transaction_movements: movements}
-               |> LedgerValidation.validate_sufficient_funds()
+               %LedgerValidation{inputs: inputs}
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(tx_address, now)
     end
 
@@ -1234,7 +1224,7 @@ defmodule Archethic.Mining.LedgerValidationTest do
                unspent_outputs: [%UnspentOutput{type: :state, encoded_payload: ^new_state}]
              } =
                %LedgerValidation{fee: 0, inputs: inputs}
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds([])
                |> LedgerValidation.consume_inputs("@Alice2", DateTime.utc_now(), new_state, nil)
     end
 
@@ -1284,7 +1274,7 @@ defmodule Archethic.Mining.LedgerValidationTest do
 
       assert %LedgerValidation{fee: 0, unspent_outputs: [], consumed_inputs: []} =
                %LedgerValidation{fee: 0, inputs: inputs}
-               |> LedgerValidation.validate_sufficient_funds()
+               |> LedgerValidation.validate_sufficient_funds([])
                |> LedgerValidation.consume_inputs("@Alice2", ~U[2022-10-10 10:44:38.983Z])
     end
 
@@ -1336,8 +1326,8 @@ defmodule Archethic.Mining.LedgerValidationTest do
       ]
 
       assert %LedgerValidation{fee: 0, unspent_outputs: [], consumed_inputs: consumed_inputs} =
-               %LedgerValidation{fee: 0, inputs: all_utxos, transaction_movements: movements}
-               |> LedgerValidation.validate_sufficient_funds()
+               %LedgerValidation{fee: 0, inputs: all_utxos}
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(random_address(), ~U[2022-10-10 10:44:38.983Z])
 
       # order does not matter
@@ -1385,8 +1375,8 @@ defmodule Archethic.Mining.LedgerValidationTest do
       movements = [%TransactionMovement{to: random_address(), amount: 200_000_000, type: :UCO}]
 
       assert %LedgerValidation{fee: 0, unspent_outputs: [], consumed_inputs: consumed_inputs} =
-               %LedgerValidation{fee: 0, inputs: all_utxos, transaction_movements: movements}
-               |> LedgerValidation.validate_sufficient_funds()
+               %LedgerValidation{fee: 0, inputs: all_utxos}
+               |> LedgerValidation.validate_sufficient_funds(movements)
                |> LedgerValidation.consume_inputs(random_address(), ~U[2022-10-10 10:44:38.983Z])
 
       # order does not matter
@@ -1441,10 +1431,9 @@ defmodule Archethic.Mining.LedgerValidationTest do
         assert %LedgerValidation{fee: 0, unspent_outputs: [], consumed_inputs: consumed_inputs} =
                  %LedgerValidation{
                    fee: 0,
-                   inputs: randomized_utxo,
-                   transaction_movements: movements
+                   inputs: randomized_utxo
                  }
-                 |> LedgerValidation.validate_sufficient_funds()
+                 |> LedgerValidation.validate_sufficient_funds(movements)
                  |> LedgerValidation.consume_inputs(
                    random_address(),
                    ~U[2022-10-10 10:44:38.983Z]
@@ -1472,7 +1461,7 @@ defmodule Archethic.Mining.LedgerValidationTest do
 
       RewardTokens.add_reward_token_address(reward_token_address)
 
-      movement = [
+      movements = [
         %TransactionMovement{to: address1, amount: 10, type: :UCO},
         %TransactionMovement{to: address1, amount: 10, type: {:token, token_address, 0}},
         %TransactionMovement{to: address1, amount: 40, type: {:token, token_address, 0}},
@@ -1488,8 +1477,7 @@ defmodule Archethic.Mining.LedgerValidationTest do
 
       assert %LedgerValidation{transaction_movements: resolved_movements} =
                LedgerValidation.build_resolved_movements(
-                 %LedgerValidation{},
-                 movement,
+                 %LedgerValidation{transaction_movements: movements},
                  resolved_addresses,
                  :transfer
                )

--- a/test/archethic/mining/ledger_validation_test.exs
+++ b/test/archethic/mining/ledger_validation_test.exs
@@ -349,6 +349,20 @@ defmodule Archethic.Mining.LedgerValidationTest do
   end
 
   describe "validate_sufficient_funds/2" do
+    test "should set the movement in the struct" do
+      movements = [
+        %TransactionMovement{
+          to: "@JeanClaude",
+          amount: 100_000_000,
+          type: {:token, "@CharlieToken", 0}
+        }
+      ]
+
+      assert %LedgerValidation{transaction_movements: ^movements} =
+               %LedgerValidation{fee: 1_000}
+               |> LedgerValidation.validate_sufficient_funds(movements)
+    end
+
     test "should return insufficient funds when not enough uco" do
       assert %LedgerValidation{sufficient_funds?: false} =
                %LedgerValidation{fee: 1_000} |> LedgerValidation.validate_sufficient_funds([])

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -189,30 +189,25 @@ defmodule Archethic.Mining.ValidationContextTest do
           ]
         )
         | transaction:
-            Transaction.new(
-              :transfer,
-              %TransactionData{
-                ledger: %Ledger{
-                  token: %TokenLedger{
-                    transfers: [
-                      %TokenLedger.Transfer{
-                        token_address: muco_addr1,
-                        token_id: 0,
-                        to: transfer_address,
-                        amount: 10
-                      },
-                      %TokenLedger.Transfer{
-                        token_address: muco_addr2,
-                        token_id: 0,
-                        to: transfer_address,
-                        amount: 10
-                      }
-                    ]
-                  }
+            TransactionFactory.create_non_valided_transaction(
+              ledger: %Ledger{
+                token: %TokenLedger{
+                  transfers: [
+                    %TokenLedger.Transfer{
+                      token_address: muco_addr1,
+                      token_id: 0,
+                      to: transfer_address,
+                      amount: 10
+                    },
+                    %TokenLedger.Transfer{
+                      token_address: muco_addr2,
+                      token_id: 0,
+                      to: transfer_address,
+                      amount: 10
+                    }
+                  ]
                 }
-              },
-              "seed",
-              0
+              }
             ),
           resolved_addresses: %{transfer_address => resolved_address}
       }

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -624,9 +624,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -656,9 +656,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -688,9 +688,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -721,9 +721,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -814,9 +814,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -846,9 +846,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
       |> Map.put(
         :consumed_inputs,

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -624,9 +624,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -656,9 +656,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -688,9 +688,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -721,9 +721,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -814,9 +814,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     %ValidationStamp{
@@ -846,9 +846,9 @@ defmodule Archethic.Mining.ValidationContextTest do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(unspent_outputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, current_protocol_version())
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
       |> Map.put(
         :consumed_inputs,

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -101,9 +101,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     poi =
@@ -160,9 +160,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =
@@ -205,9 +205,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp = %ValidationStamp{
@@ -253,9 +253,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp = %ValidationStamp{
@@ -294,9 +294,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: 1_000_000_000}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =
@@ -338,9 +338,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =
@@ -399,9 +399,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.validate_sufficient_funds()
+      |> LedgerValidation.validate_sufficient_funds(movements)
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
+      |> LedgerValidation.build_resolved_movements(resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -101,9 +101,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     poi =
@@ -160,9 +160,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =
@@ -205,9 +205,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp = %ValidationStamp{
@@ -253,9 +253,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp = %ValidationStamp{
@@ -294,9 +294,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: 1_000_000_000}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =
@@ -338,9 +338,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =
@@ -399,9 +399,9 @@ defmodule Archethic.TransactionFactory do
       %LedgerValidation{fee: fee}
       |> LedgerValidation.filter_usable_inputs(inputs, contract_context)
       |> LedgerValidation.mint_token_utxos(tx, timestamp, protocol_version)
-      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.validate_sufficient_funds()
       |> LedgerValidation.consume_inputs(tx.address, timestamp, encoded_state, contract_context)
+      |> LedgerValidation.build_resolved_movements(movements, resolved_addresses, tx.type)
       |> LedgerValidation.to_ledger_operations()
 
     validation_stamp =


### PR DESCRIPTION
# Description

A bug was introduced in 1.5.11's refactor where the UCO were consumed instead of the MUCO. This is an incorrect behaviour and people with MUCO were consuming UCO instead of MUCO when transferring MUCO.
This fix the issue by resolving MUCO only after the consume step.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a unit test

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
