### PR TITLE
change networking scheduler to every 6 hours (instead of 5 min)

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -214,8 +214,8 @@ config :archethic, Archethic.Networking.IPLookup.Static,
 # -----end-of-Networking-prod-configs-----
 
 config :archethic, Archethic.Networking.Scheduler,
-  # Every 5 minutes
-  interval: System.get_env("ARCHETHIC_NETWORKING_UPDATE_SCHEDULER", "0 */5 * * * * *")
+  # Every 6 hours (at min 22)
+  interval: System.get_env("ARCHETHIC_NETWORKING_UPDATE_SCHEDULER", "0 22 */6 * * * *")
 
 config :archethic, Archethic.OracleChain.Scheduler,
   # Poll new changes every minute


### PR DESCRIPTION
# Description

No need to try to open the port every 5 minutes. Some routers have undefined behaviours so it's best to do this as less as possible.

eg: orange connections in france

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

n/a

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
