### PR TITLE
Fix node rewards issue

### DIFF
--- a/lib/archethic/reward.ex
+++ b/lib/archethic/reward.ex
@@ -20,8 +20,6 @@ defmodule Archethic.Reward do
   alias Archethic.TransactionChain.TransactionData.TokenLedger
   alias Archethic.TransactionChain.TransactionData.TokenLedger.Transfer
 
-  alias Archethic.UTXO
-
   alias Archethic.Utils
 
   alias Crontab.CronExpression.Parser, as: CronParser
@@ -131,17 +129,15 @@ defmodule Archethic.Reward do
 
     nodes =
       P2P.authorized_and_available_nodes()
+      |> Enum.sort_by(& &1.first_public_key)
       |> Enum.map(fn %Node{reward_address: reward_address} ->
         {reward_address, uco_amount}
       end)
 
     reward_balance =
       genesis_address()
-      |> UTXO.stream_unspent_outputs()
-      |> Stream.map(& &1.unspent_output)
-      |> UTXO.get_balance()
+      |> Archethic.get_balance()
       |> Map.get(:token)
-      |> Map.to_list()
       |> Enum.sort(fn {_, qty1}, {_, qty2} -> qty1 < qty2 end)
 
     do_get_transfers(nodes, reward_balance, [])


### PR DESCRIPTION
# Description

Fixes an issue when validating the node_rewards transaction. The UTXO used to calculate the transfers are retrieved locally therefore if a node missed the last mint_reward transaction, its UTXO will not be the same and so the transaction will fail.
Fixed it by fetching UTXO instead to get them locally.
Also sorted the nodes to ensure all nodes has the same transfer order

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
