### PR TITLE
Fix self repair recipient consolidation

### DIFF
--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -821,7 +821,7 @@ defmodule Archethic.TransactionChain do
   It queries the the network for genesis address.
   """
   @spec fetch_genesis_address(address :: binary(), nodes :: list(Node.t()), opts :: Keyword.t()) ::
-          {:ok, binary()} | {:error, :network_issue}
+          {:ok, binary()} | {:error, :network_issue} | {:error, :acceptance_failed}
   def fetch_genesis_address(address, nodes, opts \\ []) when is_binary(address) do
     case find_genesis_address(address) do
       {:error, :not_found} ->
@@ -851,11 +851,8 @@ defmodule Archethic.TransactionChain do
                timeout: timeout,
                acceptance_resolver: acceptance_resolver
              ) do
-          {:ok, %GenesisAddress{address: genesis_address}} ->
-            {:ok, genesis_address}
-
-          _ ->
-            {:error, :network_issue}
+          {:ok, %GenesisAddress{address: genesis_address}} -> {:ok, genesis_address}
+          error -> error
         end
 
       res ->

--- a/test/archethic/bootstrap/network_init_test.exs
+++ b/test/archethic/bootstrap/network_init_test.exs
@@ -332,8 +332,8 @@ defmodule Archethic.Bootstrap.NetworkInitTest do
       _, %GetTransactionChainLength{}, _ ->
         %TransactionChainLength{length: 1}
 
-      _, %GetGenesisAddress{}, _ ->
-        {:ok, %NotFound{}}
+      _, %GetGenesisAddress{address: address}, _ ->
+        {:ok, %GenesisAddress{address: address, timestamp: DateTime.utc_now()}}
     end)
 
     P2P.add_and_connect_node(%Node{

--- a/test/archethic/bootstrap_test.exs
+++ b/test/archethic/bootstrap_test.exs
@@ -18,6 +18,7 @@ defmodule Archethic.BootstrapTest do
     EncryptedStorageNonce,
     GetBootstrappingNodes,
     GetGenesisAddress,
+    GenesisAddress,
     GetLastTransactionAddress,
     GetStorageNonce,
     GetTransaction,
@@ -126,14 +127,11 @@ defmodule Archethic.BootstrapTest do
         _, %GetTransactionChainLength{}, _ ->
           %TransactionChainLength{length: 1}
 
-        _, %GetGenesisAddress{}, _ ->
-          {:ok, %NotFound{}}
+        _, %GetGenesisAddress{address: address}, _ ->
+          {:ok, %GenesisAddress{address: address, timestamp: DateTime.utc_now()}}
 
         _, %GetCurrentReplicationAttestations{}, _ ->
-          {:ok,
-           %CurrentReplicationAttestations{
-             replication_attestations: []
-           }}
+          {:ok, %CurrentReplicationAttestations{replication_attestations: []}}
       end)
 
       {:ok, daily_nonce_agent} = Agent.start_link(fn -> %{} end)


### PR DESCRIPTION
# Description

Fixes an issue where a node cannot fetch the genesis address of a recipient while consolidating it in self repair.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
