### PR TITLE
Tx replication sometimes fails. #1650

### DIFF
--- a/lib/archethic/db.ex
+++ b/lib/archethic/db.ex
@@ -33,7 +33,8 @@ defmodule Archethic.DB do
                 order: :asc | :desc
               ]
             ) :: Enumerable.t()
-  @callback write_transaction(Transaction.t(), storage_type()) :: :ok
+  @callback write_transaction(Transaction.t(), storage_type()) ::
+              :ok | {:error, :transaction_already_exists}
   @callback write_beacon_summary(Summary.t()) :: :ok
   @callback clear_beacon_summaries() :: :ok
   @callback write_beacon_summaries_aggregate(SummaryAggregate.t()) :: :ok

--- a/lib/archethic/transaction_chain.ex
+++ b/lib/archethic/transaction_chain.ex
@@ -1055,7 +1055,7 @@ defmodule Archethic.TransactionChain do
   Persist only one transaction
   """
   @spec write_transaction(transaction :: Transaction.t(), storage_location :: DB.storage_type()) ::
-          :ok
+          :ok | {:error, :transaction_already_exist}
   def write_transaction(
         tx = %Transaction{
           address: address,
@@ -1064,12 +1064,14 @@ defmodule Archethic.TransactionChain do
         storage_type \\ :chain
       ) do
     DB.write_transaction(tx, storage_type)
-    KOLedger.remove_transaction(address)
+    |> tap(fn _ ->
+      KOLedger.remove_transaction(address)
 
-    Logger.info("Transaction stored",
-      transaction_address: Base.encode16(address),
-      transaction_type: type
-    )
+      Logger.info("Transaction stored",
+        transaction_address: Base.encode16(address),
+        transaction_type: type
+      )
+    end)
   end
 
   @doc """

--- a/test/archethic/db/embedded_impl_test.exs
+++ b/test/archethic/db/embedded_impl_test.exs
@@ -107,6 +107,20 @@ defmodule Archethic.DB.EmbeddedTest do
       assert File.exists?(filename_chain)
       assert !File.exists?(filename_io)
     end
+
+    test "should return an error when transaction already exists in chain storage" do
+      tx1 = TransactionFactory.create_valid_transaction()
+      assert :ok == EmbeddedImpl.write_transaction(tx1)
+
+      assert {:error, :transaction_already_exists} == EmbeddedImpl.write_transaction(tx1)
+    end
+
+    test "should return an error when transaction already exists in io storage" do
+      tx1 = TransactionFactory.create_valid_transaction()
+      assert :ok == EmbeddedImpl.write_transaction(tx1, :io)
+
+      assert {:error, :transaction_already_exists} == EmbeddedImpl.write_transaction(tx1, :io)
+    end
   end
 
   describe "transaction_exists?/2" do


### PR DESCRIPTION
# Description

When replicating transactions, checks if Tx is already present before writing it.

Check is performed in `ChainWriter.write` to ensure they are sequentials.

Fixes #1650

