### PR TITLE
Bls proof of replication

### DIFF
--- a/lib/archethic/db/embedded_impl/encoding.ex
+++ b/lib/archethic/db/embedded_impl/encoding.ex
@@ -5,6 +5,7 @@ defmodule Archethic.DB.EmbeddedImpl.Encoding do
 
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.ProofOfValidation
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Ledger
   alias Archethic.TransactionChain.TransactionData.Ownership
@@ -167,8 +168,14 @@ defmodule Archethic.DB.EmbeddedImpl.Encoding do
     ]
   end
 
-  defp encode_validation_fields(%Transaction{proof_of_validation: proof_of_validation}) do
-    [{"proof_of_validation", ProofOfValidation.serialize(proof_of_validation)}]
+  defp encode_validation_fields(%Transaction{
+         proof_of_validation: proof_of_validation,
+         proof_of_replication: proof_of_replication
+       }) do
+    [
+      {"proof_of_validation", ProofOfValidation.serialize(proof_of_validation)},
+      {"proof_of_replication", ProofOfReplication.serialize(proof_of_replication)}
+    ]
   end
 
   def decode(_tx_version, _protocol_version, "type", <<type::8>>, acc),
@@ -329,6 +336,11 @@ defmodule Archethic.DB.EmbeddedImpl.Encoding do
   def decode(_tx_version, _protocol_version, "proof_of_validation", <<rest::bitstring>>, acc) do
     {proof_of_validation, _} = ProofOfValidation.deserialize(rest)
     Map.put(acc, :proof_of_validation, proof_of_validation)
+  end
+
+  def decode(_tx_version, _protocol_version, "proof_of_replication", <<rest::bitstring>>, acc) do
+    {proof_of_replication, _} = ProofOfReplication.deserialize(rest)
+    Map.put(acc, :proof_of_replication, proof_of_replication)
   end
 
   def decode(_tx_version, _protocol_version, column, data, acc), do: Map.put(acc, column, data)

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -36,7 +36,7 @@ defmodule Archethic.Mining do
   # version 5->6 the POI changed and is now done with tx.data.recipients.args serialized with :extended mode
   # version 6->7 add Add consumed inputs in tx.validation_stamp.ledger_operations
   # version 7->8 movement resolved address are now the genesis address of the destination
-  # version 8->9 add proof of validation workflow and field tx.proof_of_validation
+  # version 8->9 add proof of validation / replication workflow and field tx.proof_of_validation / tx.proof_of_replication
   @protocol_version 9
 
   @lock_threshold 0.75

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -22,6 +22,8 @@ defmodule Archethic.Mining do
 
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.Signature
   alias Archethic.TransactionChain.Transaction.ProofOfValidation
   alias Archethic.TransactionChain.Transaction.ValidationStamp
 
@@ -247,6 +249,33 @@ defmodule Archethic.Mining do
     tx_address
     |> get_mining_process!()
     |> DistributedWorkflow.add_proof_of_validation(proof, from)
+  end
+
+  @doc """
+  Add a replication signature to the transaction process
+  """
+  @spec add_replication_signature(
+          tx_address :: Crypto.prepended_hash(),
+          replication_signature :: Signature.t()
+        ) :: :ok
+  def add_replication_signature(tx_address, replication_signature = %Signature{}) do
+    pid = get_mining_process!(tx_address)
+    if pid, do: send(pid, {:add_replication_signature, replication_signature})
+    :ok
+  end
+
+  @doc """
+  Add a proof of replication to the transaction mining process
+  """
+  @spec add_proof_of_replication(
+          tx_address :: Crypto.prepended_hash(),
+          proof_of_validation :: ProofOfReplication.t(),
+          from :: Crypto.key()
+        ) :: :ok
+  def add_proof_of_replication(tx_address, proof, from) do
+    tx_address
+    |> get_mining_process!()
+    |> DistributedWorkflow.add_proof_of_replication(proof, from)
   end
 
   @doc """

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -688,12 +688,14 @@ defmodule Archethic.Mining.ValidationContext do
   def get_validated_transaction(%__MODULE__{
         transaction: transaction,
         validation_stamp: validation_stamp,
-        proof_of_validation: proof_of_validation
+        proof_of_validation: proof_of_validation,
+        proof_of_replication: proof_of_replication
       }) do
     %Transaction{
       transaction
       | validation_stamp: validation_stamp,
-        proof_of_validation: proof_of_validation
+        proof_of_validation: proof_of_validation,
+        proof_of_replication: proof_of_replication
     }
   end
 

--- a/lib/archethic/p2p/message.ex
+++ b/lib/archethic/p2p/message.ex
@@ -80,7 +80,10 @@ defmodule Archethic.P2P.Message do
     GetDashboardData,
     DashboardData,
     UnlockChain,
-    ProofOfValidationDone
+    ProofOfValidationDone,
+    RequestReplicationSignature,
+    ReplicationSignatureDone,
+    ProofOfReplicationDone
   }
 
   require Logger
@@ -134,6 +137,9 @@ defmodule Archethic.P2P.Message do
           | RequestChainLock.t()
           | UnlockChain.t()
           | ProofOfValidationDone.t()
+          | RequestReplicationSignature.t()
+          | ProofOfReplicationDone.t()
+          | ReplicationSignatureDone.t()
 
   @type response ::
           Ok.t()

--- a/lib/archethic/p2p/message/message_id.ex
+++ b/lib/archethic/p2p/message/message_id.ex
@@ -70,7 +70,10 @@ defmodule Archethic.P2P.MessageId do
     DashboardData,
     RequestChainLock,
     UnlockChain,
-    ProofOfValidationDone
+    ProofOfValidationDone,
+    RequestReplicationSignature,
+    ReplicationSignatureDone,
+    ProofOfReplicationDone
   }
 
   alias Archethic.TransactionChain.{
@@ -100,7 +103,7 @@ defmodule Archethic.P2P.MessageId do
     AcknowledgeStorage => 13,
     NotifyEndOfNodeSync => 14,
     GetLastTransaction => 15,
-    # Message number 16 is available
+    RequestReplicationSignature => 16,
     GetTransactionInputs => 17,
     GetTransactionChainLength => 18,
     RequestChainLock => 19,
@@ -127,6 +130,8 @@ defmodule Archethic.P2P.MessageId do
     GetDashboardData => 40,
     UnlockChain => 41,
     GetCurrentReplicationAttestations => 42,
+    ProofOfReplicationDone => 43,
+    ReplicationSignatureDone => 44,
 
     # Responses
     DashboardData => 225,

--- a/lib/archethic/p2p/message/proof_of_replication_done.ex
+++ b/lib/archethic/p2p/message/proof_of_replication_done.ex
@@ -1,0 +1,36 @@
+defmodule Archethic.P2P.Message.ProofOfReplicationDone do
+  @moduledoc false
+
+  @enforce_keys [:address, :proof_of_replication]
+  defstruct [:address, :proof_of_replication]
+
+  alias Archethic.Crypto
+  alias Archethic.Mining
+  alias Archethic.P2P.Message.Ok
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
+  alias Archethic.Utils
+
+  @type t() :: %__MODULE__{
+          address: Crypto.prepended_hash(),
+          proof_of_replication: ProofOfReplication.t()
+        }
+
+  @spec process(__MODULE__.t(), Crypto.key()) :: Ok.t()
+  def process(%__MODULE__{address: address, proof_of_replication: proof}, sender_public_key) do
+    Mining.add_proof_of_replication(address, proof, sender_public_key)
+    %Ok{}
+  end
+
+  @spec serialize(t()) :: bitstring()
+  def serialize(%__MODULE__{address: address, proof_of_replication: proof}) do
+    <<address::binary, ProofOfReplication.serialize(proof)::bitstring>>
+  end
+
+  @spec deserialize(bitstring()) :: {t(), bitstring}
+  def deserialize(bin) do
+    {address, rest} = Utils.deserialize_address(bin)
+    {proof, rest} = ProofOfReplication.deserialize(rest)
+
+    {%__MODULE__{address: address, proof_of_replication: proof}, rest}
+  end
+end

--- a/lib/archethic/p2p/message/replicate_pending_transaction_chain.ex
+++ b/lib/archethic/p2p/message/replicate_pending_transaction_chain.ex
@@ -9,7 +9,6 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
   alias Archethic.Election
   alias Archethic.P2P
   alias Archethic.P2P.Message.Ok
-  alias Archethic.P2P.Message.Error
   alias Archethic.P2P.Message.AcknowledgeStorage
   alias Archethic.Replication
 
@@ -31,7 +30,7 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
           proof_of_validation: ProofOfValidation.t()
         }
 
-  @spec process(__MODULE__.t(), Crypto.key()) :: Ok.t() | Error.t()
+  @spec process(__MODULE__.t(), Crypto.key()) :: Ok.t()
   def process(
         %__MODULE__{
           address: address,
@@ -69,7 +68,7 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
 
   defp get_data_in_tx_pool(address) do
     retry_while with: constant_backoff(100) |> expiry(2000) do
-      case Replication.get_transaction_in_commit_pool(address) do
+      case Replication.pop_transaction_in_commit_pool(address) do
         {:ok, tx, validation_utxo} ->
           validation_inputs = convert_unspent_outputs_to_inputs(validation_utxo)
           {:halt, {:ok, tx, validation_inputs}}

--- a/lib/archethic/p2p/message/replicate_pending_transaction_chain.ex
+++ b/lib/archethic/p2p/message/replicate_pending_transaction_chain.ex
@@ -1,7 +1,7 @@
 defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
   @moduledoc false
 
-  defstruct [:address, :genesis_address, :proof_of_validation]
+  defstruct [:address, :genesis_address, :proof_of_replication]
 
   use Retry
 
@@ -14,7 +14,7 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
 
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.Transaction.ProofOfValidation
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
   alias Archethic.TransactionChain.Transaction.ValidationStamp
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
@@ -27,7 +27,7 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
   @type t() :: %__MODULE__{
           address: Crypto.prepended_hash(),
           genesis_address: Crypto.prepended_hash(),
-          proof_of_validation: ProofOfValidation.t()
+          proof_of_replication: ProofOfReplication.t()
         }
 
   @spec process(__MODULE__.t(), Crypto.key()) :: Ok.t()
@@ -35,7 +35,7 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
         %__MODULE__{
           address: address,
           genesis_address: genesis_address,
-          proof_of_validation: proof
+          proof_of_replication: proof
         },
         sender_public_key
       ) do
@@ -45,9 +45,10 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
       with {:ok, tx, validation_inputs} <- get_transaction_data(address),
            authorized_nodes <- P2P.authorized_and_available_nodes(tx.validation_stamp.timestamp),
            true <- Election.chain_storage_node?(address, node_public_key, authorized_nodes),
-           elected_nodes <- ProofOfValidation.get_election(authorized_nodes, address),
-           true <- ProofOfValidation.valid?(elected_nodes, proof, tx.validation_stamp) do
-        tx = %Transaction{tx | proof_of_validation: proof}
+           elected_nodes <- ProofOfReplication.get_election(authorized_nodes, address),
+           tx_summary <- TransactionSummary.from_transaction(tx, genesis_address),
+           true <- ProofOfReplication.valid?(elected_nodes, proof, tx_summary) do
+        # tx = %Transaction{tx | proof_of_replication: proof}
         replicate_transaction(tx, validation_inputs, genesis_address, sender_public_key)
       else
         _ -> :skip
@@ -85,7 +86,10 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
     res =
       [
         Task.async(fn ->
-          TransactionChain.fetch_transaction(address, storage_nodes, search_mode: :remote)
+          TransactionChain.fetch_transaction(address, storage_nodes,
+            search_mode: :remote,
+            acceptance_resolver: :accept_transaction
+          )
         end),
         Task.async(fn -> TransactionChain.fetch_inputs(address, storage_nodes) end)
       ]
@@ -143,22 +147,22 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
   def serialize(%__MODULE__{
         address: address,
         genesis_address: genesis_address,
-        proof_of_validation: proof
+        proof_of_replication: proof
       }) do
-    <<address::binary, genesis_address::binary, ProofOfValidation.serialize(proof)::bitstring>>
+    <<address::binary, genesis_address::binary, ProofOfReplication.serialize(proof)::bitstring>>
   end
 
   @spec deserialize(bitstring()) :: {t(), bitstring}
   def deserialize(bin) do
     {address, rest} = Utils.deserialize_address(bin)
     {genesis_address, rest} = Utils.deserialize_address(rest)
-    {proof, rest} = ProofOfValidation.deserialize(rest)
+    {proof, rest} = ProofOfReplication.deserialize(rest)
 
     {
       %__MODULE__{
         address: address,
         genesis_address: genesis_address,
-        proof_of_validation: proof
+        proof_of_replication: proof
       },
       rest
     }

--- a/lib/archethic/p2p/message/replicate_pending_transaction_chain.ex
+++ b/lib/archethic/p2p/message/replicate_pending_transaction_chain.ex
@@ -48,7 +48,7 @@ defmodule Archethic.P2P.Message.ReplicatePendingTransactionChain do
            elected_nodes <- ProofOfReplication.get_election(authorized_nodes, address),
            tx_summary <- TransactionSummary.from_transaction(tx, genesis_address),
            true <- ProofOfReplication.valid?(elected_nodes, proof, tx_summary) do
-        # tx = %Transaction{tx | proof_of_replication: proof}
+        tx = %Transaction{tx | proof_of_replication: proof}
         replicate_transaction(tx, validation_inputs, genesis_address, sender_public_key)
       else
         _ -> :skip

--- a/lib/archethic/p2p/message/replicate_transaction.ex
+++ b/lib/archethic/p2p/message/replicate_transaction.ex
@@ -8,13 +8,14 @@ defmodule Archethic.P2P.Message.ReplicateTransaction do
   alias Archethic.Crypto
   alias Archethic.Election
   alias Archethic.P2P
-  alias Archethic.P2P.Message.Error
   alias Archethic.P2P.Message.Ok
   alias Archethic.Replication
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.ProofOfValidation
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
+  alias Archethic.TransactionChain.TransactionSummary
   alias Archethic.Utils
 
   @type t :: %__MODULE__{
@@ -29,25 +30,31 @@ defmodule Archethic.P2P.Message.ReplicateTransaction do
             tx = %Transaction{
               address: tx_address,
               validation_stamp: stamp = %ValidationStamp{timestamp: validation_time},
-              proof_of_validation: proof_of_validation
+              proof_of_validation: proof_of_validation,
+              proof_of_replication: proof_of_replication
             },
           genesis_address: genesis_address
         },
         _
       ) do
-    elected_nodes =
+    validation_elected_nodes =
       validation_time
       |> P2P.authorized_and_available_nodes()
       |> ProofOfValidation.get_election(tx_address)
 
-    if ProofOfValidation.valid?(elected_nodes, proof_of_validation, stamp) do
+    replication_elected_nodes =
+      validation_time
+      |> P2P.authorized_and_available_nodes()
+      |> ProofOfReplication.get_election(tx_address)
+
+    tx_summary = TransactionSummary.from_transaction(tx, genesis_address)
+
+    with true <- ProofOfValidation.valid?(validation_elected_nodes, proof_of_validation, stamp),
+         true <-
+           ProofOfReplication.valid?(replication_elected_nodes, proof_of_replication, tx_summary) do
       Task.Supervisor.start_child(Archethic.task_supervisors(), fn ->
         replicate_transaction(tx, genesis_address)
       end)
-
-      %Ok{}
-    else
-      %Error{reason: :invalid_transaction}
     end
 
     %Ok{}

--- a/lib/archethic/p2p/message/replication_signature_done.ex
+++ b/lib/archethic/p2p/message/replication_signature_done.ex
@@ -1,0 +1,60 @@
+defmodule Archethic.P2P.Message.ReplicationSignatureDone do
+  @moduledoc false
+
+  defstruct [:address, :replication_signature]
+
+  use Retry
+
+  alias Archethic.Crypto
+  alias Archethic.Mining
+  alias Archethic.P2P
+  alias Archethic.P2P.Node
+  alias Archethic.P2P.Message.Ok
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.Signature
+  alias Archethic.Utils
+
+  require Logger
+
+  @type t() :: %__MODULE__{
+          address: Crypto.prepended_hash(),
+          replication_signature: Signature.t()
+        }
+
+  @spec process(__MODULE__.t(), Crypto.key()) :: Ok.t()
+  def process(
+        %__MODULE__{
+          address: address,
+          replication_signature:
+            replication_signature = %Signature{
+              node_mining_key: node_mining_key,
+              node_public_key: node_public_key
+            }
+        },
+        from
+      ) do
+    with true <- node_public_key == from,
+         %Node{mining_public_key: ^node_mining_key} <- P2P.get_node_info!(from) do
+      Mining.add_replication_signature(address, replication_signature)
+    else
+      _ ->
+        Logger.warning(
+          "Received invalid replication signature done message from #{Base.encode16(from)}"
+        )
+    end
+
+    %Ok{}
+  end
+
+  @spec serialize(t()) :: bitstring()
+  def serialize(%__MODULE__{address: address, replication_signature: signature}) do
+    <<address::binary, Signature.serialize(signature)::bitstring>>
+  end
+
+  @spec deserialize(bitstring()) :: {t(), bitstring}
+  def deserialize(bin) do
+    {address, rest} = Utils.deserialize_address(bin)
+    {signature, rest} = Signature.deserialize(rest)
+
+    {%__MODULE__{address: address, replication_signature: signature}, rest}
+  end
+end

--- a/lib/archethic/p2p/message/request_replication_signature.ex
+++ b/lib/archethic/p2p/message/request_replication_signature.ex
@@ -1,0 +1,121 @@
+defmodule Archethic.P2P.Message.RequestReplicationSignature do
+  @moduledoc false
+
+  defstruct [:address, :genesis_address, :proof_of_validation]
+
+  use Retry
+
+  alias Archethic.Crypto
+  alias Archethic.Election
+  alias Archethic.P2P
+  alias Archethic.P2P.Message.Ok
+  alias Archethic.P2P.Message.ReplicationSignatureDone
+  alias Archethic.Replication
+  alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.Signature
+  alias Archethic.TransactionChain.Transaction.ProofOfValidation
+  alias Archethic.TransactionChain.Transaction.ValidationStamp
+  alias Archethic.TransactionChain.TransactionSummary
+  alias Archethic.Utils
+
+  @type t() :: %__MODULE__{
+          address: Crypto.prepended_hash(),
+          genesis_address: Crypto.prepended_hash(),
+          proof_of_validation: ProofOfValidation.t()
+        }
+
+  @spec process(__MODULE__.t(), Crypto.key()) :: Ok.t()
+  def process(
+        %__MODULE__{
+          address: address,
+          genesis_address: genesis_address,
+          proof_of_validation: proof_of_validation
+        },
+        _
+      ) do
+    Archethic.task_supervisors()
+    |> Task.Supervisor.start_child(fn ->
+      node_public_key = Crypto.first_node_public_key()
+
+      with {:ok, tx} <- get_transaction(address),
+           authorized_nodes <- P2P.authorized_and_available_nodes(tx.validation_stamp.timestamp),
+           true <- Election.chain_storage_node?(address, node_public_key, authorized_nodes),
+           true <- valid_proof_of_validation?(proof_of_validation, tx, authorized_nodes) do
+        Replication.add_proof_of_validation_to_commit_pool(proof_of_validation, address)
+
+        tx = %Transaction{tx | proof_of_validation: proof_of_validation}
+        tx_summary = TransactionSummary.from_transaction(tx, genesis_address)
+
+        message = %ReplicationSignatureDone{
+          address: address,
+          replication_signature: Signature.create(tx_summary)
+        }
+
+        tx
+        |> get_validation_nodes(authorized_nodes)
+        |> P2P.broadcast_message(message)
+      else
+        _ -> :skip
+      end
+    end)
+
+    %Ok{}
+  end
+
+  defp get_transaction(address) do
+    # As validation can happen without all node returned the validation response
+    # it is possible to receive this message before processing the validation
+    retry_while with: constant_backoff(100) |> expiry(2000) do
+      case Replication.get_transaction_in_commit_pool(address) do
+        {:ok, tx, _} -> {:halt, {:ok, tx}}
+        er -> {:cont, er}
+      end
+    end
+  end
+
+  defp valid_proof_of_validation?(
+         proof,
+         %Transaction{address: address, validation_stamp: stamp},
+         authorized_nodes
+       ) do
+    authorized_nodes
+    |> ProofOfValidation.get_election(address)
+    |> ProofOfValidation.valid?(proof, stamp)
+  end
+
+  defp get_validation_nodes(
+         tx = %Transaction{
+           address: address,
+           validation_stamp: %ValidationStamp{proof_of_election: proof_of_election}
+         },
+         authorized_nodes
+       ) do
+    storage_nodes = Election.chain_storage_nodes(address, authorized_nodes)
+    Election.validation_nodes(tx, proof_of_election, authorized_nodes, storage_nodes)
+  end
+
+  @spec serialize(t()) :: bitstring()
+  def serialize(%__MODULE__{
+        address: address,
+        genesis_address: genesis_address,
+        proof_of_validation: proof
+      }) do
+    <<address::binary, genesis_address::binary, ProofOfValidation.serialize(proof)::bitstring>>
+  end
+
+  @spec deserialize(bitstring()) :: {t(), bitstring}
+  def deserialize(bin) do
+    {address, rest} = Utils.deserialize_address(bin)
+    {genesis_address, rest} = Utils.deserialize_address(rest)
+    {proof, rest} = ProofOfValidation.deserialize(rest)
+
+    {
+      %__MODULE__{
+        address: address,
+        genesis_address: genesis_address,
+        proof_of_validation: proof
+      },
+      rest
+    }
+  end
+end

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -32,6 +32,7 @@ defmodule Archethic.Replication do
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
+  alias Archethic.TransactionChain.Transaction.ProofOfValidation
   alias Archethic.TransactionChain.Transaction.ValidationStamp
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
@@ -132,12 +133,35 @@ defmodule Archethic.Replication do
     as: :add_transaction
 
   @doc """
-  Pop a registered transaction in the pool awaiting atomic commitment
+  Add the proof of validation to the queued transaction
   """
-  @spec get_transaction_in_commit_pool(binary()) ::
+  @spec add_proof_of_validation_to_commit_pool(
+          proof_of_validation :: ProofOfValidation.t(),
+          tx_address :: Crypto.prepended_hash()
+        ) :: :ok
+  defdelegate add_proof_of_validation_to_commit_pool(proof_of_validation, tx_address),
+    to: TransactionPool,
+    as: :add_proof_of_validation
+
+  @doc """
+  Get a registered transaction in the pool awaiting atomic commitment
+  """
+  @spec get_transaction_in_commit_pool(address :: Crypto.prepended_hash()) ::
           {:ok, Transaction.t(), list(VersionedUnspentOutput.t())}
           | {:error, :transaction_not_exists}
-  defdelegate get_transaction_in_commit_pool(address), to: TransactionPool, as: :pop_transaction
+  defdelegate get_transaction_in_commit_pool(address),
+    to: TransactionPool,
+    as: :get_transaction
+
+  @doc """
+  Pop a registered transaction in the pool awaiting atomic commitment
+  """
+  @spec pop_transaction_in_commit_pool(address :: Crypto.prepended_hash()) ::
+          {:ok, Transaction.t(), list(VersionedUnspentOutput.t())}
+          | {:error, :transaction_not_exists}
+  defdelegate pop_transaction_in_commit_pool(address),
+    to: TransactionPool,
+    as: :pop_transaction
 
   @type sync_options :: [self_repair?: boolean(), resolved_addresses: map(), chain?: boolean()]
 

--- a/lib/archethic/transaction_chain/transaction/proof_of_replication.ex
+++ b/lib/archethic/transaction_chain/transaction/proof_of_replication.ex
@@ -68,6 +68,16 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfReplication do
   end
 
   @doc """
+  Returns true if a node public key is part of the elected nodes
+  """
+  @spec elected_node?(nodes :: ElectedNodes.t(), signature :: Signature.t()) :: boolean()
+  def elected_node?(
+        %ElectedNodes{storage_nodes: nodes},
+        %Signature{node_public_key: node_public_key}
+      ),
+      do: Utils.key_in_node_list?(nodes, node_public_key)
+
+  @doc """
   Determines if enough signatures have been received to create the aggregated signature
   Returns
     - :reached if enough stamps are valid

--- a/lib/archethic/transaction_chain/transaction/proof_of_replication.ex
+++ b/lib/archethic/transaction_chain/transaction/proof_of_replication.ex
@@ -33,6 +33,7 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfReplication do
         }
 
   @bls_signature_size 96
+  @signature_threshold 0.75
 
   defmodule ElectedNodes do
     @moduledoc """
@@ -163,7 +164,8 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfReplication do
 
   defp get_nb_required_signatures(nodes) do
     %StorageConstraints{number_replicas: nb_replicas_fn} = Election.get_storage_constraints()
-    nb_replicas_fn.(nodes)
+    election_nb = nb_replicas_fn.(nodes)
+    ceil(election_nb * @signature_threshold)
   end
 
   @spec serialize(t()) :: bitstring()

--- a/lib/archethic/transaction_chain/transaction/proof_of_replication.ex
+++ b/lib/archethic/transaction_chain/transaction/proof_of_replication.ex
@@ -1,12 +1,12 @@
-defmodule Archethic.TransactionChain.Transaction.ProofOfValidation do
+defmodule Archethic.TransactionChain.Transaction.ProofOfReplication do
   @moduledoc """
   Handle the Proof Of Validation signatures containing
   - The aggregated signatures
   - Nodes bitmask (bitmask of nodes used for the signatures)
 
   Proof of Validation aggregate all valid Cross Validation Stamp signatures
-  It require a number of cross stamp without error equal or superior to the number 
-  returned by the hypergeometric distribution to be valid
+  It require a threshold of cross stamp without error based on the expected number
+  of validations nodes
   """
 
   alias Archethic.Crypto
@@ -16,12 +16,12 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfValidation do
 
   alias Archethic.P2P.Node
 
-  alias Archethic.TransactionChain.Transaction.CrossValidationStamp
-  alias Archethic.TransactionChain.Transaction.ValidationStamp
+  alias Archethic.TransactionChain.TransactionSummary
 
   alias Archethic.Utils
 
   alias __MODULE__.ElectedNodes
+  alias __MODULE__.Signature
 
   @enforce_keys [:signature, :nodes_bitmask]
   defstruct [:signature, :nodes_bitmask, version: 1]
@@ -36,76 +36,65 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfValidation do
 
   defmodule ElectedNodes do
     @moduledoc """
-    Struct holding sorted validation nodes elected for the transaction
+    Struct holding sorted storage nodes elected for the transaction
     and the required number of validations
     """
     alias Archethic.P2P.Node
 
-    @enforce_keys [:required_validations, :validation_nodes]
-    defstruct [:required_validations, validation_nodes: []]
+    @enforce_keys [:required_signatures, :storage_nodes]
+    defstruct [:required_signatures, storage_nodes: []]
 
     @type t :: %__MODULE__{
-            required_validations: non_neg_integer(),
-            validation_nodes: list(Node.t())
+            required_signatures: non_neg_integer(),
+            storage_nodes: list(Node.t())
           }
   end
 
   @doc """
-  Returns the sorted list of nodes and the required number of validation nodes
+  Returns the sorted list of nodes and the required number of storage nodes
   The input nodes list needs to be the authorized and available nodes at the time of the transaction
   """
   @spec get_election(nodes :: list(Node.t()), tx_address :: Crypto.prepended_hash()) ::
           ElectedNodes.t()
   def get_election(nodes, tx_address) do
-    required_validations = get_nb_required_validations(nodes)
-    validation_nodes = Election.storage_nodes(tx_address, nodes)
+    required_signatures = get_nb_required_signatures(nodes)
+    storage_nodes = Election.storage_nodes(tx_address, nodes)
 
     %ElectedNodes{
-      required_validations: required_validations,
-      validation_nodes: Enum.sort_by(validation_nodes, & &1.first_public_key)
+      required_signatures: required_signatures,
+      storage_nodes: Enum.sort_by(storage_nodes, & &1.first_public_key)
     }
   end
 
   @doc """
-  Determines if enough cross validation stamps have been received to create the aggregated signature
+  Determines if enough signatures have been received to create the aggregated signature
   Returns
     - :reached if enough stamps are valid
     - :not_reached if not enough stamps received yet
-    - :error if it's not possible to reach the required validations
   """
-  @spec get_state(nodes :: ElectedNodes.t(), stamps :: list(CrossValidationStamp.t())) ::
-          :reached | :not_reached | :error
+  @spec get_state(nodes :: ElectedNodes.t(), signatures :: list(Signature.t())) ::
+          :reached | :not_reached
   def get_state(
-        %ElectedNodes{required_validations: required_validations, validation_nodes: nodes},
-        stamps
+        %ElectedNodes{required_signatures: required_signatures, storage_nodes: nodes},
+        signatures
       ) do
-    nb_valid_stamps = stamps |> filter_valid_cross_stamps(nodes) |> Enum.count()
+    nb_valid_signatures = signatures |> filter_elected_signatures(nodes) |> Enum.count()
 
-    if nb_valid_stamps >= required_validations do
-      :reached
-    else
-      nb_remaining_stamps = Enum.count(nodes) - Enum.count(stamps)
-
-      # If the remaining stamp to receive cannot reach the required validations we return an error
-      if nb_valid_stamps + nb_remaining_stamps >= required_validations,
-        do: :not_reached,
-        else: :error
-    end
+    if nb_valid_signatures >= required_signatures, do: :reached, else: :not_reached
   end
 
   @doc """
-  Construct the proof of validation aggregating valid cross stamps signatures
+  Construct the proof of replication aggregating signatures
   """
-  @spec create(nodes :: ElectedNodes.t(), stamps :: list(CrossValidationStamp.t())) :: t()
-  def create(%ElectedNodes{validation_nodes: nodes}, stamps) do
-    valid_cross = filter_valid_cross_stamps(stamps, nodes)
+  @spec create(nodes :: ElectedNodes.t(), signatures :: list(Signature.t())) :: t()
+  def create(%ElectedNodes{storage_nodes: nodes}, proof_signatures) do
+    proof_signatures = filter_elected_signatures(proof_signatures, nodes)
 
     {public_keys, signatures} =
       Enum.reduce(
-        valid_cross,
+        proof_signatures,
         {[], []},
-        fn %CrossValidationStamp{node_mining_key: key, signature: signature},
-           {public_keys, signatures} ->
+        fn %Signature{node_mining_key: key, signature: signature}, {public_keys, signatures} ->
           {[key | public_keys], [signature | signatures]}
         end
       )
@@ -113,7 +102,7 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfValidation do
     aggregated_signature = Crypto.aggregate_signatures(signatures, public_keys)
 
     bitmask =
-      Enum.reduce(valid_cross, <<>>, fn %CrossValidationStamp{node_public_key: key}, acc ->
+      Enum.reduce(proof_signatures, <<>>, fn %Signature{node_public_key: key}, acc ->
         index = Enum.find_index(nodes, &(&1.first_public_key == key))
         Utils.set_bitstring_bit(acc, index)
       end)
@@ -122,10 +111,10 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfValidation do
   end
 
   @doc """
-  Returns the list of node that signed the proof of validation
+  Returns the list of node that signed the proof of replication
   """
   @spec get_nodes(nodes :: ElectedNodes.t(), proof :: t()) :: list(Node.t())
-  def get_nodes(%ElectedNodes{validation_nodes: nodes}, %__MODULE__{nodes_bitmask: bitmask}) do
+  def get_nodes(%ElectedNodes{storage_nodes: nodes}, %__MODULE__{nodes_bitmask: bitmask}) do
     bitmask
     |> Utils.bitstring_to_integer_list()
     |> Enum.with_index()
@@ -134,33 +123,33 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfValidation do
   end
 
   @doc """
-  Validate a proof of validation
-  - Number of validation reach the threshold
-  - aggregated signature is valid
+  Validate a proof of replication
+  - Number of signatures reach the threshold
+  - Aggregated signature is valid
   """
   @spec valid?(
           nodes :: ElectedNodes.t(),
           proof :: t(),
-          validation_stamp :: ValidationStamp.t()
+          transaction_summary :: TransactionSummary.t()
         ) :: boolean()
   def valid?(
         elected_nodes = %ElectedNodes{
-          required_validations: required_validations,
-          validation_nodes: validation_nodes
+          required_signatures: required_signatures,
+          storage_nodes: storage_nodes
         },
         proof = %__MODULE__{signature: signature},
-        validation_stamp
+        transaction_summary
       ) do
     signer_nodes = get_nodes(elected_nodes, proof)
 
-    with true <- Enum.count(signer_nodes) >= required_validations,
-         true <- signer_nodes |> MapSet.new() |> MapSet.subset?(MapSet.new(validation_nodes)) do
+    with true <- Enum.count(signer_nodes) >= required_signatures,
+         true <- signer_nodes |> MapSet.new() |> MapSet.subset?(MapSet.new(storage_nodes)) do
       aggregated_public_key =
         signer_nodes
         |> Enum.map(& &1.mining_public_key)
         |> Crypto.aggregate_mining_public_keys()
 
-      raw_data = CrossValidationStamp.get_raw_data_to_sign(validation_stamp, [])
+      raw_data = TransactionSummary.serialize(transaction_summary)
 
       Crypto.verify?(signature, raw_data, aggregated_public_key)
     else
@@ -168,16 +157,11 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfValidation do
     end
   end
 
-  defp filter_valid_cross_stamps(stamps, validation_nodes) do
-    Enum.filter(
-      stamps,
-      fn %CrossValidationStamp{node_public_key: node_key, inconsistencies: inconsistencies} ->
-        Enum.empty?(inconsistencies) and Utils.key_in_node_list?(validation_nodes, node_key)
-      end
-    )
+  defp filter_elected_signatures(signatures, storage_nodes) do
+    Enum.filter(signatures, &Utils.key_in_node_list?(storage_nodes, &1.node_public_key))
   end
 
-  defp get_nb_required_validations(nodes) do
+  defp get_nb_required_signatures(nodes) do
     %StorageConstraints{number_replicas: nb_replicas_fn} = Election.get_storage_constraints()
     nb_replicas_fn.(nodes)
   end

--- a/lib/archethic/transaction_chain/transaction/proof_of_replication/signature.ex
+++ b/lib/archethic/transaction_chain/transaction/proof_of_replication/signature.ex
@@ -1,0 +1,71 @@
+defmodule Archethic.TransactionChain.Transaction.ProofOfReplication.Signature do
+  @moduledoc """
+  Structure to hold a node proof of replication signature.  
+  Contains:
+  - signature: the BLS signature
+  - node mining key: the node mining key which match the signature
+  - node public key: the node public key which created the signature
+  """
+
+  alias Archethic.Utils
+  alias Archethic.Crypto
+  alias Archethic.TransactionChain.TransactionSummary
+
+  @enforce_keys [:signature, :node_mining_key, :node_public_key]
+  defstruct [:signature, :node_mining_key, :node_public_key]
+
+  @type t :: %__MODULE__{
+          signature: binary(),
+          node_mining_key: Crypto.key(),
+          node_public_key: Crypto.key()
+        }
+
+  @bls_signature_size 96
+
+  @doc """
+  Create a proof of replication signature using the node's mining private key to
+  sign the transaction summary
+  """
+  @spec create(transaction_summary :: TransactionSummary.t()) :: signature :: t()
+  def create(transaction_summary) do
+    signature =
+      transaction_summary |> TransactionSummary.serialize() |> Crypto.sign_with_mining_node_key()
+
+    %__MODULE__{
+      signature: signature,
+      node_mining_key: Crypto.mining_node_public_key(),
+      node_public_key: Crypto.first_node_public_key()
+    }
+  end
+
+  @doc """
+  Returns true if the mining public key match the signature using the transaction summary
+  """
+  @spec valid?(signature :: t(), transaction_summary :: TransactionSummary.t()) :: boolean()
+  def valid?(%__MODULE__{signature: signature, node_mining_key: public_key}, transaction_summary) do
+    raw_data = TransactionSummary.serialize(transaction_summary)
+    Crypto.verify?(signature, raw_data, public_key)
+  end
+
+  @spec serialize(signature :: t()) :: bitstring()
+  def serialize(%__MODULE__{
+        signature: signature,
+        node_mining_key: mining_key,
+        node_public_key: public_key
+      }),
+      do: <<signature::binary-size(@bls_signature_size), mining_key::binary, public_key::binary>>
+
+  @spec deserialize(bin :: bitstring()) :: {signature :: t(), rest :: bitstring()}
+  def deserialize(<<signature::binary-size(@bls_signature_size), rest::bitstring>>) do
+    {mining_key, rest} = Utils.deserialize_public_key(rest)
+    {public_key, rest} = Utils.deserialize_public_key(rest)
+
+    sig = %__MODULE__{
+      signature: signature,
+      node_mining_key: mining_key,
+      node_public_key: public_key
+    }
+
+    {sig, rest}
+  end
+end

--- a/lib/archethic/transaction_chain/transaction/proof_of_validation.ex
+++ b/lib/archethic/transaction_chain/transaction/proof_of_validation.ex
@@ -67,6 +67,16 @@ defmodule Archethic.TransactionChain.Transaction.ProofOfValidation do
   end
 
   @doc """
+  Returns true if a node public key is part of the elected nodes
+  """
+  @spec elected_node?(nodes :: ElectedNodes.t(), stamp :: CrossValidationStamp.t()) :: boolean()
+  def elected_node?(
+        %ElectedNodes{validation_nodes: nodes},
+        %CrossValidationStamp{node_public_key: node_public_key}
+      ),
+      do: Utils.key_in_node_list?(nodes, node_public_key)
+
+  @doc """
   Determines if enough cross validation stamps have been received to create the aggregated signature
   Returns
     - :reached if enough stamps are valid

--- a/lib/archethic_web/api/graphql/schema/transaction_type.ex
+++ b/lib/archethic_web/api/graphql/schema/transaction_type.ex
@@ -21,6 +21,7 @@ defmodule ArchethicWeb.API.GraphQL.Schema.TransactionType do
     field(:validation_stamp, :validation_stamp)
     field(:cross_validation_stamps, list_of(:cross_validation_stamp))
     field(:proof_of_validation, :proof_of_validation)
+    field(:proof_of_replication, :proof_of_replication)
 
     field :inputs, list_of(:transaction_input) do
       arg(:paging_offset, :non_neg_integer)
@@ -272,6 +273,18 @@ defmodule ArchethicWeb.API.GraphQL.Schema.TransactionType do
   - Node public keys: list of node public keys that signed the transaction
   """
   object :proof_of_validation do
+    field(:signature, :hex)
+    field(:node_public_keys, list_of(:public_key))
+  end
+
+  @desc """
+  [ProofOfReplication] represents the aggregated signature from all the node that confirmed the replication of the transaction.  
+  Available since protocol version 9  
+  It includes:
+  - Signature: the aggregated signature
+  - Node public keys: list of node public keys that confirmed the replication
+  """
+  object :proof_of_replication do
     field(:signature, :hex)
     field(:node_public_keys, list_of(:public_key))
   end

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -13,6 +13,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.ProofOfValidation
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
 
@@ -89,7 +90,8 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
          tx = %Transaction{
            address: address,
            validation_stamp: %ValidationStamp{timestamp: timestamp},
-           proof_of_validation: proof
+           proof_of_validation: proof_of_validation,
+           proof_of_replication: proof_of_replication
          }
        ) do
     uco_price_at_time = OracleChain.get_uco_price(timestamp)
@@ -101,16 +103,25 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
       if TransactionChain.first_transaction?(tx), do: nil, else: Transaction.previous_address(tx)
 
     proof_of_validation =
-      if proof != nil do
+      if proof_of_validation != nil do
         timestamp
         |> P2P.authorized_and_available_nodes()
         |> ProofOfValidation.get_election(address)
-        |> ProofOfValidation.to_map(proof)
+        |> ProofOfValidation.to_map(proof_of_validation)
+      end
+
+    proof_of_replication =
+      if proof_of_validation != nil do
+        timestamp
+        |> P2P.authorized_and_available_nodes()
+        |> ProofOfReplication.get_election(address)
+        |> ProofOfReplication.to_map(proof_of_replication)
       end
 
     socket
     |> assign(:transaction, tx)
     |> assign(:proof_of_validation, proof_of_validation)
+    |> assign(:proof_of_replication, proof_of_replication)
     |> assign(:previous_address, previous_address)
     |> assign(:address, address)
     |> assign(:uco_price_at_time, uco_price_at_time)

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -617,6 +617,26 @@
                     <% end %>
                   <% end %>
 
+                  <%= if @proof_of_replication != nil do %>
+                    <p class="heading mt-3">Proof of replication signature</p>
+                    <p class="mono">
+                      <%= Base.encode16(@proof_of_replication.signature) %>
+                    </p>
+                    <p class="heading mt-3">Proof of replication signers public key</p>
+                    <%= for {key, i} <- Enum.with_index(@proof_of_replication.node_public_keys, 1) do %>
+                      <p class="mono">
+                        <%= link("##{i} " <> Base.encode16(key),
+                          to:
+                            Routes.live_path(
+                              @socket,
+                              ArchethicWeb.Explorer.NodeDetailsLive,
+                              Base.encode16(key)
+                            )
+                        ) %>
+                      </p>
+                    <% end %>
+                  <% end %>
+
                   <%= for {cross_validation_stamp, i} <- Enum.with_index(@transaction.cross_validation_stamps, 1) do %>
                     <p class="heading mt-3">Cross validator #<%= i %> public key</p>
                     <p class="mono">

--- a/lib/mix/tasks/benchmark.ex
+++ b/lib/mix/tasks/benchmark.ex
@@ -1,0 +1,42 @@
+defmodule Mix.Tasks.Archethic.Benchmark do
+  @moduledoc "Drop all the data from the database"
+
+  use Mix.Task
+
+  alias Archethic.Crypto
+
+  @impl Mix.Task
+  def run(_arg) do
+    {ed_keypairs, bls_keypairs} =
+      Enum.map(1..200, fn _ ->
+        seed = :crypto.strong_rand_bytes(32)
+        bls_keypair = Crypto.generate_deterministic_keypair(seed, :bls)
+        ed_keypair = Crypto.generate_deterministic_keypair(seed)
+
+        {ed_keypair, bls_keypair}
+      end)
+      |> Enum.unzip()
+
+    data = "hello"
+
+    ed_sig_by_pub = Enum.map(ed_keypairs, fn {pub, priv} -> {pub, Crypto.sign(data, priv)} end)
+
+    {bls_pubs, bls_sigs} =
+      Enum.map(bls_keypairs, fn {pub, priv} -> {pub, Crypto.sign(data, priv)} end) |> Enum.unzip()
+
+    bls_agg_sig = Crypto.aggregate_signatures(bls_sigs, bls_pubs)
+
+    Benchee.run(%{
+      "Verifying 200 ed25519 signatures" => fn ->
+        Task.async_stream(ed_sig_by_pub, fn {pub, sig} -> Crypto.verify?(sig, data, pub) end,
+          max_concurrency: 200
+        )
+        |> Enum.all?()
+      end,
+      "Verifying aggregation of 200 bls signatures" => fn ->
+        agg_pub = Crypto.aggregate_mining_public_keys(bls_pubs)
+        Crypto.verify?(bls_agg_sig, data, agg_pub)
+      end
+    })
+  end
+end

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -37,6 +37,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
   alias Archethic.P2P.Message.Ok
   alias Archethic.P2P.Message.Ping
   alias Archethic.P2P.Message.ProofOfValidationDone
+  alias Archethic.P2P.Message.RequestReplicationSignature
+  alias Archethic.P2P.Message.ProofOfReplicationDone
   alias Archethic.P2P.Message.ReplicateTransaction
   alias Archethic.P2P.Message.ReplicatePendingTransactionChain
   alias Archethic.P2P.Message.UnlockChain
@@ -49,6 +51,8 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
 
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ProofOfValidation
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.Signature
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
@@ -870,6 +874,65 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
           {:ok, %Ok{}}
 
         %Node{first_public_key: first_public_key},
+        %RequestReplicationSignature{proof_of_validation: proof},
+        _ ->
+          tx = Agent.get(agent_pid, & &1)
+
+          assert P2P.authorized_and_available_nodes()
+                 |> ProofOfValidation.get_election(tx.address)
+                 |> ProofOfValidation.valid?(proof, tx.validation_stamp)
+
+          tx = %Transaction{tx | proof_of_validation: proof}
+          Agent.update(agent_pid, fn _ -> tx end)
+
+          genesis = Transaction.previous_address(tx)
+          tx_summary = TransactionSummary.from_transaction(tx, genesis)
+          tx_summary_bin = TransactionSummary.serialize(tx_summary)
+
+          {other_validator_pub, _} = Crypto.generate_deterministic_keypair("seed")
+
+          {other_mining_pub, other_validator_pv} =
+            Crypto.generate_deterministic_keypair("seed", :bls)
+
+          sig =
+            cond do
+              first_public_key == Crypto.first_node_public_key() ->
+                Signature.create(tx_summary)
+
+              first_public_key == elem(storage_node_keypair, 0) ->
+                {pub, pv} = mining_node_keypair
+
+                %Signature{
+                  signature: Crypto.sign(tx_summary_bin, pv),
+                  node_mining_key: pub,
+                  node_public_key: first_public_key
+                }
+
+              first_public_key == elem(storage_node_keypair2, 0) ->
+                {pub, pv} = mining_node_keypair2
+
+                %Signature{
+                  signature: Crypto.sign(tx_summary_bin, pv),
+                  node_mining_key: pub,
+                  node_public_key: first_public_key
+                }
+
+              first_public_key == other_validator_pub ->
+                %Signature{
+                  signature: Crypto.sign(tx_summary_bin, other_validator_pv),
+                  node_mining_key: other_mining_pub,
+                  node_public_key: first_public_key
+                }
+            end
+
+          send(me, {:replication_signature, sig})
+          {:ok, %Ok{}}
+
+        _, %ProofOfReplicationDone{proof_of_replication: proof}, _ ->
+          send(me, {:proof_of_replication_done, proof})
+          {:ok, %Ok{}}
+
+        %Node{first_public_key: first_public_key},
         %ReplicatePendingTransactionChain{genesis_address: genesis_address},
         _ ->
           tx = Agent.get(agent_pid, & &1)
@@ -996,86 +1059,105 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
 
             send(coordinator_pid, {:add_cross_validation_stamp, stamp})
           end
-
-          receive do
-            {:cross_replication_stamp, tx} ->
-              cross_stamp1 = %CrossValidationStamp{
-                node_mining_key: elem(mining_node_keypair, 0),
-                node_public_key: elem(storage_node_keypair, 0),
-                inconsistencies: [],
-                signature:
-                  CrossValidationStamp.get_raw_data_to_sign(tx.validation_stamp, [])
-                  |> Crypto.sign(elem(mining_node_keypair, 1))
-              }
-
-              send(coordinator_pid, {:add_cross_validation_stamp, cross_stamp1})
-              send(cross_validator_pid, {:add_cross_validation_stamp, cross_stamp1})
-
-              cross_stamp2 = %CrossValidationStamp{
-                node_mining_key: elem(mining_node_keypair2, 0),
-                node_public_key: elem(storage_node_keypair2, 0),
-                inconsistencies: [],
-                signature:
-                  CrossValidationStamp.get_raw_data_to_sign(tx.validation_stamp, [])
-                  |> Crypto.sign(elem(mining_node_keypair2, 1))
-              }
-
-              send(coordinator_pid, {:add_cross_validation_stamp, cross_stamp2})
-              send(cross_validator_pid, {:add_cross_validation_stamp, cross_stamp2})
-
-              cross_stamp3 =
-                CrossValidationStamp.sign(%CrossValidationStamp{}, tx.validation_stamp)
-
-              send(coordinator_pid, {:add_cross_validation_stamp, cross_stamp3})
-              send(cross_validator_pid, {:add_cross_validation_stamp, cross_stamp3})
-          after
-            1000 -> :skip
-          end
-
-          receive do
-            {:proof_of_validation_done, proof} ->
-              Workflow.add_proof_of_validation(
-                cross_validator_pid,
-                proof,
-                List.first(validation_nodes).first_public_key
-              )
-          after
-            1000 -> :skip
-          end
-
-          receive do
-            {:ack_replication, sig, pub} ->
-              send(coordinator_pid, {:ack_replication, sig, pub})
-          after
-            1000 -> :skip
-          end
-
-          receive do
-            {:ack_replication, sig, pub} ->
-              send(cross_validator_pid, {:ack_replication, sig, pub})
-          after
-            1000 -> :skip
-          end
-
-          receive do
-            {:ack_replication, sig, pub} ->
-              send(cross_validator_pid, {:ack_replication, sig, pub})
-          after
-            1000 -> :skip
-          end
-
-          receive do
-            {:ack_replication, sig, pub} ->
-              send(coordinator_pid, {:ack_replication, sig, pub})
-          after
-            1000 -> :skip
-          end
-
-          assert_receive :replication_done
-          refute_receive :validation_error
       after
         1000 -> :skip
       end
+
+      receive do
+        {:cross_replication_stamp, tx} ->
+          cross_stamp1 = %CrossValidationStamp{
+            node_mining_key: elem(mining_node_keypair, 0),
+            node_public_key: elem(storage_node_keypair, 0),
+            inconsistencies: [],
+            signature:
+              CrossValidationStamp.get_raw_data_to_sign(tx.validation_stamp, [])
+              |> Crypto.sign(elem(mining_node_keypair, 1))
+          }
+
+          send(coordinator_pid, {:add_cross_validation_stamp, cross_stamp1})
+          send(cross_validator_pid, {:add_cross_validation_stamp, cross_stamp1})
+
+          cross_stamp2 = %CrossValidationStamp{
+            node_mining_key: elem(mining_node_keypair2, 0),
+            node_public_key: elem(storage_node_keypair2, 0),
+            inconsistencies: [],
+            signature:
+              CrossValidationStamp.get_raw_data_to_sign(tx.validation_stamp, [])
+              |> Crypto.sign(elem(mining_node_keypair2, 1))
+          }
+
+          send(coordinator_pid, {:add_cross_validation_stamp, cross_stamp2})
+          send(cross_validator_pid, {:add_cross_validation_stamp, cross_stamp2})
+
+          cross_stamp3 = CrossValidationStamp.sign(%CrossValidationStamp{}, tx.validation_stamp)
+
+          send(coordinator_pid, {:add_cross_validation_stamp, cross_stamp3})
+          send(cross_validator_pid, {:add_cross_validation_stamp, cross_stamp3})
+      after
+        1000 -> :skip
+      end
+
+      receive do
+        {:proof_of_validation_done, proof} ->
+          Workflow.add_proof_of_validation(
+            cross_validator_pid,
+            proof,
+            List.first(validation_nodes).first_public_key
+          )
+      after
+        1000 -> :skip
+      end
+
+      Enum.each(1..4, fn _ ->
+        receive do
+          {:replication_signature, sig} ->
+            send(coordinator_pid, {:add_replication_signature, sig})
+            send(cross_validator_pid, {:add_replication_signature, sig})
+        after
+          1000 -> :skip
+        end
+      end)
+
+      receive do
+        {:proof_of_replication_done, proof} ->
+          Workflow.add_proof_of_replication(
+            cross_validator_pid,
+            proof,
+            List.first(validation_nodes).first_public_key
+          )
+      after
+        1000 -> :skip
+      end
+
+      receive do
+        {:ack_replication, sig, pub} -> send(coordinator_pid, {:ack_replication, sig, pub})
+      after
+        1000 -> :skip
+      end
+
+      receive do
+        {:ack_replication, sig, pub} ->
+          send(cross_validator_pid, {:ack_replication, sig, pub})
+      after
+        1000 -> :skip
+      end
+
+      receive do
+        {:ack_replication, sig, pub} ->
+          send(cross_validator_pid, {:ack_replication, sig, pub})
+      after
+        1000 -> :skip
+      end
+
+      receive do
+        {:ack_replication, sig, pub} ->
+          send(coordinator_pid, {:ack_replication, sig, pub})
+      after
+        1000 -> :skip
+      end
+
+      assert_receive :replication_done
+      refute_receive :validation_error
     end
 
     test "should not replicate if there is a validation error", %{tx: tx, genesis: genesis} do

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -19,6 +19,8 @@ defmodule Archethic.Mining.ValidationContextTest do
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
   alias Archethic.TransactionChain.Transaction.ProofOfValidation
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.Signature
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations
 
@@ -33,6 +35,7 @@ defmodule Archethic.Mining.ValidationContextTest do
   alias Archethic.TransactionChain.TransactionData.UCOLedger
   alias Archethic.TransactionChain.TransactionData.TokenLedger
   alias Archethic.TransactionChain.TransactionData.Recipient
+  alias Archethic.TransactionChain.TransactionSummary
 
   alias Archethic.TransactionFactory
 
@@ -644,6 +647,249 @@ defmodule Archethic.Mining.ValidationContextTest do
     end
   end
 
+  describe "add_replication_signature/2" do
+    test "should add the replication signature to the list" do
+      ctx = create_proof_context("cross")
+
+      SharedSecrets.add_origin_public_key(:software, Crypto.origin_node_public_key())
+
+      ctx =
+        ctx
+        |> ValidationContext.add_validation_stamp(create_validation_stamp(ctx))
+        |> ValidationContext.cross_validate()
+        |> ValidationContext.create_proof_of_validation()
+
+      replication_signature =
+        ctx
+        |> ValidationContext.get_validated_transaction()
+        |> TransactionSummary.from_transaction(ctx.genesis_address)
+        |> Signature.create()
+
+      assert %ValidationContext{replication_signatures: [^replication_signature]} =
+               ValidationContext.add_replication_signature(ctx, replication_signature)
+    end
+
+    test "shoud refuse the replication signature if node is not elected" do
+      ctx = create_proof_context("cross")
+
+      SharedSecrets.add_origin_public_key(:software, Crypto.origin_node_public_key())
+
+      ctx =
+        ctx
+        |> ValidationContext.add_validation_stamp(create_validation_stamp(ctx))
+        |> ValidationContext.cross_validate()
+        |> ValidationContext.create_proof_of_validation()
+
+      other_seed = "other"
+      {wrong_node_pub, _} = Crypto.derive_keypair(other_seed, 0)
+
+      {wrong_mining_pub, wrong_mining_priv} =
+        Crypto.generate_deterministic_keypair(other_seed, :bls)
+
+      tx_summary_bin =
+        ctx
+        |> ValidationContext.get_validated_transaction()
+        |> TransactionSummary.from_transaction(ctx.genesis_address)
+        |> TransactionSummary.serialize()
+
+      replication_signature = %Signature{
+        signature: Crypto.sign(tx_summary_bin, wrong_mining_priv),
+        node_mining_key: wrong_mining_pub,
+        node_public_key: wrong_node_pub
+      }
+
+      assert %ValidationContext{replication_signatures: []} =
+               ValidationContext.add_replication_signature(ctx, replication_signature)
+    end
+
+    test "shoud refuse the replication signature if the signature is invalid" do
+      ctx = create_proof_context("cross")
+
+      SharedSecrets.add_origin_public_key(:software, Crypto.origin_node_public_key())
+
+      ctx =
+        ctx
+        |> ValidationContext.add_validation_stamp(create_validation_stamp(ctx))
+        |> ValidationContext.cross_validate()
+        |> ValidationContext.create_proof_of_validation()
+
+      other_seed = "other"
+      {wrong_node_pub, _} = Crypto.derive_keypair(other_seed, 0)
+
+      {wrong_mining_pub, _wrong_mining_priv} =
+        Crypto.generate_deterministic_keypair(other_seed, :bls)
+
+      replication_signature = %Signature{
+        signature: :crypto.strong_rand_bytes(96),
+        node_mining_key: wrong_mining_pub,
+        node_public_key: wrong_node_pub
+      }
+
+      assert %ValidationContext{replication_signatures: []} =
+               ValidationContext.add_replication_signature(ctx, replication_signature)
+    end
+  end
+
+  describe "create_proof_of_replication/1" do
+    test "should create the proof of replication" do
+      ctx = create_context()
+
+      SharedSecrets.add_origin_public_key(:software, Crypto.origin_node_public_key())
+
+      assert %ValidationContext{proof_of_replication: %ProofOfReplication{}} =
+               ctx
+               |> ValidationContext.add_validation_stamp(create_validation_stamp(ctx))
+               |> ValidationContext.cross_validate()
+               |> ValidationContext.create_proof_of_validation()
+               |> then(fn ctx ->
+                 replication_signature =
+                   ctx
+                   |> ValidationContext.get_validated_transaction()
+                   |> TransactionSummary.from_transaction(ctx.genesis_address)
+                   |> Signature.create()
+
+                 ValidationContext.add_replication_signature(ctx, replication_signature)
+               end)
+               |> ValidationContext.create_proof_of_replication()
+    end
+  end
+
+  describe "valid_proof_of_replication?/2" do
+    test "should return false if proof signature is invalid" do
+      cross_seed = "cross"
+      {node_pub, _} = Crypto.derive_keypair(cross_seed, 0)
+      {mining_pub, mining_priv} = Crypto.generate_deterministic_keypair(cross_seed, :bls)
+
+      ctx = create_proof_context(cross_seed)
+
+      SharedSecrets.add_origin_public_key(:software, Crypto.origin_node_public_key())
+
+      ctx =
+        ctx
+        |> ValidationContext.add_validation_stamp(create_validation_stamp(ctx))
+        |> ValidationContext.cross_validate()
+        |> ValidationContext.create_proof_of_validation()
+
+      tx_summary =
+        ctx
+        |> ValidationContext.get_validated_transaction()
+        |> TransactionSummary.from_transaction(ctx.genesis_address)
+
+      replication_signature = Signature.create(tx_summary)
+
+      ctx = ValidationContext.add_replication_signature(ctx, replication_signature)
+
+      tx_summary_bin = TransactionSummary.serialize(tx_summary)
+
+      replication_signature = %Signature{
+        signature: Crypto.sign(tx_summary_bin, mining_priv),
+        node_public_key: node_pub,
+        node_mining_key: mining_pub
+      }
+
+      ctx = ValidationContext.add_replication_signature(ctx, replication_signature)
+
+      proof =
+        P2P.authorized_and_available_nodes()
+        |> ProofOfReplication.get_election(ctx.transaction.address)
+        |> ProofOfReplication.create(ctx.replication_signatures)
+
+      assert ValidationContext.valid_proof_of_replication?(ctx, proof)
+
+      proof = Map.put(proof, :signature, :crypto.strong_rand_bytes(96))
+      refute ValidationContext.valid_proof_of_replication?(ctx, proof)
+    end
+
+    test "should return false if proof does not reach threashold" do
+      cross_seed = "cross"
+      {node_pub, _} = Crypto.derive_keypair(cross_seed, 0)
+      {mining_pub, mining_priv} = Crypto.generate_deterministic_keypair(cross_seed, :bls)
+
+      ctx = create_proof_context(cross_seed)
+
+      SharedSecrets.add_origin_public_key(:software, Crypto.origin_node_public_key())
+
+      ctx =
+        ctx
+        |> ValidationContext.add_validation_stamp(create_validation_stamp(ctx))
+        |> ValidationContext.cross_validate()
+        |> ValidationContext.create_proof_of_validation()
+
+      tx_summary =
+        ctx
+        |> ValidationContext.get_validated_transaction()
+        |> TransactionSummary.from_transaction(ctx.genesis_address)
+
+      replication_signature = Signature.create(tx_summary)
+
+      ctx = ValidationContext.add_replication_signature(ctx, replication_signature)
+
+      tx_summary_bin = TransactionSummary.serialize(tx_summary)
+
+      replication_signature = %Signature{
+        signature: Crypto.sign(tx_summary_bin, mining_priv),
+        node_public_key: node_pub,
+        node_mining_key: mining_pub
+      }
+
+      ctx = ValidationContext.add_replication_signature(ctx, replication_signature)
+
+      proof =
+        P2P.authorized_and_available_nodes()
+        |> ProofOfReplication.get_election(ctx.transaction.address)
+        |> ProofOfReplication.create(ctx.replication_signatures)
+
+      assert ValidationContext.valid_proof_of_replication?(ctx, proof)
+
+      proof =
+        P2P.authorized_and_available_nodes()
+        |> ProofOfReplication.get_election(ctx.transaction.address)
+        |> ProofOfReplication.create(Enum.take(ctx.replication_signatures, 1))
+
+      refute ValidationContext.valid_proof_of_replication?(ctx, proof)
+    end
+
+    test "should return false if proof is signed by other node than expected" do
+      other_seed = "other"
+      {wrong_node_pub, _} = Crypto.derive_keypair(other_seed, 0)
+
+      {wrong_mining_pub, wrong_mining_priv} =
+        Crypto.generate_deterministic_keypair(other_seed, :bls)
+
+      ctx = create_proof_context("cross")
+
+      SharedSecrets.add_origin_public_key(:software, Crypto.origin_node_public_key())
+
+      ctx =
+        ctx
+        |> ValidationContext.add_validation_stamp(create_validation_stamp(ctx))
+        |> ValidationContext.cross_validate()
+        |> ValidationContext.create_proof_of_validation()
+
+      tx_summary =
+        ctx
+        |> ValidationContext.get_validated_transaction()
+        |> TransactionSummary.from_transaction(ctx.genesis_address)
+
+      replication_signature_valid = Signature.create(tx_summary)
+
+      tx_summary_bin = TransactionSummary.serialize(tx_summary)
+
+      replication_signature_invalid = %Signature{
+        signature: Crypto.sign(tx_summary_bin, wrong_mining_priv),
+        node_public_key: wrong_node_pub,
+        node_mining_key: wrong_mining_pub
+      }
+
+      proof =
+        P2P.authorized_and_available_nodes()
+        |> ProofOfReplication.get_election(ctx.transaction.address)
+        |> ProofOfReplication.create([replication_signature_valid, replication_signature_invalid])
+
+      refute ValidationContext.valid_proof_of_replication?(ctx, proof)
+    end
+  end
+
   describe "get_confirmed_replication_nodes/1" do
     test "should return the correct nodes" do
       ctx = create_context()
@@ -709,8 +955,11 @@ defmodule Archethic.Mining.ValidationContextTest do
       cross_validation_nodes: [cross_validation_node],
       chain_storage_nodes: [coordinator_node, cross_validation_node],
       validation_time: validation_time,
-      proof_elected_nodes:
-        P2P.authorized_and_available_nodes() |> ProofOfValidation.get_election(tx.address)
+      genesis_address: Transaction.previous_address(tx),
+      validation_proof_elected_nodes:
+        P2P.authorized_and_available_nodes() |> ProofOfValidation.get_election(tx.address),
+      replication_proof_elected_nodes:
+        P2P.authorized_and_available_nodes() |> ProofOfReplication.get_election(tx.address)
     }
   end
 
@@ -765,8 +1014,11 @@ defmodule Archethic.Mining.ValidationContextTest do
       validation_time: validation_time,
       resolved_addresses: resolved_addresses,
       chain_storage_nodes: previous_storage_nodes,
-      proof_elected_nodes:
-        P2P.authorized_and_available_nodes() |> ProofOfValidation.get_election(tx.address)
+      genesis_address: Transaction.previous_address(tx),
+      validation_proof_elected_nodes:
+        P2P.authorized_and_available_nodes() |> ProofOfValidation.get_election(tx.address),
+      replication_proof_elected_nodes:
+        P2P.authorized_and_available_nodes() |> ProofOfReplication.get_election(tx.address)
     }
   end
 

--- a/test/archethic/p2p/message/proof_of_replication_done_test.exs
+++ b/test/archethic/p2p/message/proof_of_replication_done_test.exs
@@ -1,0 +1,22 @@
+defmodule Archethic.P2P.Message.ProofOfReplicationDoneTest do
+  @moduledoc false
+  use ArchethicCase
+  import ArchethicCase
+
+  alias Archethic.P2P.Message.ProofOfReplicationDone
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
+
+  test "serialize/deserialize" do
+    proof = %ProofOfReplication{
+      signature: :crypto.strong_rand_bytes(96),
+      nodes_bitmask: <<0::5, -1::3, 0::2>>
+    }
+
+    msg = %ProofOfReplicationDone{address: random_address(), proof_of_replication: proof}
+
+    assert {^msg, <<>>} =
+             msg
+             |> ProofOfReplicationDone.serialize()
+             |> ProofOfReplicationDone.deserialize()
+  end
+end

--- a/test/archethic/p2p/message/replication_signature_done_test.exs
+++ b/test/archethic/p2p/message/replication_signature_done_test.exs
@@ -1,0 +1,26 @@
+defmodule Archethic.P2P.Message.ReplicationSignatureDoneTest do
+  @moduledoc false
+  use ArchethicCase
+  import ArchethicCase
+
+  alias Archethic.P2P.Message.ReplicationSignatureDone
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.Signature
+
+  test "serialize/deserialize" do
+    sig = %Signature{
+      signature: :crypto.strong_rand_bytes(96),
+      node_mining_key: random_public_key(:bls),
+      node_public_key: random_public_key()
+    }
+
+    msg = %ReplicationSignatureDone{
+      address: random_address(),
+      replication_signature: sig
+    }
+
+    assert {^msg, <<>>} =
+             msg
+             |> ReplicationSignatureDone.serialize()
+             |> ReplicationSignatureDone.deserialize()
+  end
+end

--- a/test/archethic/p2p/message/request_replication_signature_test.exs
+++ b/test/archethic/p2p/message/request_replication_signature_test.exs
@@ -1,0 +1,26 @@
+defmodule Archethic.P2P.Message.RequestReplicationSignatureTest do
+  @moduledoc false
+  use ArchethicCase
+  import ArchethicCase
+
+  alias Archethic.P2P.Message.RequestReplicationSignature
+  alias Archethic.TransactionChain.Transaction.ProofOfValidation
+
+  test "serialize/deserialize" do
+    proof = %ProofOfValidation{
+      signature: :crypto.strong_rand_bytes(96),
+      nodes_bitmask: <<0::5, -1::3, 0::2>>
+    }
+
+    msg = %RequestReplicationSignature{
+      address: random_address(),
+      genesis_address: random_address(),
+      proof_of_validation: proof
+    }
+
+    assert {^msg, <<>>} =
+             msg
+             |> RequestReplicationSignature.serialize()
+             |> RequestReplicationSignature.deserialize()
+  end
+end

--- a/test/archethic/replication/transaction_pool_test.exs
+++ b/test/archethic/replication/transaction_pool_test.exs
@@ -1,65 +1,100 @@
 defmodule Archethic.ReplicationTransactionPoolTest do
-  use ExUnit.Case
+  use ArchethicCase
+  import ArchethicCase
 
   alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ProofOfValidation
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
 
   alias Archethic.Replication.TransactionPool
 
+  alias Archethic.TransactionFactory
+
   test "add_transaction/2 should add transaction in the pool" do
     {:ok, pid} = TransactionPool.start_link([clean_interval: 0], [])
-    address = :crypto.strong_rand_bytes(33)
-    now = DateTime.utc_now()
 
-    TransactionPool.add_transaction(pid, %Transaction{address: address, type: :transfer}, [
-      %VersionedUnspentOutput{
-        unspent_output: %UnspentOutput{
-          from: ArchethicCase.random_address(),
-          amount: 100_000_000,
-          type: :UCO
-        }
+    tx = %Transaction{address: address} = TransactionFactory.create_valid_transaction()
+
+    inputs = [
+      %UnspentOutput{
+        from: ArchethicCase.random_address(),
+        amount: 100_000_000,
+        type: :UCO
       }
-    ])
+      |> VersionedUnspentOutput.wrap_unspent_output(current_protocol_version())
+    ]
 
-    assert %{
-             transactions: %{
-               ^address =>
-                 {_, expire_at,
-                  [%VersionedUnspentOutput{unspent_output: %UnspentOutput{amount: 100_000_000}}]}
-             }
-           } = :sys.get_state(pid)
+    now = DateTime.utc_now()
+    TransactionPool.add_transaction(pid, tx, inputs)
+
+    assert %{transactions: %{^address => {^tx, expire_at, ^inputs}}} = :sys.get_state(pid)
 
     assert DateTime.diff(expire_at, now, :second) == 60
   end
 
-  test "pop_transaction/2 should get and remove a registed transaction in the pool" do
-    {:ok, pid} = TransactionPool.start_link([clean_interval: 0], [])
-    address = :crypto.strong_rand_bytes(33)
-    tx = %Transaction{address: address, type: :transfer}
+  describe "get_transaction/2" do
+    test "should get and let a registered transaction in the pool" do
+      {:ok, pid} = TransactionPool.start_link([clean_interval: 0], [])
 
-    TransactionPool.add_transaction(pid, tx, [
-      %VersionedUnspentOutput{
-        unspent_output: %UnspentOutput{
-          from: ArchethicCase.random_address(),
-          amount: 100_000_000,
-          type: :UCO
+      tx = %Transaction{address: address} = TransactionFactory.create_valid_transaction()
+
+      inputs = [
+        %VersionedUnspentOutput{
+          unspent_output: %UnspentOutput{from: random_address(), amount: 100_000_000, type: :UCO}
         }
+      ]
+
+      TransactionPool.add_transaction(pid, tx, inputs)
+
+      assert {:ok, ^tx, ^inputs} = TransactionPool.get_transaction(pid, address)
+
+      assert %{transactions: %{^address => {^tx, _, ^inputs}}} = :sys.get_state(pid)
+    end
+  end
+
+  describe "pop_transaction/2" do
+    test "should get and remove a registered transaction in the pool" do
+      {:ok, pid} = TransactionPool.start_link([clean_interval: 0], [])
+
+      tx = %Transaction{address: address} = TransactionFactory.create_valid_transaction()
+
+      inputs = [
+        %VersionedUnspentOutput{
+          unspent_output: %UnspentOutput{from: random_address(), amount: 100_000_000, type: :UCO}
+        }
+      ]
+
+      TransactionPool.add_transaction(pid, tx, inputs)
+
+      assert {:ok, ^tx, ^inputs} = TransactionPool.pop_transaction(pid, address)
+
+      assert %{transactions: %{}} = :sys.get_state(pid)
+    end
+  end
+
+  test "add_proof_of_validation/3 should add the proof of validation to registered transaction in the pool" do
+    {:ok, pid} = TransactionPool.start_link([clean_interval: 0], [])
+
+    tx = %Transaction{address: address} = TransactionFactory.create_valid_transaction()
+
+    {proof = %ProofOfValidation{}, tx_without_proof} =
+      Map.get_and_update!(tx, :proof_of_validation, fn proof -> {proof, nil} end)
+
+    inputs = [
+      %VersionedUnspentOutput{
+        unspent_output: %UnspentOutput{from: random_address(), amount: 100_000_000, type: :UCO}
       }
-    ])
+    ]
 
-    {:ok, ^tx,
-     [
-       %VersionedUnspentOutput{
-         unspent_output: %UnspentOutput{
-           amount: 100_000_000,
-           type: :UCO
-         }
-       }
-     ]} = TransactionPool.pop_transaction(pid, address)
+    TransactionPool.add_transaction(pid, tx_without_proof, inputs)
 
-    assert %{transactions: %{}} = :sys.get_state(pid)
+    assert {:ok, ^tx_without_proof, ^inputs} = TransactionPool.get_transaction(pid, address)
+
+    assert :ok = TransactionPool.add_proof_of_validation(pid, proof, address)
+
+    assert {:ok, ^tx, ^inputs} = TransactionPool.get_transaction(pid, address)
   end
 
   test "should clean too long transactions" do

--- a/test/archethic/transaction_chain/transaction/proof_of_replication/signature_test.exs
+++ b/test/archethic/transaction_chain/transaction/proof_of_replication/signature_test.exs
@@ -1,0 +1,81 @@
+defmodule Archethic.TransactionChain.Transaction.ProofOfReplication.SignatureTest do
+  use ArchethicCase
+  import ArchethicCase
+
+  alias Archethic.Crypto
+  alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.Signature
+  alias Archethic.TransactionChain.TransactionSummary
+
+  alias Archethic.TransactionFactory
+
+  test "create/1 should create a proof signature" do
+    tx = TransactionFactory.create_valid_transaction()
+    genesis = Transaction.previous_address(tx)
+    tx_summary = TransactionSummary.from_transaction(tx, genesis)
+
+    expected_public_key = Crypto.first_node_public_key()
+    expected_mining_key = Crypto.mining_node_public_key()
+
+    assert %Signature{
+             node_public_key: ^expected_public_key,
+             node_mining_key: ^expected_mining_key,
+             signature: signature
+           } = Signature.create(tx_summary)
+
+    raw_data = TransactionSummary.serialize(tx_summary)
+
+    assert Crypto.verify?(signature, raw_data, expected_mining_key)
+  end
+
+  describe "valid?/2" do
+    test "should return true of the signature is valid" do
+      tx = TransactionFactory.create_valid_transaction()
+      genesis = Transaction.previous_address(tx)
+      tx_summary = TransactionSummary.from_transaction(tx, genesis)
+
+      proof_signature = Signature.create(tx_summary)
+
+      assert Signature.valid?(proof_signature, tx_summary)
+    end
+
+    test "should return false if the signature public key is invalid" do
+      tx = TransactionFactory.create_valid_transaction()
+      genesis = Transaction.previous_address(tx)
+      tx_summary = TransactionSummary.from_transaction(tx, genesis)
+
+      proof_signature = %Signature{
+        Signature.create(tx_summary)
+        | node_mining_key: random_public_key(:bls)
+      }
+
+      refute Signature.valid?(proof_signature, tx_summary)
+    end
+
+    test "should return false if the signature is invalid" do
+      tx1 = TransactionFactory.create_valid_transaction()
+      genesis = Transaction.previous_address(tx1)
+      tx_summary1 = TransactionSummary.from_transaction(tx1, genesis)
+
+      proof_signature = Signature.create(tx_summary1)
+      assert Signature.valid?(proof_signature, tx_summary1)
+
+      tx2 = TransactionFactory.create_valid_transaction([], content: "Hello")
+      genesis = Transaction.previous_address(tx2)
+      tx_summary2 = TransactionSummary.from_transaction(tx2, genesis)
+
+      refute Signature.valid?(proof_signature, tx_summary2)
+    end
+  end
+
+  test "serialization" do
+    tx = TransactionFactory.create_valid_transaction()
+    genesis = Transaction.previous_address(tx)
+    tx_summary = TransactionSummary.from_transaction(tx, genesis)
+
+    proof_signature = Signature.create(tx_summary)
+
+    assert {proof_signature, <<>>} ==
+             proof_signature |> Signature.serialize() |> Signature.deserialize()
+  end
+end

--- a/test/archethic/transaction_chain/transaction/proof_of_replication_test.exs
+++ b/test/archethic/transaction_chain/transaction/proof_of_replication_test.exs
@@ -1,0 +1,245 @@
+defmodule Archethic.TransactionChain.Transaction.ProofOfReplicationTest do
+  use ArchethicCase
+  import ArchethicCase
+
+  alias Archethic.TransactionChain.TransactionSummary
+  alias Archethic.Crypto
+  alias Archethic.Election
+  alias Archethic.P2P
+  alias Archethic.P2P.Node
+  alias Archethic.TransactionChain.Transaction
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.ElectedNodes
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.Signature
+
+  alias Archethic.TransactionFactory
+
+  @nb_nodes 53
+
+  setup do
+    nodes =
+      Enum.map(1..@nb_nodes, fn i ->
+        seed = :crypto.strong_rand_bytes(32)
+        {mining_pub, mining_pv} = seed |> Crypto.generate_deterministic_keypair(:bls)
+
+        # patch needed to satisfy election geo distribution
+        patch = "#{i |> rem(16) |> Integer.to_string(16)}AA"
+
+        node =
+          new_node(
+            first_public_key: seed |> Crypto.derive_keypair(0) |> elem(0),
+            last_public_key: seed |> Crypto.derive_keypair(1) |> elem(0),
+            mining_public_key: mining_pub,
+            geo_patch: patch,
+            network_path: patch
+          )
+
+        P2P.add_and_connect_node(node)
+        {mining_pv, node}
+      end)
+
+    tx = %Transaction{address: tx_address} = TransactionFactory.create_valid_transaction()
+    genesis = Transaction.previous_address(tx)
+    tx_summary = TransactionSummary.from_transaction(tx, genesis)
+
+    %ElectedNodes{storage_nodes: storage_nodes} =
+      P2P.authorized_and_available_nodes() |> ProofOfReplication.get_election(tx_address)
+
+    mapped_storage_nodes =
+      Enum.map(storage_nodes, fn node -> Enum.find(nodes, &(elem(&1, 1) == node)) end)
+
+    proof_signatures = Enum.map(mapped_storage_nodes, &create_proof_signature(&1, tx_summary))
+
+    # Ensure election have less nodes than the total number of nodes
+    assert tx_address |> Election.storage_nodes(P2P.authorized_and_available_nodes()) |> length() !=
+             length(nodes)
+
+    %{nodes: nodes, transaction_summary: tx_summary, proof_signatures: proof_signatures}
+  end
+
+  describe "get_state/2" do
+    test "should return :reached when threshold is reached", %{
+      nodes: nodes,
+      transaction_summary: tx_summary = %TransactionSummary{address: tx_address},
+      proof_signatures: proof_signatures
+    } do
+      assert :reached ==
+               P2P.authorized_and_available_nodes()
+               |> ProofOfReplication.get_election(tx_address)
+               |> ProofOfReplication.get_state(proof_signatures)
+
+      nb_invalid = @nb_nodes - length(proof_signatures)
+
+      assert nb_invalid > 0
+
+      proof_signatures =
+        nodes
+        |> Enum.take_random(nb_invalid)
+        |> Enum.map(&create_proof_signature(&1, tx_summary))
+        |> Enum.concat(proof_signatures)
+
+      # over threashold with invalid stamps
+      assert :reached ==
+               P2P.authorized_and_available_nodes()
+               |> ProofOfReplication.get_election(tx_address)
+               |> ProofOfReplication.get_state(proof_signatures)
+    end
+
+    test "should return :not_reached when required number is not reached but still possible", %{
+      transaction_summary: %TransactionSummary{address: tx_address},
+      proof_signatures: proof_signatures
+    } do
+      nb_validation = length(proof_signatures)
+      some_proof_signatures = Enum.take_random(proof_signatures, nb_validation - 2)
+
+      assert :not_reached ==
+               P2P.authorized_and_available_nodes()
+               |> ProofOfReplication.get_election(tx_address)
+               |> ProofOfReplication.get_state(some_proof_signatures)
+    end
+  end
+
+  describe "create/2" do
+    test "should aggregate cross stamps signature and create bitmask of which node signed", %{
+      transaction_summary: %TransactionSummary{address: tx_address},
+      proof_signatures: proof_signatures
+    } do
+      %ElectedNodes{required_signatures: required_signatures} =
+        P2P.authorized_and_available_nodes() |> ProofOfReplication.get_election(tx_address)
+
+      expected_bitmask = <<-1::integer-size(required_signatures)>>
+
+      assert %ProofOfReplication{signature: <<_::768>>, nodes_bitmask: ^expected_bitmask} =
+               P2P.authorized_and_available_nodes()
+               |> ProofOfReplication.get_election(tx_address)
+               |> ProofOfReplication.create(proof_signatures)
+
+      [_, _ | proof_signatures] = proof_signatures
+
+      # removed two first nodes
+      expected_bitmask = <<0::2, -1::integer-size(required_signatures - 2)>>
+
+      assert %ProofOfReplication{signature: <<_::768>>, nodes_bitmask: ^expected_bitmask} =
+               P2P.authorized_and_available_nodes()
+               |> ProofOfReplication.get_election(tx_address)
+               |> ProofOfReplication.create(proof_signatures)
+    end
+  end
+
+  describe "valid?/2" do
+    test "should return true if proof reach threashold and signature is valid", %{
+      transaction_summary: tx_summary = %TransactionSummary{address: tx_address},
+      proof_signatures: proof_signatures
+    } do
+      proof =
+        P2P.authorized_and_available_nodes()
+        |> ProofOfReplication.get_election(tx_address)
+        |> ProofOfReplication.create(proof_signatures)
+
+      assert P2P.authorized_and_available_nodes()
+             |> ProofOfReplication.get_election(tx_address)
+             |> ProofOfReplication.valid?(proof, tx_summary)
+    end
+
+    test "should return false if proof does not reach threashold and signature is valid", %{
+      transaction_summary: tx_summary = %TransactionSummary{address: tx_address},
+      proof_signatures: proof_signatures
+    } do
+      nb_validation = length(proof_signatures)
+      proof_signatures = Enum.take(proof_signatures, nb_validation - 2)
+
+      proof =
+        P2P.authorized_and_available_nodes()
+        |> ProofOfReplication.get_election(tx_address)
+        |> ProofOfReplication.create(proof_signatures)
+
+      refute P2P.authorized_and_available_nodes()
+             |> ProofOfReplication.get_election(tx_address)
+             |> ProofOfReplication.valid?(proof, tx_summary)
+    end
+
+    test "should return false if proof reach threashold and signature is invalid", %{
+      transaction_summary: tx_summary = %TransactionSummary{address: tx_address},
+      proof_signatures: proof_signatures
+    } do
+      proof =
+        P2P.authorized_and_available_nodes()
+        |> ProofOfReplication.get_election(tx_address)
+        |> ProofOfReplication.create(proof_signatures)
+        |> Map.put(:signature, :crypto.strong_rand_bytes(96))
+
+      refute P2P.authorized_and_available_nodes()
+             |> ProofOfReplication.get_election(tx_address)
+             |> ProofOfReplication.valid?(proof, tx_summary)
+    end
+
+    test "should return false if signer nodes are not the elected ones", %{
+      nodes: nodes,
+      transaction_summary: tx_summary = %TransactionSummary{address: tx_address},
+      proof_signatures: proof_signatures
+    } do
+      elected_nodes =
+        %ElectedNodes{storage_nodes: storage_nodes} =
+        P2P.authorized_and_available_nodes() |> ProofOfReplication.get_election(tx_address)
+
+      not_elected_node =
+        Enum.find(nodes, fn {_, node} -> not Enum.member?(storage_nodes, node) end)
+
+      invalid_proof_signature = create_proof_signature(not_elected_node, tx_summary)
+
+      [_ | proof_signatures] = proof_signatures
+
+      proof =
+        ProofOfReplication.create(elected_nodes, [invalid_proof_signature | proof_signatures])
+
+      refute ProofOfReplication.valid?(elected_nodes, proof, tx_summary)
+    end
+  end
+
+  describe "get_nodes/2" do
+    test "should return nodes which signed the proof", %{
+      transaction_summary: %TransactionSummary{address: tx_address},
+      proof_signatures: proof_signatures
+    } do
+      elected_nodes =
+        %ElectedNodes{storage_nodes: storage_nodes} =
+        P2P.authorized_and_available_nodes() |> ProofOfReplication.get_election(tx_address)
+
+      [_, _ | proof_signatures] = proof_signatures
+      proof = ProofOfReplication.create(elected_nodes, proof_signatures)
+
+      proof_nodes = ProofOfReplication.get_nodes(elected_nodes, proof)
+
+      [_, _ | storage_nodes] = storage_nodes
+      assert proof_nodes == storage_nodes
+    end
+  end
+
+  describe "serialization" do
+    test "should serialize and deserialize properly", %{
+      transaction_summary: %TransactionSummary{address: tx_address},
+      proof_signatures: proof_signatures
+    } do
+      proof =
+        P2P.authorized_and_available_nodes()
+        |> ProofOfReplication.get_election(tx_address)
+        |> ProofOfReplication.create(proof_signatures)
+
+      assert {proof, ""} ==
+               proof |> ProofOfReplication.serialize() |> ProofOfReplication.deserialize()
+    end
+  end
+
+  defp create_proof_signature(
+         {pv, %Node{mining_public_key: mining_public_key, first_public_key: first_public_key}},
+         tx_summary
+       ) do
+    raw_data = TransactionSummary.serialize(tx_summary)
+
+    %Signature{
+      node_public_key: first_public_key,
+      node_mining_key: mining_public_key,
+      signature: Crypto.sign(raw_data, pv)
+    }
+  end
+end

--- a/test/archethic/transaction_chain/transaction_test.exs
+++ b/test/archethic/transaction_chain/transaction_test.exs
@@ -9,6 +9,7 @@ defmodule Archethic.TransactionChain.TransactionTest do
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
   alias Archethic.TransactionChain.Transaction.ProofOfValidation
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
   alias Archethic.TransactionChain.Transaction.ValidationStamp
 
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.TransactionMovement
@@ -535,16 +536,22 @@ defmodule Archethic.TransactionChain.TransactionTest do
   describe "symmetric serialization" do
     test "should use cross_validation_stamps under protocol_version 9" do
       tx =
-        %Transaction{cross_validation_stamps: [_ | _], proof_of_validation: nil} =
-        TransactionFactory.create_valid_transaction([], protocol_version: 8)
+        %Transaction{
+          cross_validation_stamps: [_ | _],
+          proof_of_validation: nil,
+          proof_of_replication: nil
+        } = TransactionFactory.create_valid_transaction([], protocol_version: 8)
 
       assert {tx, <<>>} == tx |> Transaction.serialize() |> Transaction.deserialize()
     end
 
-    test "should use proof_of_validation since protocol_version 9" do
+    test "should use proof_of_validation / proof_of_replication since protocol_version 9" do
       tx =
-        %Transaction{cross_validation_stamps: [], proof_of_validation: %ProofOfValidation{}} =
-        TransactionFactory.create_valid_transaction([])
+        %Transaction{
+          cross_validation_stamps: [],
+          proof_of_validation: %ProofOfValidation{},
+          proof_of_replication: %ProofOfReplication{}
+        } = TransactionFactory.create_valid_transaction([])
 
       assert {tx, <<>>} == tx |> Transaction.serialize() |> Transaction.deserialize()
     end

--- a/test/support/transaction_factory.ex
+++ b/test/support/transaction_factory.ex
@@ -12,6 +12,8 @@ defmodule Archethic.TransactionFactory do
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.CrossValidationStamp
   alias Archethic.TransactionChain.Transaction.ProofOfValidation
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication
+  alias Archethic.TransactionChain.Transaction.ProofOfReplication.Signature
   alias Archethic.TransactionChain.Transaction.ValidationStamp
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
 
@@ -21,6 +23,8 @@ defmodule Archethic.TransactionFactory do
 
   alias Archethic.TransactionChain.TransactionData
   alias Archethic.TransactionChain.TransactionData.Ledger
+
+  alias Archethic.TransactionChain.TransactionSummary
 
   alias Archethic.SharedSecrets
 
@@ -143,16 +147,30 @@ defmodule Archethic.TransactionFactory do
             cross_validation_stamps: cross_stamps
         }
       else
-        proof =
-          [new_node()]
+        nodes = [new_node()]
+
+        proof_of_validation =
+          nodes
           |> ProofOfValidation.get_election(tx.address)
           |> ProofOfValidation.create(cross_validation_stamps)
 
-        %Transaction{
+        tx = %Transaction{
           tx
           | validation_stamp: validation_stamp,
-            proof_of_validation: proof
+            proof_of_validation: proof_of_validation
         }
+
+        replication_signature =
+          tx
+          |> TransactionSummary.from_transaction(Transaction.previous_address(tx))
+          |> Signature.create()
+
+        proof_of_replication =
+          nodes
+          |> ProofOfReplication.get_election(tx.address)
+          |> ProofOfReplication.create([replication_signature])
+
+        %Transaction{tx | proof_of_replication: proof_of_replication}
       end
 
     {tx, cross_validation_stamps}


### PR DESCRIPTION
# Description

Handle new BLS replication signatures
- Add new ProofOfReplication module that create and validate the replication aggregated signatures
- A threshold of 75% of replication nodes is expected to consider the proof valid
- Once the proof of validation is created, validation nodes request replication nodes to create the replication signature which signs the transaction summary
- Replication signatures are sent asynchronously allowing validation nodes to create the proof as soon as the threshold is reached
- Coordinator node is responsible to create the proof of replication and share it to other validation nodes

Fixes #1544 and #1545

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
