### PR TITLE
Fix timeout issue in subset making genserver crash + refactor

### DIFF
--- a/lib/archethic/contracts/wasm/contract.ex
+++ b/lib/archethic/contracts/wasm/contract.ex
@@ -55,7 +55,7 @@ defmodule Archethic.Contracts.WasmContract do
   @doc """
   Validate WASM contract
   """
-  @spec validate_and_parse(t()) :: {:ok, t()} | {:error, String.t()}
+  @spec validate_and_parse(contract :: Contract.t()) :: {:ok, t()} | {:error, String.t()}
   def validate_and_parse(%Contract{manifest: manifest, bytecode: bytecode}) do
     uncompressed_bytes = :zlib.unzip(bytecode)
 

--- a/lib/archethic/p2p/client/connection.ex
+++ b/lib/archethic/p2p/client/connection.ex
@@ -91,6 +91,9 @@ defmodule Archethic.P2P.Client.Connection do
   @spec get_availability_timer(Crypto.key(), boolean()) :: non_neg_integer()
   def get_availability_timer(public_key, reset?) do
     GenStateMachine.call(via_tuple(public_key), {:get_timer, reset?})
+  rescue
+    # call timeout
+    _ -> 0
   end
 
   @doc """

--- a/test/archethic/beacon_chain/subset_test.exs
+++ b/test/archethic/beacon_chain/subset_test.exs
@@ -254,7 +254,7 @@ defmodule Archethic.BeaconChain.SubsetTest do
              }
            }}
       end)
-      |> expect(:get_availability_timer, 4, fn _, _ -> 0 end)
+      |> expect(:get_availability_timer, 2, fn _, _ -> 0 end)
 
       # slot time matches summary time interval
       slot_time = ~U[2023-07-11 01:00:00Z]


### PR DESCRIPTION
# Description

- Removed useless p2p view request while adding new attestation in subset
- Refactor p2p view creation
- Create slot and summary inside async Task to not block the subset Genserver
- Also fixes an old issue to send beacon slot even if not beacon slot node

Fixes #981 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
