### PR TITLE
Add uniq filter on UTXO list while DB write

### DIFF
--- a/lib/archethic/utxo/loader.ex
+++ b/lib/archethic/utxo/loader.ex
@@ -114,7 +114,8 @@ defmodule Archethic.UTXO.Loader do
       genesis_address
       |> UTXO.stream_unspent_outputs()
       |> Stream.reject(&Enum.member?(consumed_inputs, &1.unspent_output))
-      |> Enum.concat(transaction_unspent_outputs)
+      |> Stream.concat(transaction_unspent_outputs)
+      |> Enum.uniq()
 
     # We compact all the unspent outputs into new ones, cleaning the previous unspent outputs
     DBLedger.flush(genesis_address, new_unspent_outputs)


### PR DESCRIPTION
# Description

Ensure no UTXO are stored in multiple occurrence in UTXO file DB

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
