### PR TITLE
Validation election new algo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ erl_crash.dump
 # Dialyzer
 /priv/plts
 
+# Code assistant
+.aider*
+
 /assets/node_modules
 
 log_*

--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -76,13 +76,17 @@ defmodule Archethic do
 
     cond do
       P2P.authorized_and_available_node?() and shared_secret_synced?() ->
-        validation_nodes = Mining.get_validation_nodes(tx, ref_timestamp)
+        synchronization_nodes =
+          tx
+          |> Mining.get_validation_nodes(ref_timestamp)
+          |> Enum.filter(&P2P.node_connected?/1)
+          |> Election.get_synchronization_nodes()
 
         responses =
           %{already_locked?: already_locked?} =
           do_send_transaction(
             tx,
-            validation_nodes,
+            synchronization_nodes,
             welcome_node_key,
             contract_context,
             ref_timestamp
@@ -90,7 +94,7 @@ defmodule Archethic do
 
         maybe_start_resync(responses)
 
-        if forward? and not enough_ack?(responses, length(validation_nodes)),
+        if forward? and not enough_ack?(responses, length(synchronization_nodes)),
           do: forward_transaction(tx, welcome_node_key, contract_context)
 
         if already_locked?, do: notify_welcome_node(welcome_node_key, address, :already_locked)
@@ -124,7 +128,7 @@ defmodule Archethic do
 
   defp do_send_transaction(
          tx = %Transaction{type: tx_type},
-         validation_nodes,
+         synchronization_nodes,
          welcome_node_key,
          contract_context,
          ref_timestamp
@@ -132,7 +136,7 @@ defmodule Archethic do
     message = %StartMining{
       transaction: tx,
       welcome_node_public_key: get_welcome_node_public_key(tx_type, welcome_node_key),
-      validation_node_public_keys: Enum.map(validation_nodes, & &1.last_public_key),
+      synchronization_node_public_keys: Enum.map(synchronization_nodes, & &1.first_public_key),
       network_chains_view_hash: NetworkView.get_chains_hash(),
       p2p_view_hash: NetworkView.get_p2p_hash(),
       contract_context: contract_context,
@@ -141,7 +145,7 @@ defmodule Archethic do
 
     Task.Supervisor.async_stream_nolink(
       Archethic.task_supervisors(),
-      validation_nodes,
+      synchronization_nodes,
       &P2P.send_message(&1, message),
       ordered: false,
       on_timeout: :kill_task,

--- a/lib/archethic.ex
+++ b/lib/archethic.ex
@@ -272,11 +272,8 @@ defmodule Archethic do
   # are more susceptible to failures.
   defp get_welcome_node_public_key(:node, key) do
     case P2P.get_node_info(key) do
-      {:error, _} ->
-        Crypto.last_node_public_key()
-
-      _ ->
-        key
+      {:error, _} -> Crypto.first_node_public_key()
+      _ -> key
     end
   end
 

--- a/lib/archethic/election.ex
+++ b/lib/archethic/election.ex
@@ -106,7 +106,7 @@ defmodule Archethic.Election do
       ...>     %Node{last_public_key: "node8", geo_patch: "F10"},
       ...>     %Node{last_public_key: "node9", geo_patch: "ECA"}
       ...>   ],
-      ...>   %ValidationConstraints{validation_number: fn _, 6 -> 3 end, min_geo_patch: fn -> 2 end}
+      ...>   %ValidationConstraints{validation_number: fn _ -> 3 end, min_geo_patch: fn -> 2 end}
       ...> )
       [
         %Node{last_public_key: "node1", geo_patch: "AAA"},
@@ -135,10 +135,7 @@ defmodule Archethic.Election do
     start = System.monotonic_time()
 
     # Evaluate validation constraints
-    # Ensure there is never more validation nodes than storage nodes
-    nb_validations =
-      min(length(storage_nodes), validation_number_fun.(tx, length(authorized_nodes)))
-
+    nb_validations = validation_number_fun.(authorized_nodes)
     min_geo_patch = min_geo_patch_fun.()
 
     nodes =

--- a/lib/archethic/election/constraints/validation.ex
+++ b/lib/archethic/election/constraints/validation.ex
@@ -4,41 +4,33 @@ defmodule Archethic.Election.ValidationConstraints do
   """
 
   @default_min_validation_geo_patch 3
-  @default_min_validations 3
 
   defstruct [
     :min_geo_patch,
-    :min_validation_nodes,
     :validation_number
   ]
 
+  alias Archethic.Election.HypergeometricDistribution
   alias Archethic.TransactionChain.Transaction
-  alias Archethic.TransactionChain.TransactionData
-  alias Archethic.TransactionChain.TransactionData.Ledger
-  alias Archethic.TransactionChain.TransactionData.UCOLedger
 
   @typedoc """
   Each validation constraints represent a function which will be executed during the election algorithms:
   - min_geo_patch: Require number of distinct geographic patch for the elected validation nodes.
   This property ensure the geographical security of the transaction validation by spliting
   the computation in many place on the world.
-  - min_validation_nodes: Require number of minimum validation nodes.
   - validation_number: Require number of validation nodes for a given transaction.
   """
   @type t :: %__MODULE__{
           min_geo_patch: (() -> non_neg_integer()),
-          min_validation_nodes: (non_neg_integer() -> non_neg_integer()),
           validation_number: (Transaction.t(), non_neg_integer() -> non_neg_integer())
         }
 
   def new(
         min_geo_patch_fun \\ &min_geo_patch/0,
-        min_validation_nodes_fun \\ &min_validation_nodes/1,
-        validation_number_fun \\ &validation_number/2
+        validation_number_fun \\ &hypergeometric_distribution/1
       ) do
     %__MODULE__{
       min_geo_patch: min_geo_patch_fun,
-      min_validation_nodes: min_validation_nodes_fun,
       validation_number: validation_number_fun
     }
   end
@@ -50,46 +42,12 @@ defmodule Archethic.Election.ValidationConstraints do
   def min_geo_patch, do: @default_min_validation_geo_patch
 
   @doc """
-  Define the minimum of validations
+  Run a simulation of the hypergeometric distribution based on a number of nodes
   """
-  @spec min_validation_nodes(non_neg_integer()) :: non_neg_integer()
-  def min_validation_nodes(nb_authorized_nodes)
-      when nb_authorized_nodes < @default_min_validations,
-      do: nb_authorized_nodes
-
-  def min_validation_nodes(_), do: @default_min_validations
-
-  @doc """
-  Get the number of validations for a given transaction.
-  """
-  @spec validation_number(Transaction.t(), nb_authorized_nodes :: non_neg_integer()) ::
-          non_neg_integer()
-  def validation_number(
-        %Transaction{
-          data: %TransactionData{ledger: %Ledger{uco: %UCOLedger{transfers: transfers}}}
-        },
-        nb_authorized_nodes
-      )
-      when is_integer(nb_authorized_nodes) do
-    total_transfers = Enum.reduce(transfers, 0.0, &(&2 + &1.amount))
-
-    if total_transfers > 0 do
-      validation_number =
-        @default_min_validations +
-          (:math.log10(total_transfers / 100_000_000) |> trunc())
-
-      cond do
-        validation_number > nb_authorized_nodes ->
-          nb_authorized_nodes
-
-        validation_number < @default_min_validations ->
-          min_validation_nodes(nb_authorized_nodes)
-
-        true ->
-          validation_number
-      end
-    else
-      min_validation_nodes(nb_authorized_nodes)
-    end
+  @spec hypergeometric_distribution(nodes :: list(Node.t())) :: pos_integer()
+  def hypergeometric_distribution(nodes) when is_list(nodes) and length(nodes) >= 0 do
+    nodes
+    |> length()
+    |> HypergeometricDistribution.run_simulation()
   end
 end

--- a/lib/archethic/mining.ex
+++ b/lib/archethic/mining.ex
@@ -74,7 +74,7 @@ defmodule Archethic.Mining do
       transaction: tx,
       welcome_node: P2P.get_node_info!(welcome_node_public_key),
       validation_nodes: Enum.map(validation_node_public_keys, &P2P.get_node_info!/1),
-      node_public_key: Crypto.last_node_public_key(),
+      node_public_key: Crypto.first_node_public_key(),
       contract_context: contract_context,
       ref_timestamp: ref_timestamp
     })

--- a/lib/archethic/mining/distributed_workflow.ex
+++ b/lib/archethic/mining/distributed_workflow.ex
@@ -256,7 +256,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
         |> Election.io_storage_nodes(authorized_nodes)
       end
 
-    [coordinator_node = %Node{last_public_key: coordinator_key} | cross_validation_nodes] =
+    [coordinator_node = %Node{first_public_key: coordinator_key} | cross_validation_nodes] =
       validation_nodes
 
     context =
@@ -873,7 +873,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
     validation_nodes =
       [coordinator_node | cross_validation_nodes]
       |> P2P.distinct_nodes()
-      |> Enum.reject(&(&1.last_public_key == node_public_key))
+      |> Enum.reject(&(&1.first_public_key == node_public_key))
 
     P2P.broadcast_message(validation_nodes, %ReplicationError{
       address: tx.address,
@@ -940,7 +940,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
           |> Map.put(:cross_validation_nodes, next_cross_validation_nodes)
           |> Map.put(:cross_validation_nodes_confirmation, <<0::size(nb_cross_validation_nodes)>>)
 
-        if next_coordinator.last_public_key == node_public_key do
+        if next_coordinator.first_public_key == node_public_key do
           {:next_state, :coordinator, %{data | context: new_context}}
         else
           actions = [
@@ -1067,7 +1067,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
       address: tx_address,
       utxos_hashes: Enum.map(unspent_outputs, &VersionedUnspentOutput.hash/1),
       validation_node_public_key: node_public_key,
-      previous_storage_nodes_public_keys: Enum.map(previous_storage_nodes, & &1.last_public_key),
+      previous_storage_nodes_public_keys: Enum.map(previous_storage_nodes, & &1.first_public_key),
       chain_storage_nodes_view: chain_storage_nodes_view,
       beacon_storage_nodes_view: beacon_storage_nodes_view,
       io_storage_nodes_view: io_storage_nodes_view
@@ -1115,7 +1115,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
     nodes =
       [coordinator_node | cross_validation_nodes]
       |> P2P.distinct_nodes()
-      |> Enum.reject(&(&1.last_public_key == Crypto.last_node_public_key()))
+      |> Enum.reject(&(&1.first_public_key == Crypto.first_node_public_key()))
 
     Logger.info(
       "Send cross validation stamps to #{Enum.map_join(nodes, ", ", &Node.endpoint/1)}",
@@ -1173,7 +1173,7 @@ defmodule Archethic.Mining.DistributedWorkflow do
       validation_nodes =
         [coordinator_node | cross_validation_nodes]
         |> P2P.distinct_nodes()
-        |> Enum.reject(&(&1.last_public_key == node_public_key))
+        |> Enum.reject(&(&1.first_public_key == node_public_key))
 
       Logger.info(
         "Send replication validation message to validation nodes: #{Enum.map_join(validation_nodes, ",", &Node.endpoint/1)}",

--- a/lib/archethic/mining/standalone_workflow.ex
+++ b/lib/archethic/mining/standalone_workflow.ex
@@ -160,7 +160,7 @@ defmodule Archethic.Mining.StandaloneWorkflow do
 
   defp validate(context = %ValidationContext{}) do
     context
-    |> ValidationContext.confirm_validation_node(Crypto.last_node_public_key())
+    |> ValidationContext.confirm_validation_node(Crypto.first_node_public_key())
     |> ValidationContext.create_validation_stamp()
     |> ValidationContext.create_replication_tree()
     |> ValidationContext.cross_validate()
@@ -247,10 +247,7 @@ defmodule Archethic.Mining.StandaloneWorkflow do
     message = %ValidationError{address: tx_address, error: error}
 
     Task.Supervisor.async_nolink(Archethic.task_supervisors(), fn ->
-      P2P.send_message(
-        Crypto.last_node_public_key(),
-        message
-      )
+      P2P.send_message(Crypto.first_node_public_key(), message)
     end)
 
     # Notify storage nodes to unlock chain

--- a/lib/archethic/mining/validation_context.ex
+++ b/lib/archethic/mining/validation_context.ex
@@ -122,20 +122,20 @@ defmodule Archethic.Mining.ValidationContext do
 
     iex> ValidationContext.new(
     ...>   transaction: %Transaction{},
-    ...>   welcome_node: %Node{last_public_key: "key1"},
-    ...>   coordinator_node: %Node{last_public_key: "key2"},
-    ...>   cross_validation_nodes: [%Node{last_public_key: "key3"}],
-    ...>   chain_storage_nodes: [%Node{last_public_key: "key4"}, %Node{last_public_key: "key5"}],
-    ...>   beacon_storage_nodes: [%Node{last_public_key: "key6"}, %Node{last_public_key: "key7"}]
+    ...>   welcome_node: %Node{first_public_key: "key1"},
+    ...>   coordinator_node: %Node{first_public_key: "key2"},
+    ...>   cross_validation_nodes: [%Node{first_public_key: "key3"}],
+    ...>   chain_storage_nodes: [%Node{first_public_key: "key4"}, %Node{first_public_key: "key5"}],
+    ...>   beacon_storage_nodes: [%Node{first_public_key: "key6"}, %Node{first_public_key: "key7"}]
     ...> )
     %ValidationContext{
       transaction: %Transaction{},
-      welcome_node: %Node{last_public_key: "key1"},
-      coordinator_node: %Node{last_public_key: "key2"},
-      cross_validation_nodes: [%Node{last_public_key: "key3"}],
+      welcome_node: %Node{first_public_key: "key1"},
+      coordinator_node: %Node{first_public_key: "key2"},
+      cross_validation_nodes: [%Node{first_public_key: "key3"}],
       cross_validation_nodes_confirmation: <<0::1>>,
-      chain_storage_nodes: [%Node{last_public_key: "key4"}, %Node{last_public_key: "key5"}],
-      beacon_storage_nodes: [%Node{last_public_key: "key6"}, %Node{last_public_key: "key7"}]
+      chain_storage_nodes: [%Node{first_public_key: "key4"}, %Node{first_public_key: "key5"}],
+      beacon_storage_nodes: [%Node{first_public_key: "key6"}, %Node{first_public_key: "key7"}]
     }
   """
   @spec new(opts :: Keyword.t()) :: t()
@@ -194,16 +194,16 @@ defmodule Archethic.Mining.ValidationContext do
 
     iex> %ValidationContext{
     ...>   cross_validation_nodes: [
-    ...>     %Node{last_public_key: "key2"},
-    ...>     %Node{last_public_key: "key3"}
+    ...>     %Node{first_public_key: "key2"},
+    ...>     %Node{first_public_key: "key3"}
     ...>   ],
     ...>   cross_validation_nodes_confirmation: <<0::1, 0::1>>
     ...> }
     ...> |> ValidationContext.confirm_validation_node("key3")
     %ValidationContext{
       cross_validation_nodes: [
-        %Node{last_public_key: "key2"},
-        %Node{last_public_key: "key3"}
+        %Node{first_public_key: "key2"},
+        %Node{first_public_key: "key3"}
       ],
       cross_validation_nodes_confirmation: <<0::1, 1::1>>
     }
@@ -212,7 +212,7 @@ defmodule Archethic.Mining.ValidationContext do
         context = %__MODULE__{cross_validation_nodes: cross_validation_nodes},
         node_public_key
       ) do
-    index = Enum.find_index(cross_validation_nodes, &(&1.last_public_key == node_public_key))
+    index = Enum.find_index(cross_validation_nodes, &(&1.first_public_key == node_public_key))
 
     Map.update!(
       context,
@@ -228,17 +228,17 @@ defmodule Archethic.Mining.ValidationContext do
 
     iex> %ValidationContext{
     ...>   cross_validation_nodes: [
-    ...>     %Node{last_public_key: "key1"},
-    ...>     %Node{last_public_key: "key2"},
-    ...>     %Node{last_public_key: "key3"},
-    ...>     %Node{last_public_key: "key4"}
+    ...>     %Node{first_public_key: "key1"},
+    ...>     %Node{first_public_key: "key2"},
+    ...>     %Node{first_public_key: "key3"},
+    ...>     %Node{first_public_key: "key4"}
     ...>   ],
     ...>   cross_validation_nodes_confirmation: <<0::1, 1::1, 0::1, 1::1>>
     ...> }
     ...> |> ValidationContext.get_confirmed_validation_nodes()
     [
-      %Node{last_public_key: "key2"},
-      %Node{last_public_key: "key4"}
+      %Node{first_public_key: "key2"},
+      %Node{first_public_key: "key4"}
     ]
   """
   @spec get_confirmed_validation_nodes(t()) :: list(Node.t())
@@ -408,22 +408,22 @@ defmodule Archethic.Mining.ValidationContext do
   ## Examples
 
     iex> %ValidationContext{
-    ...>   coordinator_node: %Node{last_public_key: "key1"},
+    ...>   coordinator_node: %Node{first_public_key: "key1"},
     ...>   cross_validation_nodes: [
-    ...>     %Node{last_public_key: "key2"},
-    ...>     %Node{last_public_key: "key3"},
-    ...>     %Node{last_public_key: "key4"}
+    ...>     %Node{first_public_key: "key2"},
+    ...>     %Node{first_public_key: "key3"},
+    ...>     %Node{first_public_key: "key4"}
     ...>   ]
     ...> }
     ...> |> ValidationContext.cross_validation_node?("key3")
     true
 
     iex> %ValidationContext{
-    ...>   coordinator_node: %Node{last_public_key: "key1"},
+    ...>   coordinator_node: %Node{first_public_key: "key1"},
     ...>   cross_validation_nodes: [
-    ...>     %Node{last_public_key: "key2"},
-    ...>     %Node{last_public_key: "key3"},
-    ...>     %Node{last_public_key: "key4"}
+    ...>     %Node{first_public_key: "key2"},
+    ...>     %Node{first_public_key: "key3"},
+    ...>     %Node{first_public_key: "key4"}
     ...>   ]
     ...> }
     ...> |> ValidationContext.cross_validation_node?("key1")
@@ -435,7 +435,7 @@ defmodule Archethic.Mining.ValidationContext do
         node_public_key
       )
       when is_binary(node_public_key) do
-    Enum.any?(cross_validation_nodes, &(&1.last_public_key == node_public_key))
+    Enum.any?(cross_validation_nodes, &(&1.first_public_key == node_public_key))
   end
 
   @doc """
@@ -456,8 +456,8 @@ defmodule Archethic.Mining.ValidationContext do
     ...>   }
     ...> } =
     ...>   %ValidationContext{
-    ...>     coordinator_node: %Node{last_public_key: "key1"},
-    ...>     cross_validation_nodes: [%Node{last_public_key: "key2"}],
+    ...>     coordinator_node: %Node{first_public_key: "key1"},
+    ...>     cross_validation_nodes: [%Node{first_public_key: "key2"}],
     ...>     cross_validation_nodes_confirmation: <<1::1>>
     ...>   }
     ...>   |> ValidationContext.add_replication_tree(
@@ -490,7 +490,7 @@ defmodule Archethic.Mining.ValidationContext do
     confirmed_cross_validation_nodes = get_confirmed_validation_nodes(context)
 
     validation_nodes = [coordinator_node | confirmed_cross_validation_nodes]
-    validator_index = Enum.find_index(validation_nodes, &(&1.last_public_key == node_public_key))
+    validator_index = Enum.find_index(validation_nodes, &(&1.first_public_key == node_public_key))
 
     sub_chain_tree = Enum.at(chain_tree, validator_index)
 
@@ -897,11 +897,10 @@ defmodule Archethic.Mining.ValidationContext do
       iex> %ValidationContext{
       ...>   coordinator_node: %Node{
       ...>     first_public_key: "key1",
-      ...>     network_patch: "AAA",
-      ...>     last_public_key: "key1"
+      ...>     network_patch: "AAA"
       ...>   },
       ...>   cross_validation_nodes: [
-      ...>     %Node{first_public_key: "key2", network_patch: "FAC", last_public_key: "key2"}
+      ...>     %Node{first_public_key: "key2", network_patch: "FAC"}
       ...>   ],
       ...>   chain_storage_nodes: [
       ...>     %Node{first_public_key: "key3", network_patch: "BBB", available?: true},
@@ -925,11 +924,10 @@ defmodule Archethic.Mining.ValidationContext do
         },
         coordinator_node: %Node{
           first_public_key: "key1",
-          network_patch: "AAA",
-          last_public_key: "key1"
+          network_patch: "AAA"
         },
         cross_validation_nodes: [
-          %Node{first_public_key: "key2", network_patch: "FAC", last_public_key: "key2"}
+          %Node{first_public_key: "key2", network_patch: "FAC"}
         ],
         chain_storage_nodes: [
           %Node{first_public_key: "key3", network_patch: "BBB", available?: true},
@@ -943,11 +941,10 @@ defmodule Archethic.Mining.ValidationContext do
       iex> %ValidationContext{
       ...>   coordinator_node: %Node{
       ...>     first_public_key: "key1",
-      ...>     network_patch: "AAA",
-      ...>     last_public_key: "key1"
+      ...>     network_patch: "AAA"
       ...>   },
       ...>   cross_validation_nodes: [
-      ...>     %Node{first_public_key: "key2", network_patch: "FAC", last_public_key: "key2"}
+      ...>     %Node{first_public_key: "key2", network_patch: "FAC"}
       ...>   ],
       ...>   chain_storage_nodes: [
       ...>     %Node{first_public_key: "key3", network_patch: "BBB", available?: true},
@@ -972,11 +969,10 @@ defmodule Archethic.Mining.ValidationContext do
         },
         coordinator_node: %Node{
           first_public_key: "key1",
-          network_patch: "AAA",
-          last_public_key: "key1"
+          network_patch: "AAA"
         },
         cross_validation_nodes: [
-          %Node{first_public_key: "key2", network_patch: "FAC", last_public_key: "key2"}
+          %Node{first_public_key: "key2", network_patch: "FAC"}
         ],
         chain_storage_nodes: [
           %Node{first_public_key: "key3", network_patch: "BBB", available?: true},

--- a/lib/archethic/replication.ex
+++ b/lib/archethic/replication.ex
@@ -496,59 +496,59 @@ defmodule Archethic.Replication do
   ## Examples
 
       iex> validation_nodes = [
-      ...>   %Node{network_patch: "AC2", last_public_key: "key_v1"},
-      ...>   %Node{network_patch: "DF3", last_public_key: "key_v2"},
-      ...>   %Node{network_patch: "C22", last_public_key: "key_v3"},
-      ...>   %Node{network_patch: "E19", last_public_key: "key_v4"},
-      ...>   %Node{network_patch: "22A", last_public_key: "key_v5"}
+      ...>   %Node{network_patch: "AC2", first_public_key: "key_v1"},
+      ...>   %Node{network_patch: "DF3", first_public_key: "key_v2"},
+      ...>   %Node{network_patch: "C22", first_public_key: "key_v3"},
+      ...>   %Node{network_patch: "E19", first_public_key: "key_v4"},
+      ...>   %Node{network_patch: "22A", first_public_key: "key_v5"}
       ...> ]
       ...> 
       ...> storage_nodes = [
-      ...>   %Node{network_patch: "F36", first_public_key: "key_S1", last_public_key: "key_S1"},
-      ...>   %Node{network_patch: "A23", first_public_key: "key_S2", last_public_key: "key_S2"},
-      ...>   %Node{network_patch: "B43", first_public_key: "key_S3", last_public_key: "key_S3"},
-      ...>   %Node{network_patch: "2A9", first_public_key: "key_S4", last_public_key: "key_S4"},
-      ...>   %Node{network_patch: "143", first_public_key: "key_S5", last_public_key: "key_S5"},
-      ...>   %Node{network_patch: "BB2", first_public_key: "key_S6", last_public_key: "key_S6"},
-      ...>   %Node{network_patch: "A63", first_public_key: "key_S7", last_public_key: "key_S7"},
-      ...>   %Node{network_patch: "D32", first_public_key: "key_S8", last_public_key: "key_S8"},
-      ...>   %Node{network_patch: "19A", first_public_key: "key_S9", last_public_key: "key_S9"},
-      ...>   %Node{network_patch: "C2A", first_public_key: "key_S10", last_public_key: "key_S10"},
-      ...>   %Node{network_patch: "C23", first_public_key: "key_S11", last_public_key: "key_S11"},
-      ...>   %Node{network_patch: "F22", first_public_key: "key_S12", last_public_key: "key_S12"},
-      ...>   %Node{network_patch: "E2B", first_public_key: "key_S13", last_public_key: "key_S13"},
-      ...>   %Node{network_patch: "AA0", first_public_key: "key_S14", last_public_key: "key_S14"},
-      ...>   %Node{network_patch: "042", first_public_key: "key_S15", last_public_key: "key_S15"},
-      ...>   %Node{network_patch: "3BC", first_public_key: "key_S16", last_public_key: "key_S16"}
+      ...>   %Node{network_patch: "F36", first_public_key: "key_S1"},
+      ...>   %Node{network_patch: "A23", first_public_key: "key_S2"},
+      ...>   %Node{network_patch: "B43", first_public_key: "key_S3"},
+      ...>   %Node{network_patch: "2A9", first_public_key: "key_S4"},
+      ...>   %Node{network_patch: "143", first_public_key: "key_S5"},
+      ...>   %Node{network_patch: "BB2", first_public_key: "key_S6"},
+      ...>   %Node{network_patch: "A63", first_public_key: "key_S7"},
+      ...>   %Node{network_patch: "D32", first_public_key: "key_S8"},
+      ...>   %Node{network_patch: "19A", first_public_key: "key_S9"},
+      ...>   %Node{network_patch: "C2A", first_public_key: "key_S10"},
+      ...>   %Node{network_patch: "C23", first_public_key: "key_S11"},
+      ...>   %Node{network_patch: "F22", first_public_key: "key_S12"},
+      ...>   %Node{network_patch: "E2B", first_public_key: "key_S13"},
+      ...>   %Node{network_patch: "AA0", first_public_key: "key_S14"},
+      ...>   %Node{network_patch: "042", first_public_key: "key_S15"},
+      ...>   %Node{network_patch: "3BC", first_public_key: "key_S16"}
       ...> ]
       ...> 
       ...> Replication.generate_tree(validation_nodes, storage_nodes)
       %{
         "key_v1" => [
-          %Node{first_public_key: "key_S14", last_public_key: "key_S14", network_patch: "AA0"},
-          %Node{first_public_key: "key_S7", last_public_key: "key_S7", network_patch: "A63"},
-          %Node{first_public_key: "key_S2", last_public_key: "key_S2", network_patch: "A23"}
+          %Node{first_public_key: "key_S14", network_patch: "AA0"},
+          %Node{first_public_key: "key_S7", network_patch: "A63"},
+          %Node{first_public_key: "key_S2", network_patch: "A23"}
         ],
         "key_v2" => [
-          %Node{first_public_key: "key_S13", last_public_key: "key_S13", network_patch: "E2B"},
-          %Node{first_public_key: "key_S8", last_public_key: "key_S8", network_patch: "D32"},
-          %Node{first_public_key: "key_S5", last_public_key: "key_S5", network_patch: "143"}
+          %Node{first_public_key: "key_S13", network_patch: "E2B"},
+          %Node{first_public_key: "key_S8", network_patch: "D32"},
+          %Node{first_public_key: "key_S5", network_patch: "143"}
         ],
         "key_v3" => [
-          %Node{first_public_key: "key_S11", last_public_key: "key_S11", network_patch: "C23"},
-          %Node{first_public_key: "key_S6", last_public_key: "key_S6", network_patch: "BB2"},
-          %Node{first_public_key: "key_S3", last_public_key: "key_S3", network_patch: "B43"}
+          %Node{first_public_key: "key_S11", network_patch: "C23"},
+          %Node{first_public_key: "key_S6", network_patch: "BB2"},
+          %Node{first_public_key: "key_S3", network_patch: "B43"}
         ],
         "key_v4" => [
-          %Node{first_public_key: "key_S12", last_public_key: "key_S12", network_patch: "F22"},
-          %Node{first_public_key: "key_S10", last_public_key: "key_S10", network_patch: "C2A"},
-          %Node{first_public_key: "key_S1", last_public_key: "key_S1", network_patch: "F36"}
+          %Node{first_public_key: "key_S12", network_patch: "F22"},
+          %Node{first_public_key: "key_S10", network_patch: "C2A"},
+          %Node{first_public_key: "key_S1", network_patch: "F36"}
         ],
         "key_v5" => [
-          %Node{first_public_key: "key_S16", last_public_key: "key_S16", network_patch: "3BC"},
-          %Node{first_public_key: "key_S15", last_public_key: "key_S15", network_patch: "042"},
-          %Node{first_public_key: "key_S9", last_public_key: "key_S9", network_patch: "19A"},
-          %Node{first_public_key: "key_S4", last_public_key: "key_S4", network_patch: "2A9"}
+          %Node{first_public_key: "key_S16", network_patch: "3BC"},
+          %Node{first_public_key: "key_S15", network_patch: "042"},
+          %Node{first_public_key: "key_S9", network_patch: "19A"},
+          %Node{first_public_key: "key_S4", network_patch: "2A9"}
         ]
       }
   """
@@ -557,7 +557,7 @@ defmodule Archethic.Replication do
   def generate_tree(validation_nodes, storage_nodes) do
     storage_nodes
     |> Enum.reduce(%{}, fn storage_node, tree_acc ->
-      %Node{last_public_key: validation_node_key} =
+      %Node{first_public_key: validation_node_key} =
         find_closest_validation_node(tree_acc, storage_node, validation_nodes)
 
       Map.update(tree_acc, validation_node_key, [storage_node], &[storage_node | &1])
@@ -568,7 +568,7 @@ defmodule Archethic.Replication do
     {closest_validation_node, _} =
       validation_nodes
       # Get the number of replicas by nodes
-      |> Enum.reduce(%{}, &Map.put(&2, &1, tree_sub_size(tree, &1.last_public_key)))
+      |> Enum.reduce(%{}, &Map.put(&2, &1, tree_sub_size(tree, &1.first_public_key)))
       # Sort each validation nodes by its network patch from the storage node network patch
       |> Enum.sort_by(fn {validation_node, _} ->
         sort_closest_node(validation_node, storage_node)

--- a/test/archethic/election_test.exs
+++ b/test/archethic/election_test.exs
@@ -10,9 +10,6 @@ defmodule Archethic.ElectionTest do
 
   alias Archethic.TransactionChain.Transaction
   alias Archethic.TransactionChain.TransactionData
-  alias Archethic.TransactionChain.TransactionData.Ledger
-  alias Archethic.TransactionChain.TransactionData.UCOLedger
-  alias Archethic.TransactionChain.TransactionData.UCOLedger.Transfer
 
   doctest Election
 
@@ -193,7 +190,7 @@ defmodule Archethic.ElectionTest do
     } do
       tx = tx1
 
-      # simulate two diffrenet transaction mining timestamps
+      # simulate two different transaction mining timestamps
       ref_timestamp_first_attempt = ~U[2024-11-04 13:41:18.280699Z]
 
       ref_timestamp_second_attempt = ~U[2024-11-04 13:41:50.280699Z]
@@ -249,95 +246,6 @@ defmodule Archethic.ElectionTest do
 
       assert Enum.map(first_election, & &1.last_public_key) ==
                Enum.map(second_election, & &1.last_public_key)
-    end
-
-    test "should never return more validation nodes than storages nodes" do
-      authorized_nodes = [
-        %Node{
-          first_public_key: "Node0",
-          last_public_key: "Node0",
-          available?: true,
-          geo_patch: "AAA"
-        },
-        %Node{
-          first_public_key: "Node1",
-          last_public_key: "Node1",
-          available?: true,
-          geo_patch: "BBB"
-        },
-        %Node{
-          first_public_key: "Node2",
-          last_public_key: "Node2",
-          available?: true,
-          geo_patch: "CCC"
-        },
-        %Node{
-          first_public_key: "Node3",
-          last_public_key: "Node3",
-          available?: true,
-          geo_patch: "DDD"
-        }
-      ]
-
-      storage_nodes = [
-        %Node{
-          first_public_key: "Node10",
-          last_public_key: "Node10",
-          available?: true,
-          geo_patch: random_patch()
-        },
-        %Node{
-          first_public_key: "Node11",
-          last_public_key: "Node11",
-          available?: true,
-          geo_patch: random_patch()
-        },
-        %Node{
-          first_public_key: "Node12",
-          last_public_key: "Node12",
-          available?: true,
-          geo_patch: random_patch()
-        }
-      ]
-
-      tx1 = %Transaction{
-        address:
-          <<0, 120, 195, 32, 77, 84, 215, 196, 116, 215, 56, 141, 40, 54, 226, 48, 66, 254, 119,
-            11, 73, 77, 243, 125, 62, 94, 133, 67, 9, 253, 45, 134, 89>>,
-        type: :transfer,
-        data: %TransactionData{
-          ledger: %Ledger{
-            # 1_000_000_000 will require 1 more validator than the min (1 + 3 = 4)
-            uco: %UCOLedger{transfers: [%Transfer{to: <<>>, amount: 1_000_000_000}]}
-          }
-        },
-        previous_public_key:
-          <<0, 239, 240, 90, 182, 66, 190, 68, 20, 250, 131, 83, 190, 29, 184, 177, 52, 166, 207,
-            80, 193, 110, 57, 6, 199, 152, 184, 24, 178, 179, 11, 164, 150>>,
-        previous_signature:
-          <<200, 70, 0, 25, 105, 111, 15, 161, 146, 188, 100, 234, 147, 62, 127, 8, 152, 60, 66,
-            169, 113, 255, 51, 112, 59, 200, 61, 63, 128, 228, 111, 104, 47, 15, 81, 185, 179, 36,
-            59, 86, 171, 7, 138, 199, 203, 252, 50, 87, 160, 107, 119, 131, 121, 11, 239, 169, 99,
-            203, 76, 159, 158, 243, 133, 133>>,
-        origin_signature:
-          <<162, 223, 100, 72, 17, 56, 99, 212, 78, 132, 166, 81, 127, 91, 214, 143, 221, 32, 106,
-            189, 247, 64, 183, 27, 55, 142, 254, 72, 47, 215, 34, 108, 233, 55, 35, 94, 49, 165,
-            180, 248, 229, 160, 229, 220, 191, 35, 80, 127, 213, 240, 195, 185, 165, 89, 172, 97,
-            170, 217, 57, 254, 125, 127, 62, 169>>
-      }
-
-      ref_timestamp = ~U[2024-11-04 13:41:18.280699Z]
-
-      assert 3 ==
-               length(
-                 Election.validation_nodes(
-                   tx1,
-                   Election.validation_nodes_election_seed_sorting(tx1, ref_timestamp),
-                   authorized_nodes,
-                   storage_nodes,
-                   ValidationConstraints.new()
-                 )
-               )
     end
   end
 

--- a/test/archethic/election_test.exs
+++ b/test/archethic/election_test.exs
@@ -118,6 +118,53 @@ defmodule Archethic.ElectionTest do
     }
   end
 
+  describe "get_synchronization_nodes/1" do
+    test "should return all nodes when nodes count is less than or equal to synchronization nodes limit" do
+      nodes = [
+        %Node{first_public_key: "node1", geo_patch: "AAA"},
+        %Node{first_public_key: "node2", geo_patch: "BBB"},
+        %Node{first_public_key: "node3", geo_patch: "CCC"}
+      ]
+
+      assert nodes == Election.get_synchronization_nodes(nodes)
+    end
+
+    test "should prioritize nodes from different geo patches with highest number of nodes" do
+      nodes = [
+        %Node{first_public_key: "node1", geo_patch: "AAA"},
+        %Node{first_public_key: "node2", geo_patch: "AAA"},
+        %Node{first_public_key: "node3", geo_patch: "BBB"},
+        %Node{first_public_key: "node4", geo_patch: "CCC"},
+        %Node{first_public_key: "node5", geo_patch: "DDD"},
+        %Node{first_public_key: "node6", geo_patch: "DDD"},
+        %Node{first_public_key: "node7", geo_patch: "DDD"},
+        %Node{first_public_key: "node8", geo_patch: "EEE"},
+        %Node{first_public_key: "node9", geo_patch: "FFF"},
+        %Node{first_public_key: "node10", geo_patch: "FFF"}
+      ]
+
+      synchronization_nodes =
+        Election.get_synchronization_nodes(nodes) |> Enum.map(& &1.first_public_key)
+
+      assert ["node5", "node1", "node9", "node3"] == synchronization_nodes
+    end
+
+    test "should handle cases with fewer unique geo patches than synchronization nodes" do
+      nodes = [
+        %Node{first_public_key: "node1", geo_patch: "AAA"},
+        %Node{first_public_key: "node2", geo_patch: "AAA"},
+        %Node{first_public_key: "node3", geo_patch: "BBB"},
+        %Node{first_public_key: "node4", geo_patch: "BBB"},
+        %Node{first_public_key: "node5", geo_patch: "CCC"}
+      ]
+
+      synchronization_nodes =
+        Election.get_synchronization_nodes(nodes) |> Enum.map(& &1.first_public_key)
+
+      assert ["node1", "node2", "node3", "node5"] == synchronization_nodes
+    end
+  end
+
   describe "validation_nodes_election_seed_sorting/2" do
     test "should change for different transactions", %{
       tx1: tx1,

--- a/test/archethic/mining/distributed_workflow_test.exs
+++ b/test/archethic/mining/distributed_workflow_test.exs
@@ -313,7 +313,7 @@ defmodule Archethic.Mining.DistributedWorkflowTest do
       assert chain_storage_nodes_view == <<1::1, 1::1, 1::1, 1::1>>
       assert beacon_storage_nodes_view == <<1::1, 1::1, 1::1, 1::1>>
       assert io_storage_nodes_view == <<1::1, 1::1, 1::1, 1::1>>
-      assert <<0::1, 1::1>> == confirmed_validation_nodes
+      assert <<0::1, 0::1, 1::1>> == confirmed_validation_nodes
     end
 
     test "aggregate context and create validation stamp when enough context are retrieved", %{

--- a/test/archethic/mining/validation_context_test.exs
+++ b/test/archethic/mining/validation_context_test.exs
@@ -95,8 +95,8 @@ defmodule Archethic.Mining.ValidationContextTest do
                io_storage_nodes_view: <<1::1, 0::1, 0::1>>,
                cross_validation_nodes_confirmation: <<0::1, 1::1>>,
                cross_validation_nodes: [
-                 %Node{last_public_key: "key3"},
-                 %Node{last_public_key: "key5"}
+                 %Node{first_public_key: "key3"},
+                 %Node{first_public_key: "key5"}
                ],
                unspent_outputs: ^utxos_coordinator
              } =
@@ -106,8 +106,8 @@ defmodule Archethic.Mining.ValidationContextTest do
                  beacon_storage_nodes_view: <<1::1, 0::1, 1::1>>,
                  io_storage_nodes_view: <<1::1, 0::1, 0::1>>,
                  cross_validation_nodes: [
-                   %Node{last_public_key: "key3"},
-                   %Node{last_public_key: "key5"}
+                   %Node{first_public_key: "key3"},
+                   %Node{first_public_key: "key5"}
                  ],
                  cross_validation_nodes_confirmation: <<0::1, 0::1>>,
                  unspent_outputs: utxos_coordinator
@@ -543,7 +543,7 @@ defmodule Archethic.Mining.ValidationContextTest do
     }
 
     coordinator_node = %Node{
-      first_public_key: Crypto.last_node_public_key(),
+      first_public_key: Crypto.first_node_public_key(),
       last_public_key: Crypto.last_node_public_key(),
       geo_patch: "AAA",
       ip: {127, 0, 0, 1},

--- a/test/archethic/p2p/messages_test.exs
+++ b/test/archethic/p2p/messages_test.exs
@@ -173,7 +173,7 @@ defmodule Archethic.P2P.MessageTest do
       tx = Transaction.new(:transfer, %TransactionData{}, "seed", 0)
       {welcome_node_public_key, _} = Crypto.generate_deterministic_keypair("wkey")
 
-      validation_node_public_keys =
+      synchronization_node_public_keys =
         Enum.map(1..10, fn i ->
           {pub, _} = Crypto.generate_deterministic_keypair("vkey" <> Integer.to_string(i))
           pub
@@ -187,7 +187,7 @@ defmodule Archethic.P2P.MessageTest do
       assert %StartMining{
                transaction: tx,
                welcome_node_public_key: welcome_node_public_key,
-               validation_node_public_keys: validation_node_public_keys,
+               synchronization_node_public_keys: synchronization_node_public_keys,
                network_chains_view_hash: network_hash,
                p2p_view_hash: p2p_hash,
                ref_timestamp: ref_timestamp
@@ -195,7 +195,7 @@ defmodule Archethic.P2P.MessageTest do
                %StartMining{
                  transaction: tx,
                  welcome_node_public_key: welcome_node_public_key,
-                 validation_node_public_keys: validation_node_public_keys,
+                 synchronization_node_public_keys: synchronization_node_public_keys,
                  network_chains_view_hash: network_hash,
                  p2p_view_hash: p2p_hash,
                  ref_timestamp: ref_timestamp
@@ -214,7 +214,7 @@ defmodule Archethic.P2P.MessageTest do
       assert %StartMining{
                transaction: tx,
                welcome_node_public_key: welcome_node_public_key,
-               validation_node_public_keys: validation_node_public_keys,
+               synchronization_node_public_keys: synchronization_node_public_keys,
                network_chains_view_hash: network_hash,
                p2p_view_hash: p2p_hash,
                contract_context: ctx,
@@ -223,7 +223,7 @@ defmodule Archethic.P2P.MessageTest do
                %StartMining{
                  transaction: tx,
                  welcome_node_public_key: welcome_node_public_key,
-                 validation_node_public_keys: validation_node_public_keys,
+                 synchronization_node_public_keys: synchronization_node_public_keys,
                  network_chains_view_hash: network_hash,
                  p2p_view_hash: p2p_hash,
                  contract_context: ctx,


### PR DESCRIPTION
# Description

- Update validation node election algorithm so the number of validation nodes is the number returned by the hypergeometric distribution.
- During election, authorized nodes are now sorted by their first public key instead of the last.
- Created a new `synchronization_nodes` function to select some nodes of the validation nodes to be the synchronization nodes. It selects nodes from different geo patch priorize geo patch with the most number of validation nodes.
- For now until BLS proofs are implemented, distributed workflow take the synchronization nodes as the entire validation node to not change the validation process
- Update the validation context and distributed workflow to use the first node public key to identify nodes instead of the last


Fixes #1607 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
