### PR TITLE
Fix acceptance resolver in self repair

### DIFF
--- a/lib/archethic/self_repair/sync/transaction_handler.ex
+++ b/lib/archethic/self_repair/sync/transaction_handler.ex
@@ -138,15 +138,19 @@ defmodule Archethic.SelfRepair.Sync.TransactionHandler do
          },
          storage_nodes
        ) do
-    acceptance_resolver = fn tx = %Transaction{} ->
-      # TODO:
-      # we can add a verification to ensure the proof of integrity is the right one
-      # using the previous transaction and hence asserting the TransactionSummary.validation_stamp_checksum
-      # in order to remove malicious node given false transaction's data
+    acceptance_resolver = fn
+      tx = %Transaction{} ->
+        # TODO:
+        # we can add a verification to ensure the proof of integrity is the right one
+        # using the previous transaction and hence asserting the TransactionSummary.validation_stamp_checksum
+        # in order to remove malicious node given false transaction's data
 
-      tx
-      |> TransactionSummary.from_transaction(genesis_address, version)
-      |> TransactionSummary.equals?(expected_summary)
+        tx
+        |> TransactionSummary.from_transaction(genesis_address, version)
+        |> TransactionSummary.equals?(expected_summary)
+
+      _ ->
+        false
     end
 
     TransactionChain.fetch_transaction(address, storage_nodes,


### PR DESCRIPTION
# Description

Fixes the acceptance resolver while downloading a transaction in the self repair. The function raised a no match if no transaction was found in the request and receiving `%NotFound{}`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
