### PR TITLE
Ignore asdf upstate exit code

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,7 +57,7 @@ echo '. $HOME/.asdf/asdf.sh' >> ~/.profile
 echo '. $HOME/.asdf/completions/asdf.bash' >> ~/.profile
 source ~/.profile
 
-asdf update
+asdf update || :
 
 asdf plugin add erlang || :
 asdf plugin add elixir || :


### PR DESCRIPTION
# Description

Since last version of asdf, the command `asdf update` is deprecated and return an exit code 1 which stop the install.sh script
I just ignored the exit code so the script don't stop

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
