### PR TITLE
Handle acceptance_failed in adjust attestation

### DIFF
--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -417,6 +417,9 @@ defmodule Archethic.SelfRepair.Sync do
           {:ok, genesis_address} ->
             genesis_address
 
+          {:error, :acceptance_failed} ->
+            tx_address
+
           {:error, reason} ->
             raise SelfRepair.Error,
               function: "adjust_attestation",


### PR DESCRIPTION
# Description

Fixes an issue where a transaction address is the same as its genesis address. This was not properly handled in self repair.
PS: this is not possible anymore since we added a control in pending validation. But old transaction may be wrong so we need to handle this case

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
