### PR TITLE
Use ZIP to reduce smart contract state size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ erl_crash.dump
 .elixir_ls
 **/doc
 .
+.env
 
 /rel/artifacts
 

--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -3,6 +3,7 @@ defmodule Archethic do
   Provides high level functions serving the API and the Explorer
   """
 
+  alias Archethic.TransactionChain.VersionedTransactionInput
   alias Archethic.UTXO
   alias Archethic.BeaconChain
   alias Archethic.Crypto
@@ -337,11 +338,29 @@ defmodule Archethic do
   def get_transaction_inputs(address, paging_offset \\ 0, limit \\ 0)
       when is_binary(address) and is_integer(paging_offset) and paging_offset >= 0 and
              is_integer(limit) and limit >= 0 do
+    get_versioned_transaction_inputs(address, paging_offset, limit)
+    |> VersionedTransactionInput.unwrap_inputs()
+  end
+
+  @doc """
+  Request to fetch the versioned inputs for a transaction address from the closest nodes
+  """
+  @spec get_versioned_transaction_inputs(
+          Crypto.prepended_hash(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          list(VersionedTransactionInput.t())
+  def get_versioned_transaction_inputs(address, paging_offset \\ 0, limit \\ 0)
+      when is_binary(address) and is_integer(paging_offset) and paging_offset >= 0 and
+             is_integer(limit) and limit >= 0 do
     case Archethic.fetch_genesis_address(address) do
       {:ok, genesis_address} ->
         genesis_inputs_task =
           Task.async(fn ->
-            genesis_address |> get_unspent_outputs() |> Enum.map(&TransactionInput.from_utxo/1)
+            genesis_address
+            |> get_versioned_unspent_outputs()
+            |> Enum.map(&VersionedTransactionInput.from_utxo/1)
           end)
 
         if address == genesis_address do
@@ -368,8 +387,7 @@ defmodule Archethic do
 
         first_address
         |> TransactionChain.fetch_inputs(storage_nodes, paging_offset, limit)
-        |> Enum.map(& &1.input)
-        |> Enum.map(&TransactionInput.set_spent(&1, genesis_inputs))
+        |> Enum.map(&VersionedTransactionInput.set_spent(&1, genesis_inputs))
 
       _ ->
         Task.await(genesis_inputs_task)
@@ -388,8 +406,7 @@ defmodule Archethic do
 
         next_address
         |> TransactionChain.fetch_inputs(storage_nodes, paging_offset, limit)
-        |> Enum.map(& &1.input)
-        |> Enum.map(&TransactionInput.set_spent(&1, genesis_inputs))
+        |> Enum.map(&VersionedTransactionInput.set_spent(&1, genesis_inputs))
 
       _ ->
         Task.await(genesis_inputs_task)
@@ -405,6 +422,19 @@ defmodule Archethic do
           limit :: non_neg_integer()
         ) :: list(UnspentOutput.t())
   def get_unspent_outputs(address, paging_offset \\ nil, limit \\ 0) do
+    get_versioned_unspent_outputs(address, paging_offset, limit)
+    |> VersionedUnspentOutput.unwrap_unspent_outputs()
+  end
+
+  @doc """
+  Request to fetch the versioned unspent outputs for a transaction address from the closest nodes
+  """
+  @spec get_versioned_unspent_outputs(
+          address :: Crypto.prepended_hash(),
+          paging_offset :: Crypto.sha256() | nil,
+          limit :: non_neg_integer()
+        ) :: list(VersionedUnspentOutput.t())
+  def get_versioned_unspent_outputs(address, paging_offset \\ nil, limit \\ 0) do
     previous_summary_time = BeaconChain.previous_summary_time(DateTime.utc_now())
 
     nodes =
@@ -414,7 +444,6 @@ defmodule Archethic do
 
     address
     |> TransactionChain.fetch_unspent_outputs(nodes, paging_offset: paging_offset, limit: limit)
-    |> VersionedUnspentOutput.unwrap_unspent_outputs()
   end
 
   @doc """

--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -346,9 +346,9 @@ defmodule Archethic do
   Request to fetch the versioned inputs for a transaction address from the closest nodes
   """
   @spec get_versioned_transaction_inputs(
-          Crypto.prepended_hash(),
-          non_neg_integer(),
-          non_neg_integer()
+          address :: Crypto.prepended_hash(),
+          paging_offset :: non_neg_integer(),
+          limit :: non_neg_integer()
         ) ::
           list(VersionedTransactionInput.t())
   def get_versioned_transaction_inputs(address, paging_offset \\ 0, limit \\ 0)

--- a/lib/archethic/contracts.ex
+++ b/lib/archethic/contracts.ex
@@ -668,6 +668,7 @@ defmodule Archethic.Contracts do
         %WasmContract{module: module},
         transaction = %Transaction{
           validation_stamp: %ValidationStamp{
+            protocol_version: protocol_version,
             ledger_operations: %LedgerOperations{
               unspent_outputs: next_unspent_outputs
             }
@@ -685,7 +686,7 @@ defmodule Archethic.Contracts do
             %{}
 
           %UnspentOutput{encoded_payload: encoded_payload} ->
-            {state, _} = State.deserialize(encoded_payload)
+            {state, _} = State.deserialize(encoded_payload, protocol_version)
             state
         end
 

--- a/lib/archethic/contracts/contract/state.ex
+++ b/lib/archethic/contracts/contract/state.ex
@@ -25,7 +25,7 @@ defmodule Archethic.Contracts.Contract.State do
   @doc """
   Serialize the given state
   """
-  @spec serialize(t(), protocol_version :: pos_integer()) :: encoded()
+  @spec serialize(state :: t(), protocol_version :: pos_integer()) :: encoded()
   def serialize(state, protocol_version \\ Mining.protocol_version())
 
   def serialize(state, protocol_version) when protocol_version < 9,
@@ -45,7 +45,8 @@ defmodule Archethic.Contracts.Contract.State do
   @doc """
   Deserialize the state
   """
-  @spec deserialize(bitstring(), protocol_version :: pos_integer()) :: {t(), bitstring()}
+  @spec deserialize(bitstring :: bitstring(), protocol_version :: pos_integer()) ::
+          {t(), bitstring()}
   def deserialize(bitstring, protocol_version) when protocol_version < 9,
     do: TypedEncoding.deserialize(bitstring, :compact)
 

--- a/lib/archethic/contracts/contract/state.ex
+++ b/lib/archethic/contracts/contract/state.ex
@@ -3,6 +3,9 @@ defmodule Archethic.Contracts.Contract.State do
   Module to manipulate the contract state
   """
   alias Archethic.Utils.TypedEncoding
+  alias Archethic.Utils
+  alias Archethic.Utils.VarInt
+  alias Archethic.Mining
 
   # 3 MB
   @max_compressed_state_size 3 * 1024 * 1024
@@ -22,14 +25,39 @@ defmodule Archethic.Contracts.Contract.State do
   @doc """
   Serialize the given state
   """
-  @spec serialize(t()) :: encoded()
-  def serialize(state), do: TypedEncoding.serialize(state, :compact)
+  @spec serialize(t(), protocol_version :: pos_integer()) :: encoded()
+  def serialize(state, protocol_version \\ Mining.protocol_version())
+
+  def serialize(state, protocol_version) when protocol_version < 9,
+    do: TypedEncoding.serialize(state, :compact)
+
+  def serialize(state, _protocol_version) do
+    encoded_payload =
+      TypedEncoding.serialize(state, :compact)
+      |> Utils.wrap_binary()
+      |> :zlib.zip()
+
+    encoded_payload_size = encoded_payload |> byte_size() |> VarInt.from_value()
+
+    <<encoded_payload_size::binary, encoded_payload::binary>>
+  end
 
   @doc """
   Deserialize the state
   """
-  @spec deserialize(bitstring()) :: {t(), bitstring()}
-  def deserialize(bitsting), do: TypedEncoding.deserialize(bitsting, :compact)
+  @spec deserialize(bitstring(), protocol_version :: pos_integer()) :: {t(), bitstring()}
+  def deserialize(bitstring, protocol_version) when protocol_version < 9,
+    do: TypedEncoding.deserialize(bitstring, :compact)
+
+  def deserialize(bitstring, _protocol_version) do
+    {encoded_payload_size, rest} = VarInt.get_value(bitstring)
+
+    <<encoded_payload::binary-size(encoded_payload_size), rest::bitstring>> = rest
+
+    {state, _} = :zlib.unzip(encoded_payload) |> TypedEncoding.deserialize(:compact)
+
+    {state, rest}
+  end
 
   @doc """
   Return a valid JSON of the given state

--- a/lib/archethic/contracts/interpreter/contract.ex
+++ b/lib/archethic/contracts/interpreter/contract.ex
@@ -76,12 +76,13 @@ defmodule Archethic.Contracts.Interpreter.Contract do
 
   defp get_state_from_tx(%Transaction{
          validation_stamp: %ValidationStamp{
+           protocol_version: protocol_version,
            ledger_operations: %LedgerOperations{unspent_outputs: utxos}
          }
        }) do
     case Enum.find(utxos, &(&1.type == :state)) do
       %UnspentOutput{encoded_payload: encoded_state} ->
-        {state, _rest} = State.deserialize(encoded_state)
+        {state, _rest} = State.deserialize(encoded_state, protocol_version)
         state
 
       nil ->

--- a/lib/archethic/contracts/wasm/contract.ex
+++ b/lib/archethic/contracts/wasm/contract.ex
@@ -85,12 +85,13 @@ defmodule Archethic.Contracts.WasmContract do
 
   defp get_state_from_tx(%Transaction{
          validation_stamp: %ValidationStamp{
+           protocol_version: protocol_version,
            ledger_operations: %LedgerOperations{unspent_outputs: utxos}
          }
        }) do
     case Enum.find(utxos, &(&1.type == :state)) do
       %UnspentOutput{encoded_payload: encoded_state} ->
-        {state, _rest} = State.deserialize(encoded_state)
+        {state, _rest} = State.deserialize(encoded_state, protocol_version)
         state
 
       nil ->

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -34,7 +34,7 @@ defmodule Archethic.Mining do
   # version 5->6 the POI changed and is now done with tx.data.recipients.args serialized with :extended mode
   # version 6->7 add Add consumed inputs in tx.validation_stamp.ledger_operations
   # version 7->8 movement resolved address are now the genesis address of the destination
-  # version 8->9 genesis in the validation stamp
+  # version 8->9 genesis in the validation stamp // TODO ajouter infos au sujet du Zip du state
   @protocol_version 9
 
   @lock_threshold 0.75

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -34,7 +34,9 @@ defmodule Archethic.Mining do
   # version 5->6 the POI changed and is now done with tx.data.recipients.args serialized with :extended mode
   # version 6->7 add Add consumed inputs in tx.validation_stamp.ledger_operations
   # version 7->8 movement resolved address are now the genesis address of the destination
-  # version 8->9 genesis in the validation stamp // TODO ajouter infos au sujet du Zip du state
+  # version 8->9
+  #    - genesis in the validation stamp
+  #    - smart contracts' state is now compressed to reduce storage and p2p communications load
   @protocol_version 9
 
   @lock_threshold 0.75

--- a/lib/archethic/transaction_chain/transaction/validation_stamp.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp.ex
@@ -226,14 +226,15 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp do
         recipients: recipients,
         signature: signature,
         error: error,
-        genesis_address: genesis_address
+        genesis_address: genesis_address,
+        protocol_version: protocol_version
       }) do
     %{
       timestamp: timestamp,
       proof_of_work: pow,
       proof_of_integrity: poi,
       proof_of_election: poe,
-      ledger_operations: LedgerOperations.to_map(ledger_operations),
+      ledger_operations: LedgerOperations.to_map(ledger_operations, protocol_version),
       recipients: recipients,
       signature: signature,
       error: error,

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations.ex
@@ -191,16 +191,19 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
     }
   end
 
-  @spec to_map(t()) :: map()
-  def to_map(%__MODULE__{
-        transaction_movements: transaction_movements,
-        unspent_outputs: unspent_outputs,
-        fee: fee,
-        consumed_inputs: consumed_inputs
-      }) do
+  @spec to_map(t(), protocol_version :: pos_integer()) :: map()
+  def to_map(
+        %__MODULE__{
+          transaction_movements: transaction_movements,
+          unspent_outputs: unspent_outputs,
+          fee: fee,
+          consumed_inputs: consumed_inputs
+        },
+        protocol_version
+      ) do
     %{
       transaction_movements: Enum.map(transaction_movements, &TransactionMovement.to_map/1),
-      unspent_outputs: Enum.map(unspent_outputs, &UnspentOutput.to_map/1),
+      unspent_outputs: Enum.map(unspent_outputs, &UnspentOutput.to_map(&1, protocol_version)),
       fee: fee,
       consumed_inputs: Enum.map(consumed_inputs, &VersionedUnspentOutput.to_map/1)
     }

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/unspent_output.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/unspent_output.ex
@@ -262,7 +262,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>   type: :UCO,
       ...>   timestamp: ~U[2022-10-11 07:27:22.815Z]
       ...> }
-      ...> |> UnspentOutput.to_map()
+      ...> |> UnspentOutput.to_map(9)
       %{
         from:
           <<0, 0, 214, 107, 17, 107, 227, 11, 17, 43, 204, 48, 78, 129, 145, 126, 45, 68, 194, 159,
@@ -282,7 +282,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
       ...>      <<0, 49, 101, 72, 154, 152, 3, 174, 47, 2, 35, 7, 92, 122, 206, 185, 71, 140, 74,
       ...>        197, 46, 99, 117, 89, 96, 100, 20, 0, 34, 181, 215, 143, 175>>, 0}
       ...> }
-      ...> |> UnspentOutput.to_map()
+      ...> |> UnspentOutput.to_map(9)
       %{
         from:
           <<0, 0, 214, 107, 17, 107, 227, 11, 17, 43, 204, 48, 78, 129, 145, 126, 45, 68, 194, 159,
@@ -296,13 +296,16 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
         timestamp: nil
       }
   """
-  @spec to_map(t()) :: map()
-  def to_map(%__MODULE__{
-        from: from,
-        amount: amount,
-        type: :UCO,
-        timestamp: timestamp
-      }) do
+  @spec to_map(t(), protocol_version :: pos_integer()) :: map()
+  def to_map(
+        %__MODULE__{
+          from: from,
+          amount: amount,
+          type: :UCO,
+          timestamp: timestamp
+        },
+        _protocol_version
+      ) do
     %{
       from: from,
       amount: amount,
@@ -311,12 +314,15 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
     }
   end
 
-  def to_map(%__MODULE__{
-        from: from,
-        amount: amount,
-        type: {:token, token_address, token_id},
-        timestamp: timestamp
-      }) do
+  def to_map(
+        %__MODULE__{
+          from: from,
+          amount: amount,
+          type: {:token, token_address, token_id},
+          timestamp: timestamp
+        },
+        _protocol_version
+      ) do
     %{
       from: from,
       amount: amount,
@@ -327,25 +333,31 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
     }
   end
 
-  def to_map(%__MODULE__{
-        from: from,
-        type: :state,
-        encoded_payload: encoded_payload,
-        timestamp: timestamp
-      }) do
+  def to_map(
+        %__MODULE__{
+          from: from,
+          type: :state,
+          encoded_payload: encoded_payload,
+          timestamp: timestamp
+        },
+        protocol_version
+      ) do
     %{
       from: from,
       type: "state",
-      state: State.deserialize(encoded_payload) |> elem(0),
+      state: State.deserialize(encoded_payload, protocol_version) |> elem(0),
       timestamp: timestamp
     }
   end
 
-  def to_map(%__MODULE__{
-        from: from,
-        type: :call,
-        timestamp: timestamp
-      }) do
+  def to_map(
+        %__MODULE__{
+          from: from,
+          type: :call,
+          timestamp: timestamp
+        },
+        _protocol_version
+      ) do
     %{
       from: from,
       type: "call",

--- a/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/versioned_unspent_output.ex
+++ b/lib/archethic/transaction_chain/transaction/validation_stamp/ledger_operations/versioned_unspent_output.ex
@@ -61,7 +61,7 @@ defmodule Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperation
   """
   @spec to_map(versioned_unspent_output :: t()) :: map()
   def to_map(%__MODULE__{unspent_output: utxo, protocol_version: protocol_version}) do
-    utxo |> UnspentOutput.to_map() |> Map.put(:protocol_version, protocol_version)
+    utxo |> UnspentOutput.to_map(protocol_version) |> Map.put(:protocol_version, protocol_version)
   end
 
   @doc """

--- a/lib/archethic/transaction_chain/transaction_input.ex
+++ b/lib/archethic/transaction_chain/transaction_input.ex
@@ -202,14 +202,17 @@ defmodule Archethic.TransactionChain.TransactionInput do
     end
   end
 
-  @spec to_map(__MODULE__.t()) :: map()
-  def to_map(%__MODULE__{
-        amount: amount,
-        from: from,
-        spent?: spent?,
-        type: :UCO,
-        timestamp: timestamp
-      }) do
+  @spec to_map(__MODULE__.t(), protocol_version :: pos_integer()) :: map()
+  def to_map(
+        %__MODULE__{
+          amount: amount,
+          from: from,
+          spent?: spent?,
+          type: :UCO,
+          timestamp: timestamp
+        },
+        _protocol_version
+      ) do
     %{
       amount: amount,
       from: from,
@@ -219,13 +222,16 @@ defmodule Archethic.TransactionChain.TransactionInput do
     }
   end
 
-  def to_map(%__MODULE__{
-        amount: amount,
-        from: from,
-        spent?: spent?,
-        type: {:token, token_address, token_id},
-        timestamp: timestamp
-      }) do
+  def to_map(
+        %__MODULE__{
+          amount: amount,
+          from: from,
+          spent?: spent?,
+          type: {:token, token_address, token_id},
+          timestamp: timestamp
+        },
+        _protocol_version
+      ) do
     %{
       amount: amount,
       from: from,
@@ -237,7 +243,10 @@ defmodule Archethic.TransactionChain.TransactionInput do
     }
   end
 
-  def to_map(%__MODULE__{amount: _, from: from, spent?: spent?, type: :call, timestamp: timestamp}) do
+  def to_map(
+        %__MODULE__{amount: _, from: from, spent?: spent?, type: :call, timestamp: timestamp},
+        _protocol_version
+      ) do
     %{
       from: from,
       type: "call",
@@ -246,20 +255,23 @@ defmodule Archethic.TransactionChain.TransactionInput do
     }
   end
 
-  def to_map(%__MODULE__{
-        amount: _,
-        from: from,
-        spent?: spent?,
-        type: :state,
-        timestamp: timestamp,
-        encoded_payload: encoded_payload
-      }) do
+  def to_map(
+        %__MODULE__{
+          amount: _,
+          from: from,
+          spent?: spent?,
+          type: :state,
+          timestamp: timestamp,
+          encoded_payload: encoded_payload
+        },
+        protocol_version
+      ) do
     %{
       from: from,
       type: "state",
       spent: spent?,
       timestamp: timestamp,
-      encoded_payload: encoded_payload |> State.deserialize() |> elem(0)
+      encoded_payload: encoded_payload |> State.deserialize(protocol_version) |> elem(0)
     }
   end
 

--- a/lib/archethic/transaction_chain/versioned_transaction_input.ex
+++ b/lib/archethic/transaction_chain/versioned_transaction_input.ex
@@ -48,8 +48,8 @@ defmodule Archethic.TransactionChain.VersionedTransactionInput do
   Unwrap a list of VersionedTransactionInput into a list of UnspentOutput
   """
   @spec unwrap_inputs(versioned_inputs :: list(t())) :: list(TransactionInput.t())
-  def unwrap_inputs(utxos),
-    do: Enum.map(utxos, &unwrap_input/1)
+  def unwrap_inputs(versioned_inputs),
+    do: Enum.map(versioned_inputs, &unwrap_input/1)
 
   @doc """
   Unwrap a VersionedTransactionInput into an TransactionInput

--- a/lib/archethic/transaction_chain/versioned_transaction_input.ex
+++ b/lib/archethic/transaction_chain/versioned_transaction_input.ex
@@ -7,10 +7,55 @@ defmodule Archethic.TransactionChain.VersionedTransactionInput do
 
   alias Archethic.TransactionChain.TransactionInput
 
+  alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.VersionedUnspentOutput
+
   @type t :: %__MODULE__{
           protocol_version: pos_integer(),
           input: TransactionInput.t()
         }
+
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{
+        protocol_version: protocol_version,
+        input: input
+      }) do
+    TransactionInput.to_map(input, protocol_version)
+  end
+
+  @doc """
+  Convert an VersionedUnspentOutput into a VersionedTransactionInput struct
+  """
+  @spec from_utxo(VersionedUnspentOutput.t()) :: t()
+  def from_utxo(%VersionedUnspentOutput{protocol_version: protocol_version, unspent_output: utxo}) do
+    %__MODULE__{
+      protocol_version: protocol_version,
+      input: TransactionInput.from_utxo(utxo)
+    }
+  end
+
+  @doc """
+  Mark the input as spent if it is not a member of the genesis inputs
+  """
+  @spec set_spent(t(), list(t())) :: t()
+  def set_spent(versioned_input = %__MODULE__{input: input}, genesis_inputs) do
+    %{
+      versioned_input
+      | input: TransactionInput.set_spent(input, genesis_inputs |> Enum.map(& &1.input))
+    }
+  end
+
+  @doc """
+  Unwrap a list of VersionedTransactionInput into a list of UnspentOutput
+  """
+  @spec unwrap_inputs(versioned_inputs :: list(t())) :: list(TransactionInput.t())
+  def unwrap_inputs(utxos),
+    do: Enum.map(utxos, &unwrap_input/1)
+
+  @doc """
+  Unwrap a VersionedTransactionInput into an TransactionInput
+  """
+  @spec unwrap_input(versioned_input :: t()) :: TransactionInput.t()
+  def unwrap_input(%__MODULE__{input: input}), do: input
 
   @spec serialize(t()) :: bitstring()
   def serialize(

--- a/lib/archethic_web/api/graphql/schema/resolver.ex
+++ b/lib/archethic_web/api/graphql/schema/resolver.ex
@@ -16,7 +16,7 @@ defmodule ArchethicWeb.API.GraphQL.Schema.Resolver do
   alias Archethic.TransactionChain
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
-  alias Archethic.TransactionChain.TransactionInput
+  alias Archethic.TransactionChain.VersionedTransactionInput
 
   alias Archethic.Mining
 
@@ -90,8 +90,8 @@ defmodule ArchethicWeb.API.GraphQL.Schema.Resolver do
   def get_inputs(address, paging_offset \\ 0, limit \\ 0) do
     inputs =
       address
-      |> Archethic.get_transaction_inputs(paging_offset, limit)
-      |> Enum.map(&TransactionInput.to_map/1)
+      |> Archethic.get_versioned_transaction_inputs(paging_offset, limit)
+      |> Enum.map(&VersionedTransactionInput.to_map/1)
 
     {:ok, inputs}
   end
@@ -342,7 +342,7 @@ defmodule ArchethicWeb.API.GraphQL.Schema.Resolver do
 
   def get_genesis_unspent_outputs(address, paging_offset \\ nil, limit \\ 0) do
     {:ok,
-     Archethic.get_unspent_outputs(address, paging_offset, limit)
-     |> Enum.map(&UnspentOutput.to_map/1)}
+     Archethic.get_versioned_unspent_outputs(address, paging_offset, limit)
+     |> Enum.map(&UnspentOutput.to_map(&1.unspent_output, &1.protocol_version))}
   end
 end

--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -1,6 +1,7 @@
 defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
   @moduledoc false
   alias Archethic.TransactionChain.Transaction.ValidationStamp.LedgerOperations.UnspentOutput
+
   use ArchethicWeb.Explorer, :live_view
 
   alias Archethic.Contracts.Contract.State
@@ -331,8 +332,8 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
     |> assign(:ko?, true)
   end
 
-  def print_state(%UnspentOutput{encoded_payload: encoded_state}) do
-    encoded_state |> State.deserialize() |> elem(0) |> State.format()
+  def print_state(%UnspentOutput{encoded_payload: encoded_state}, protocol_version) do
+    encoded_state |> State.deserialize(protocol_version) |> elem(0) |> State.format()
   end
 
   defp similar?(

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -237,6 +237,8 @@
                   &(&1.type == :state)
                 )
 
+              protocol_version = @transaction.validation_stamp.protocol_version
+
               state_bytes =
                 case state_utxo do
                   nil -> 0
@@ -261,7 +263,7 @@
                     class="language-json"
                     phx-hook="CodeViewer"
                   >
-                    <%= print_state(state_utxo) %>
+                    <%= print_state(state_utxo, protocol_version) %>
                   </pre>
                 <% end %>
               </div>

--- a/test/archethic/contracts/state_test.exs
+++ b/test/archethic/contracts/state_test.exs
@@ -4,13 +4,22 @@ defmodule Archethic.Contracts.Contract.StateTest do
   use ArchethicCase
 
   describe "serialization/deserialization" do
-    test "should work" do
+    test "should deserialize when protocol_version < 9" do
       state = complex_state()
 
       assert {^state, <<>>} =
                state
-               |> State.serialize()
-               |> State.deserialize()
+               |> State.serialize(8)
+               |> State.deserialize(8)
+    end
+
+    test "should serialize/deserialize when protocol_version >=9" do
+      state = complex_state()
+
+      assert {^state, <<>>} =
+               state
+               |> State.serialize(9)
+               |> State.deserialize(9)
     end
   end
 


### PR DESCRIPTION
# Description

Smart contracts state is compressed using  `zlib`.

Fixes #1615
