### PR TITLE
Add infinity timeout on Genserver DB call

### DIFF
--- a/lib/archethic/db/embedded_impl/chain_writer.ex
+++ b/lib/archethic/db/embedded_impl/chain_writer.ex
@@ -28,7 +28,7 @@ defmodule Archethic.DB.EmbeddedImpl.ChainWriter do
   @spec append_transaction(binary(), Transaction.t()) :: :ok
   def append_transaction(genesis_address, tx = %Transaction{}) do
     via_tuple = {:via, PartitionSupervisor, {ChainWriterSupervisor, genesis_address}}
-    GenServer.call(via_tuple, {:append_tx, genesis_address, tx})
+    GenServer.call(via_tuple, {:append_tx, genesis_address, tx}, :infinity)
   end
 
   @doc """

--- a/lib/archethic/utxo/loader.ex
+++ b/lib/archethic/utxo/loader.ex
@@ -29,7 +29,7 @@ defmodule Archethic.UTXO.Loader do
   def add_utxo(utxo = %VersionedUnspentOutput{}, genesis_address) do
     genesis_address
     |> via_tuple()
-    |> GenServer.call({:add_utxo, utxo, genesis_address})
+    |> GenServer.call({:add_utxo, utxo, genesis_address}, :infinity)
   end
 
   @doc """
@@ -39,7 +39,7 @@ defmodule Archethic.UTXO.Loader do
   def add_utxos(utxos, genesis_address) do
     genesis_address
     |> via_tuple()
-    |> GenServer.call({:add_utxos, utxos, genesis_address})
+    |> GenServer.call({:add_utxos, utxos, genesis_address}, :infinity)
   end
 
   @doc """
@@ -59,7 +59,7 @@ defmodule Archethic.UTXO.Loader do
   def consume_inputs(tx = %Transaction{}, genesis_address) do
     genesis_address
     |> via_tuple()
-    |> GenServer.call({:consume_inputs, tx, genesis_address})
+    |> GenServer.call({:consume_inputs, tx, genesis_address}, :infinity)
   end
 
   defp via_tuple(genesis_address) do


### PR DESCRIPTION
# Description

Add infinity timeout on DB write through Genserver.call

Fixes #1617 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
