### PR TITLE
Fix timeout when writing slot in summary cache

### DIFF
--- a/lib/archethic/beacon_chain/subset/summary_cache.ex
+++ b/lib/archethic/beacon_chain/subset/summary_cache.ex
@@ -66,7 +66,7 @@ defmodule Archethic.BeaconChain.Subset.SummaryCache do
   @spec add_slot(Slot.t(), Crypto.key()) :: :ok
   def add_slot(slot = %Slot{subset: subset}, node_public_key) do
     via_tuple = {:via, PartitionSupervisor, {SummaryCacheSupervisor, subset}}
-    GenServer.call(via_tuple, {:add_slot, slot, node_public_key})
+    GenServer.call(via_tuple, {:add_slot, slot, node_public_key}, :infinity)
   end
 
   def handle_call({:add_slot, slot, node_public_key}, _from, state) do


### PR DESCRIPTION
# Description

Add infinity timeout on the Genserver.call when adding slot into summary cache

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
